### PR TITLE
feat(email): correos de solicitud proveedor y tour en confirmacion de compra

### DIFF
--- a/src/main/java/com/tourya/api/constans/enums/EmailTemplateNameEnum.java
+++ b/src/main/java/com/tourya/api/constans/enums/EmailTemplateNameEnum.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 public enum EmailTemplateNameEnum {
     ACTIVATE_ACCOUNT("activate_account"),
     TEMPORARY_PASSWORD("temporary_password"),
-    PURCHASE_CONFIRMATION("purchase_confirmation");
+    PURCHASE_CONFIRMATION("purchase_confirmation"),
+    REQUEST_PROVIDER_STATUS("request_provider_status");
     private final String name;
     EmailTemplateNameEnum(String name) {
         this.name = name;

--- a/src/main/java/com/tourya/api/services/EmailService.java
+++ b/src/main/java/com/tourya/api/services/EmailService.java
@@ -148,4 +148,42 @@ public class EmailService {
         helper.setText(template, true);
         mailSender.send(mimeMessage);
     }
+
+    @Async
+    public void sendRequestProviderStatusEmail(
+            String to,
+            String username,
+            String providerName,
+            String statusLabel,
+            String messageBody,
+            String reason,
+            String subject
+    ) throws MessagingException {
+        String templateName = EmailTemplateNameEnum.REQUEST_PROVIDER_STATUS.getName();
+
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(
+                mimeMessage,
+                MULTIPART_MODE_MIXED,
+                UTF_8.name()
+        );
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("username", username);
+        properties.put("providerName", providerName);
+        properties.put("statusLabel", statusLabel);
+        properties.put("messageBody", messageBody);
+        properties.put("reason", reason);
+
+        Context context = new Context();
+        context.setVariables(properties);
+
+        helper.setFrom(fromEmail);
+        helper.setTo(to);
+        helper.setSubject(subject);
+
+        String template = templateEngine.process(templateName, context);
+        helper.setText(template, true);
+        mailSender.send(mimeMessage);
+    }
 }

--- a/src/main/java/com/tourya/api/services/PaymentService.java
+++ b/src/main/java/com/tourya/api/services/PaymentService.java
@@ -217,8 +217,9 @@ public class PaymentService {
                     response != null ? response.getReservations() : null,
                     subject
             );
-        } catch (Exception ignored) {
-            // best-effort: no bloquear el pago por fallo de correo
+        } catch (Exception e) {
+            log.error("No se pudo enviar correo de confirmación de compra paymentId={}: {}",
+                    payment.getPaymentId(), e.getMessage());
         }
     }
 
