### PR TITLE
feat(provider-payout): proofUrl en listado y defaults en payout_status

### DIFF
--- a/src/main/java/com/tourya/api/models/Reservation.java
+++ b/src/main/java/com/tourya/api/models/Reservation.java
@@ -4,7 +4,9 @@ import com.tourya.api.common.BaseEntity;
 import com.tourya.api.constans.enums.CancellationReasonEnum;
 import com.tourya.api.constans.enums.DeliveryStatusEnum;
 import jakarta.persistence.*;
+import org.hibernate.annotations.DynamicInsert;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -28,6 +30,7 @@ import java.time.OffsetDateTime;
 @NoArgsConstructor
 @Entity
 @Table(name = "reservation")
+@DynamicInsert
 public class Reservation extends BaseEntity {
 
     /** Valor inicial en BD (migration 032); coincide con columna NOT NULL DEFAULT 'PENDING'. */
@@ -52,8 +55,9 @@ public class Reservation extends BaseEntity {
     @Column(name = "payout_available_date")
     private LocalDate payoutAvailableDate;
 
+    @Builder.Default
     @Column(name = "payout_status", nullable = false, length = 20)
-    private String payoutStatus;
+    private String payoutStatus = PAYOUT_STATUS_PENDING;
 
     @Column(name = "payout_paid_at")
     private OffsetDateTime payoutPaidAt;

--- a/src/main/java/com/tourya/api/models/responses/ProviderPayoutOrderListItemResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/ProviderPayoutOrderListItemResponse.java
@@ -1,6 +1,7 @@
 package com.tourya.api.models.responses;
 
 import com.tourya.api.constans.enums.ProviderPayoutOrderStatusEnum;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -18,5 +19,9 @@ public class ProviderPayoutOrderListItemResponse {
     private ProviderPayoutOrderStatusEnum status;
     private BigDecimal amountTotal;
     private Integer reservationsCount;
+
+    /** URL del comprobante subido por backoffice (último adjunto si hay varios); null si aún no hay archivo. */
+    @Schema(description = "URL pública del comprobante de pago (si existe); null si no se ha subido")
+    private String proofUrl;
 }
 

--- a/src/main/java/com/tourya/api/repository/ProviderPayoutAttachmentRepository.java
+++ b/src/main/java/com/tourya/api/repository/ProviderPayoutAttachmentRepository.java
@@ -4,10 +4,13 @@ import com.tourya.api.models.ProviderPayoutAttachment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 
 @Repository
 public interface ProviderPayoutAttachmentRepository extends JpaRepository<ProviderPayoutAttachment, Long> {
     List<ProviderPayoutAttachment> findByPayoutOrderId(Long payoutOrderId);
+
+    List<ProviderPayoutAttachment> findByPayoutOrderIdIn(Collection<Long> payoutOrderIds);
 }
 

--- a/src/main/java/com/tourya/api/services/ProviderPayoutOrderService.java
+++ b/src/main/java/com/tourya/api/services/ProviderPayoutOrderService.java
@@ -30,7 +30,10 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -54,8 +57,13 @@ public class ProviderPayoutOrderService {
         User user = (User) connectedUser.getPrincipal();
         Provider provider = providerService.findByUserAndStatusActive(user);
 
-        return payoutOrderRepository.findAll().stream()
+        List<ProviderPayoutOrder> orders = payoutOrderRepository.findAll().stream()
                 .filter(o -> o.getProviderId().equals(provider.getId()))
+                .toList();
+        Map<Long, String> proofUrlByOrderId = latestProofUrlByOrderIds(
+                orders.stream().map(ProviderPayoutOrder::getId).toList());
+
+        return orders.stream()
                 .map(o -> ProviderPayoutOrderListItemResponse.builder()
                         .id(o.getId())
                         .providerId(o.getProviderId())
@@ -64,6 +72,7 @@ public class ProviderPayoutOrderService {
                         .status(o.getStatus())
                         .amountTotal(o.getAmountTotal())
                         .reservationsCount(payoutOrderReservationRepository.findByPayoutOrderId(o.getId()).size())
+                        .proofUrl(proofUrlByOrderId.get(o.getId()))
                         .build())
                 .toList();
     }
@@ -76,7 +85,11 @@ public class ProviderPayoutOrderService {
             throw new InsufficientPrivilegesException(NOT_PRIVILEGES);
         }
 
-        return payoutOrderRepository.findAll().stream()
+        List<ProviderPayoutOrder> orders = payoutOrderRepository.findAll().stream().toList();
+        Map<Long, String> proofUrlByOrderId = latestProofUrlByOrderIds(
+                orders.stream().map(ProviderPayoutOrder::getId).toList());
+
+        return orders.stream()
                 .map(o -> ProviderPayoutOrderListItemResponse.builder()
                         .id(o.getId())
                         .providerId(o.getProviderId())
@@ -85,6 +98,7 @@ public class ProviderPayoutOrderService {
                         .status(o.getStatus())
                         .amountTotal(o.getAmountTotal())
                         .reservationsCount(payoutOrderReservationRepository.findByPayoutOrderId(o.getId()).size())
+                        .proofUrl(proofUrlByOrderId.get(o.getId()))
                         .build())
                 .toList();
     }
@@ -204,6 +218,24 @@ public class ProviderPayoutOrderService {
                 .attachments(attDtos)
                 .reservations(items)
                 .build();
+    }
+
+    /**
+     * Una sola consulta de adjuntos para todas las órdenes; por orden devuelve la URL del adjunto más reciente.
+     */
+    private Map<Long, String> latestProofUrlByOrderIds(Collection<Long> orderIds) {
+        Map<Long, String> result = new HashMap<>();
+        if (orderIds == null || orderIds.isEmpty()) {
+            return result;
+        }
+        List<ProviderPayoutAttachment> attachments = payoutAttachmentRepository.findByPayoutOrderIdIn(orderIds);
+        Map<Long, ProviderPayoutAttachment> latest = new HashMap<>();
+        for (ProviderPayoutAttachment a : attachments) {
+            latest.merge(a.getPayoutOrderId(), a, (a1, a2) ->
+                    a1.getCreatedAt().isAfter(a2.getCreatedAt()) ? a1 : a2);
+        }
+        latest.forEach((id, att) -> result.put(id, att.getFileUrl()));
+        return result;
     }
 
     private void validateProofFile(MultipartFile file) {


### PR DESCRIPTION
- Listado de ordenes de pago: campo proofUrl (URL del comprobante o null)
- Batch de adjuntos por orden para evitar N+1
- Reservation: DynamicInsert y payout_status por defecto PENDING