@@ -479,13 +480,11 @@ public class PaymentService {
         Long itemId = reservation.getItemId();
         ShoppingCartItem item = itemId != null ? shoppingCartItemRepository.findById(itemId).orElse(null) : null;
 
-        if (item == null || item.getTourSchedule() == null) {
+        if (item == null) {
             return;
         }
-        
-        TourSchedule schedule = item.getTourSchedule();
-        Integer tourId = schedule.getTourId();
-        
+
+        Integer tourId = resolveTourIdFromCartItem(item);
         if (tourId == null) {
             return;
         }
@@ -596,6 +595,22 @@ public class PaymentService {
         if (!extraServices.isEmpty()) {
             response.setExtraServices(extraServices);
         }
+    }
+
+    /**
+     * Tour desde horario del carrito o, si no hay FK, desde productId cuando productType es TOUR.
+     */
+    private Integer resolveTourIdFromCartItem(ShoppingCartItem item) {
+        TourSchedule schedule = item.getTourSchedule();
+        if (schedule != null && schedule.getTourId() != null) {
+            return schedule.getTourId();
+        }
+        if (item.getProductType() != null
+                && "TOUR".equalsIgnoreCase(item.getProductType())
+                && item.getProductId() != null) {
+            return item.getProductId();
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/com/tourya/api/services/RequestProviderService.java
+++ b/src/main/java/com/tourya/api/services/RequestProviderService.java
@@ -21,7 +21,9 @@ import com.tourya.api.repository.RequestProviderGalleryRepository;
 import com.tourya.api.repository.RoleRepository;
 import com.tourya.api.repository.RequestProviderRepository;
 import com.tourya.api.repository.UserRepository;
+import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -35,6 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RequestProviderService {
@@ -49,6 +52,8 @@ public class RequestProviderService {
     private final CountryService countryService;
     private final CityService cityService;
     private final StateService stateService;
+    private final EmailService emailService;
+
     private static final String NOT_PRIVILEGES = "You have no privileges to perform this action.";
     private static final String REQUEST_PROVIDER_NOT_FOUND = "RequestProvider not found Id: ";
     @Transactional
@@ -224,6 +229,14 @@ public class RequestProviderService {
                 requestProvider.setStatus(RequestProviderStatusEnum.APPROVED);
                 RequestProvider requestProviderUpdate = requestProviderRepository.save(requestProvider);
 
+                sendRequestProviderStatusEmailBestEffort(
+                        requestProviderUpdate,
+                        "Aprobada",
+                        "¡Felicitaciones! Tu solicitud como proveedor ha sido aprobada. Ya puedes publicar tours en Tourya.",
+                        null,
+                        "Solicitud proveedor aprobada - Tourya"
+                );
+
                 return requestProviderMapper.toRequestProviderResponse(requestProviderUpdate);
             }else{
                 throw new ResourceNotFoundException(REQUEST_PROVIDER_NOT_FOUND+requestProviderId);
@@ -250,6 +263,14 @@ public class RequestProviderService {
                 requestProvider.setDeclinedReason(requestProviderActionRequest.getDeclinedReason());
                 RequestProvider requestProviderUpdate = requestProviderRepository.save(requestProvider);
 
+                sendRequestProviderStatusEmailBestEffort(
+                        requestProviderUpdate,
+                        "Cancelada",
+                        "Tu solicitud como proveedor ha sido cancelada. Si tienes dudas, contáctanos.",
+                        requestProviderUpdate.getDeclinedReason(),
+                        "Solicitud proveedor cancelada - Tourya"
+                );
+
                 return requestProviderMapper.toRequestProviderResponse(requestProviderUpdate);
             }else{
                 throw new ResourceNotFoundException(REQUEST_PROVIDER_NOT_FOUND+requestProviderId);
@@ -270,6 +291,15 @@ public class RequestProviderService {
                 requestProvider.setStatus(RequestProviderStatusEnum.INCOMPLETE_INFORMATION);
                 requestProvider.setIncompleteReason(requestProviderActionRequest.getIncompleteReason());
                 RequestProvider requestProviderUpdate = requestProviderRepository.save(requestProvider);
+
+                sendRequestProviderStatusEmailBestEffort(
+                        requestProviderUpdate,
+                        "Información incompleta",
+                        "Tu solicitud requiere información o documentos adicionales. Revisa el detalle e ingresa a la plataforma para completarla.",
+                        requestProviderUpdate.getIncompleteReason(),
+                        "Solicitud proveedor - información incompleta - Tourya"
+                );
+
                 return requestProviderMapper.toRequestProviderResponse(requestProviderUpdate);
             }else{
                 throw new ResourceNotFoundException(REQUEST_PROVIDER_NOT_FOUND+requestProviderId);
@@ -319,12 +349,56 @@ public class RequestProviderService {
                 requestProvider.setStatus(RequestProviderStatusEnum.PRE_APPROVED);
                 RequestProvider requestProviderUpdate = requestProviderRepository.save(requestProvider);
 
+                sendRequestProviderStatusEmailBestEffort(
+                        requestProviderUpdate,
+                        "Pre-aprobada",
+                        "Tu solicitud ha sido pre-aprobada. Ya puedes cargar y enviar la documentación requerida en la plataforma.",
+                        null,
+                        "Solicitud proveedor pre-aprobada - Tourya"
+                );
+
                 return requestProviderMapper.toRequestProviderResponse(requestProviderUpdate);
             }else{
                 throw new ResourceNotFoundException(REQUEST_PROVIDER_NOT_FOUND+requestProviderId);
             }
         }else{
             throw new InsufficientPrivilegesException(NOT_PRIVILEGES);
+        }
+    }
+
+    private void sendRequestProviderStatusEmailBestEffort(
+            RequestProvider requestProvider,
+            String statusLabel,
+            String messageBody,
+            String reason,
+            String subject
+    ) {
+        try {
+            Provider provider = requestProvider.getProvider();
+            if (provider == null || provider.getUser() == null) {
+                log.warn("No se envió correo de solicitud proveedor {}: proveedor o usuario no encontrado", requestProvider.getId());
+                return;
+            }
+            User providerUser = provider.getUser();
+            if (providerUser.getEmail() == null || providerUser.getEmail().isBlank()) {
+                log.warn("No se envió correo de solicitud proveedor {}: el usuario no tiene email", requestProvider.getId());
+                return;
+            }
+            String username = providerUser.fullName();
+            if (username == null || username.isBlank()) {
+                username = provider.getName() != null ? provider.getName() : "Proveedor";
+            }
+            emailService.sendRequestProviderStatusEmail(
+                    providerUser.getEmail(),
+                    username,
+                    provider.getName(),
+                    statusLabel,
+                    messageBody,
+                    reason,
+                    subject
+            );
+        } catch (MessagingException e) {
+            log.error("Error enviando correo de solicitud proveedor id={}: {}", requestProvider.getId(), e.getMessage());
         }
     }
 }

--- a/src/main/java/com/tourya/api/services/ReservationService.java
+++ b/src/main/java/com/tourya/api/services/ReservationService.java
@@ -77,6 +77,7 @@ public class ReservationService {
     private final TourMainAttractionRepository tourMainAttractionRepository;
     private final TourIncludesExcludesRepository tourIncludesExcludesRepository;
     private final TourAddressRepository tourAddressRepository;
+    private final TourGalleryRepository tourGalleryRepository;
     private final ReservationNativeRepository reservationNativeRepository;
     private final TourCancellationPolicyRepository tourCancellationPolicyRepository;
     private final CreditRepository creditRepository;
@@ -207,15 +208,14 @@ public class ReservationService {
         Long itemId = reservation.getItemId();
         ShoppingCartItem item = itemId != null ? shoppingCartItemRepository.findById(itemId).orElse(null) : null;
 
-        if (item == null || item.getTourSchedule() == null) {
+        if (item == null) {
             enrichReservationResponseWithoutCartItem(response, reservation);
             return;
         }
-        
-        TourSchedule schedule = item.getTourSchedule();
-        Integer tourId = schedule.getTourId();
-        
+
+        Integer tourId = resolveTourIdFromCartItem(item);
         if (tourId == null) {
+            enrichReservationResponseWithoutCartItem(response, reservation);
             return;
         }
         
@@ -226,6 +226,7 @@ public class ReservationService {
         
         // Información básica del tour
         response.setTourId(tourId);
+        applyMainTourImageUrl(response, tourId);
         if (tour.getName() != null && tour.getName().getEs() != null) {
             response.setTourName(tour.getName().getEs());
         }
@@ -300,6 +301,29 @@ public class ReservationService {
         logIfPaymentPayerDiffersFromCartUser(reservation, item);
     }
 
+    private Integer resolveTourIdFromCartItem(ShoppingCartItem item) {
+        TourSchedule schedule = item.getTourSchedule();
+        if (schedule != null && schedule.getTourId() != null) {
+            return schedule.getTourId();
+        }
+        if (item.getProductType() != null
+                && "TOUR".equalsIgnoreCase(item.getProductType())
+                && item.getProductId() != null) {
+            return item.getProductId();
+        }
+        return null;
+    }
+
+    private void applyMainTourImageUrl(ReservationResponse response, Integer tourId) {
+        List<TourGallery> galleries = tourGalleryRepository.findByTourIdAndOrderIndex(tourId, 1);
+        if (galleries == null || galleries.isEmpty()) {
+            galleries = tourGalleryRepository.findByTourIdOrderByOrderIndexAsc(tourId);
+        }
+        if (galleries != null && !galleries.isEmpty()) {
+            response.setTourImageUrl(galleries.get(0).getImageUrl());
+        }
+    }
+
     /**
      * Cuando el {@code shopping_cart_item} ya no existe o se desvinculó, conservar en respuesta lo persistido
      * en {@code reservation} y, si aplica, el tour vía reseña asociada.
@@ -317,6 +341,7 @@ public class ReservationService {
                 return;
             }
             response.setTourId(tid);
+            applyMainTourImageUrl(response, tid);
             tourRepository.findById(tid).ifPresent(tour -> {
                 if (tour.getName() != null && tour.getName().getEs() != null) {
                     response.setTourName(tour.getName().getEs());

--- a/src/main/resources/templates/purchase_confirmation.html
+++ b/src/main/resources/templates/purchase_confirmation.html
@@ -46,9 +46,11 @@
                 </div>
 
                 <div style="margin-top:10px">
-                    <div class="muted" style="font-weight:700">QR</div>
-                    <div class="qr" th:text="${r.qrUrl != null ? r.qrUrl : 'QR no disponible'}"></div>
-                    <a class="btn" th:if="${r.qrUrl != null}" th:href="${r.qrUrl}" target="_blank">Ver QR</a>
+                    <div class="muted" style="font-weight:700">Código QR de tu reserva</div>
+                    <img th:if="${r.qrUrl != null}" th:src="${r.qrUrl}" alt="QR reserva"
+                         style="max-width:220px;margin-top:8px;border:1px solid #eee;border-radius:8px;display:block"/>
+                    <p class="muted" th:if="${r.qrUrl == null}">QR no disponible</p>
+                    <a class="btn" th:if="${r.qrUrl != null}" th:href="${r.qrUrl}" target="_blank">Abrir QR</a>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/request_provider_status.html
+++ b/src/main/resources/templates/request_provider_status.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Actualización solicitud proveedor</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; padding: 0; background-color: #f4f4f4; color: #111; }
+        .container { max-width: 600px; margin: 12px auto; padding: 20px; background-color: #fff; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.08); }
+        .header h1 { margin: 0 0 8px; font-size: 20px; }
+        .muted { color: #666; font-size: 14px; line-height: 1.5; }
+        .status { display: inline-block; margin: 12px 0; padding: 6px 10px; background: #eef5ff; color: #004a99; border-radius: 6px; font-weight: 700; }
+        .reason { margin-top: 12px; padding: 12px; background: #fafafa; border-left: 4px solid #007bff; font-size: 14px; }
+        .footer { margin-top: 18px; padding-top: 12px; border-top: 1px solid #eee; font-size: 12px; color: #777; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="header">
+        <h1>Actualización de tu solicitud</h1>
+        <p class="muted" th:text="'Hola ' + ${username} + ','"></p>
+    </div>
+
+    <p class="muted">Te informamos sobre el estado de tu solicitud como proveedor en Tourya
+        <span th:if="${providerName != null && !#strings.isEmpty(providerName)}" th:text="' (' + ${providerName} + ')'"></span>:
+    </p>
+
+    <div class="status" th:text="${statusLabel}"></div>
+
+    <p class="muted" th:text="${messageBody}"></p>
+
+    <div class="reason" th:if="${reason != null && !#strings.isEmpty(reason)}">
+        <strong>Detalle:</strong>
+        <div th:text="${reason}"></div>
+    </div>
+
+    <div class="footer">
+        Si tienes dudas, responde a este correo o contáctanos desde la plataforma.
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION

Enviar correo Thymeleaf al cambiar estado admin de requestProvider. Enriquecer reservas con tourId, nombre e imagen usando productId si falta tourSchedule. Mejorar plantilla de compra con imagen QR y registrar fallos SMTP en logs.