### PR TITLE
feat: actividad maritima v2, filtros i18n y cancelacion por lluvia

### DIFF
--- a/MIGRACIONES_A_EJECUTAR.txt
+++ b/MIGRACIONES_A_EJECUTAR.txt
@@ -62,10 +62,25 @@
     - SP `sp_get_provider_reservations`: filtro `p_customer_user_id`, columna `providerprice`
     - Reemplaza firma de 4 parámetros (ejecutar en EC2 antes del deploy del API)
 
+
+
+
+
+
+
+
 14. `database/migrations/052_tour_schedule_slot_price_override.sql`
     - Overrides de % Tourya y precio de venta **por schedule (día)** y slot/price
     - Requerido para PUT `/tour-schedules/tours/{tourId}/percentage` por rango de fechas
 
 15. `database/migrations/053_fix_tour_schedule_override_audit_columns.sql`
     - Si 052 ya se ejecutó: agrega `last_modified_by` y ajusta auditoría JPA
+
+### 8) Ajustes back 09/06/2026
+16. `database/migrations/055_maritime_department_and_filter_name_i18n.sql`
+    - i18n tags/categorías + columna subcategorías name (jsonb)
+17. `database/migrations/056_fix_filter_i18n_complete_translations.sql`
+    - Traducciones completas es/en/pt (Filtros tours)
+18. `database/migrations/057_maritime_activity_report_location_and_dates.sql`
+    - Reportes DIMAR: country_id, state_id, city_id, business_category_id, subcategory_code, report_start_date, report_end_date
 

--- a/database/migrations/055_maritime_department_and_filter_name_i18n.sql
+++ b/database/migrations/055_maritime_department_and_filter_name_i18n.sql
@@ -1,0 +1,33 @@
+-- Migration: Maritime report department + i18n name for tags and business categories
+-- Date: 2026-06-09
+
+-- 1) Department en reportes DIMAR
+ALTER TABLE public.maritim_activity_report
+    ADD COLUMN IF NOT EXISTS department varchar(100) NULL;
+
+COMMENT ON COLUMN public.maritim_activity_report.department IS 'Departamento donde se realiza la actividad';
+
+-- 2) Tags: columna name (jsonb) para respuestas multilenguaje
+ALTER TABLE public.tags
+    ADD COLUMN IF NOT EXISTS name jsonb NULL;
+
+UPDATE public.tags
+SET name = jsonb_build_object('es', nombre, 'en', '', 'pt', '')
+WHERE name IS NULL;
+
+-- 3) Categorías de búsqueda: name como jsonb
+ALTER TABLE public.tour_business_category
+    DROP CONSTRAINT IF EXISTS tour_business_category_name_key;
+
+ALTER TABLE public.tour_business_category
+    ALTER COLUMN name TYPE jsonb
+    USING jsonb_build_object('es', name, 'en', '', 'pt', '');
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_tour_business_category_name_es
+    ON public.tour_business_category ((name->>'es'));
+
+-- 4) Subcategorías: columna name (jsonb)
+ALTER TABLE public.tour_business_subcategory_mapping
+    ADD COLUMN IF NOT EXISTS name jsonb NULL;
+
+-- Traducciones completas: ejecutar 056_fix_filter_i18n_complete_translations.sql

--- a/database/migrations/056_fix_filter_i18n_complete_translations.sql
+++ b/database/migrations/056_fix_filter_i18n_complete_translations.sql
@@ -1,0 +1,85 @@
+-- Migration: Traducciones completas (es/en/pt) para filtros de búsqueda
+-- Date: 2026-06-09
+-- Complementa 055 con textos del documento "Filtros tours"
+
+-- =============================================================================
+-- CATEGORÍAS
+-- =============================================================================
+UPDATE public.tour_business_category SET name = '{"es":"Acuático","en":"Water Activities","pt":"Aquático"}'::jsonb WHERE code = 'ACUATICO';
+UPDATE public.tour_business_category SET name = '{"es":"Deportes","en":"Sports & Diving","pt":"Esportes"}'::jsonb WHERE code = 'DEPORTES';
+UPDATE public.tour_business_category SET name = '{"es":"Terrestre","en":"Land Tours","pt":"Terrestre"}'::jsonb WHERE code = 'TERRESTRE';
+UPDATE public.tour_business_category SET name = '{"es":"Aventura","en":"Adventure","pt":"Aventura"}'::jsonb WHERE code = 'AVENTURA';
+UPDATE public.tour_business_category SET name = '{"es":"Nocturno","en":"Nightlife","pt":"Noturno / Vida Noturna"}'::jsonb WHERE code = 'NOCTURNO';
+UPDATE public.tour_business_category SET name = '{"es":"Cultural / Experiencias","en":"Culture & Experiences","pt":"Cultura e Experiências"}'::jsonb WHERE code = 'CULTURAL_EXPERIENCIAS';
+UPDATE public.tour_business_category SET name = '{"es":"Alquiler de Transporte","en":"Transport Rental","pt":"Aluguel de Transporte"}'::jsonb WHERE code = 'ALQUILER_TRANSPORTE';
+
+-- =============================================================================
+-- SUBCATEGORÍAS
+-- =============================================================================
+ALTER TABLE public.tour_business_subcategory_mapping
+    ADD COLUMN IF NOT EXISTS name jsonb NULL;
+
+UPDATE public.tour_business_subcategory_mapping
+SET name = jsonb_build_object('es', display_name, 'en', '', 'pt', '')
+WHERE name IS NULL;
+
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Paseo al cayo","en":"Cay / Islet Tour","pt":"Passeio ao Ilhéu (Cayo)"}'::jsonb WHERE subcategory_code = 'paseo_al_cayo';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Buceo","en":"Scuba Diving","pt":"Mergulho Cilindro"}'::jsonb WHERE subcategory_code = 'buceo';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Snuba","en":"Snuba Diving","pt":"Snuba"}'::jsonb WHERE subcategory_code = 'snuba';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Windsurf","en":"Windsurfing","pt":"Windsurf"}'::jsonb WHERE subcategory_code = 'windsurf';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Esquí acuático","en":"Water Skiing","pt":"Esqui Aquático"}'::jsonb WHERE subcategory_code = 'esqui_acuatico';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Wakeboard","en":"Wakeboarding","pt":"Wakeboard"}'::jsonb WHERE subcategory_code = 'wakeboard';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Fly board","en":"Flyboarding","pt":"Flyboard"}'::jsonb WHERE subcategory_code = 'fly_board';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Fiesta noche blanca","en":"White Night Party Cruise","pt":"Festa Noite Branca"}'::jsonb WHERE subcategory_code = 'fiesta_noche_blanca';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Parasail","en":"Parasailing","pt":"Parasail"}'::jsonb WHERE subcategory_code = 'parasail';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Paddle board","en":"Paddleboarding (SUP)","pt":"Stand Up Paddle"}'::jsonb WHERE subcategory_code = 'paddle_board';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Moto","en":"Motorbike / Scooter Rental","pt":"Aluguel de Moto / Scooter"}'::jsonb WHERE subcategory_code = 'moto';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Bicicleta","en":"Bicycle Rental","pt":"Aluguel de Bicicleta"}'::jsonb WHERE subcategory_code = 'bicicleta';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Carro playero","en":"Golf Cart / Buggy Rental","pt":"Aluguel de Carrinho de Golfe / Buggy"}'::jsonb WHERE subcategory_code = 'carro_playero';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Tour bahía diurno","en":"Daytime Bay Cruise","pt":"Tour Diurno pela Baía"}'::jsonb WHERE subcategory_code = 'tour_bahia_diurno';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Vuelta a la isla (City Tour)","en":"Island Tour (City Tour)","pt":"Volta à Ilha (City Tour)"}'::jsonb WHERE subcategory_code = 'vuelta_a_la_isla_city_tour';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Snorkeling","en":"Snorkeling","pt":"Snorkeling / Mergulho de Superfície"}'::jsonb WHERE subcategory_code = 'snorkeling';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Semi submarino","en":"Semi-Submarine Tour","pt":"Semi-Submarino"}'::jsonb WHERE subcategory_code = 'semi_submarino';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Pontón","en":"Pontoon Boat Charter","pt":"Passeio de Ponton"}'::jsonb WHERE subcategory_code = 'ponton';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Bar en el agua","en":"Floating Bar Experience","pt":"Bar Flutuante"}'::jsonb WHERE subcategory_code = 'bar_en_el_agua';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Yate de lujo","en":"Luxury Yacht Charter","pt":"Iate de Luxo"}'::jsonb WHERE subcategory_code = 'yate_de_lujo';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Jet Ski","en":"Jet Ski Rental","pt":"Jet Ski"}'::jsonb WHERE subcategory_code = 'jet_ski';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Aquanautas","en":"Helmet Diving (Aquanauts)","pt":"Caminhada Subaquática (Aquanautas)"}'::jsonb WHERE subcategory_code = 'aquanautas';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Kayak","en":"Kayak","pt":"Caiaque"}'::jsonb WHERE subcategory_code = 'kayak';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Cocina local","en":"Local Cuisine Experience","pt":"Culinária Local"}'::jsonb WHERE subcategory_code = 'cocina_local';
+UPDATE public.tour_business_subcategory_mapping SET name = '{"es":"Picnic","en":"Picnic Experience","pt":"Piquenique"}'::jsonb WHERE subcategory_code = 'picnic';
+
+-- =============================================================================
+-- ETIQUETAS (TAGS)
+-- =============================================================================
+UPDATE public.tags SET name = '{"es":"Familiar","en":"Family-Friendly","pt":"Familiar / Para Famílias"}'::jsonb WHERE slug = 'familiar';
+UPDATE public.tags SET name = '{"es":"Solo Adultos","en":"Adults Only","pt":"Apenas Adultos"}'::jsonb WHERE slug = 'solo-adultos';
+UPDATE public.tags SET name = '{"es":"Romántico / Parejas","en":"Romantic / Couples","pt":"Romântico / Casais"}'::jsonb WHERE slug = 'romantico-parejas';
+UPDATE public.tags SET name = '{"es":"Pet Friendly","en":"Pet Friendly","pt":"Pet Friendly / Aceita Pets"}'::jsonb WHERE slug = 'pet-friendly';
+UPDATE public.tags SET name = '{"es":"Ideal Niños / Bebés","en":"Great for Kids & Babies","pt":"Ideal para Crianças e Bebês"}'::jsonb WHERE slug = 'ideal-ninos-bebes';
+UPDATE public.tags SET name = '{"es":"Adulto Mayor","en":"Senior-Friendly","pt":"Adequado para Idosos"}'::jsonb WHERE slug = 'adulto-mayor';
+UPDATE public.tags SET name = '{"es":"Aguas Cristalinas","en":"Crystal Clear Waters","pt":"Águas Cristalinas"}'::jsonb WHERE slug = 'aguas-cristalinas';
+UPDATE public.tags SET name = '{"es":"Instagrammable","en":"Instagrammable / Scenic","pt":"Instagramável / Fotos Lindas"}'::jsonb WHERE slug = 'instagrammable';
+UPDATE public.tags SET name = '{"es":"Adrenalina","en":"Adrenaline / Thrill","pt":"Adrenalina / Pura Emoção"}'::jsonb WHERE slug = 'adrenalina';
+UPDATE public.tags SET name = '{"es":"Relax / Chill Out","en":"Relax / Chill Out","pt":"Relaxar / Calmo"}'::jsonb WHERE slug = 'relax-chill-out';
+UPDATE public.tags SET name = '{"es":"Vida Marina","en":"Marine Life / Wildlife","pt":"Vida Marinha"}'::jsonb WHERE slug = 'vida-marina';
+UPDATE public.tags SET name = '{"es":"Naturaleza / Eco","en":"Nature / Eco-Tour","pt":"Natureza / Eco-Tour"}'::jsonb WHERE slug = 'naturaleza-eco';
+UPDATE public.tags SET name = '{"es":"Cultura Raizal","en":"Local Culture & Heritage","pt":"Cultura Local / Raizal"}'::jsonb WHERE slug = 'cultura-raizal';
+UPDATE public.tags SET name = '{"es":"No requiere saber nadar","en":"No Swimming Skills Required","pt":"Não Precisa Saber Nadar"}'::jsonb WHERE slug = 'no-requiere-saber-nadar';
+UPDATE public.tags SET name = '{"es":"Aventura Extrema","en":"Extreme Adventure","pt":"Aventura Extrema"}'::jsonb WHERE slug = 'aventura-extrema';
+UPDATE public.tags SET name = '{"es":"Apto para principiantes","en":"Beginner-Friendly","pt":"Ideal para Iniciantes"}'::jsonb WHERE slug = 'apto-para-principiantes';
+UPDATE public.tags SET name = '{"es":"Certificación requerida","en":"Certification Required","pt":"Certificação Necessária"}'::jsonb WHERE slug = 'certificacion-requerida';
+UPDATE public.tags SET name = '{"es":"Reserva Instantánea","en":"Instant Booking","pt":"Reserva Instantânea"}'::jsonb WHERE slug = 'reserva-instantanea';
+UPDATE public.tags SET name = '{"es":"Incluye Almuerzo","en":"Lunch Included","pt":"Almoço Incluso"}'::jsonb WHERE slug = 'incluye-almuerzo';
+UPDATE public.tags SET name = '{"es":"Barra Libre / Open Bar","en":"Open Bar","pt":"Open Bar / Bar Aberto"}'::jsonb WHERE slug = 'barra-libre-open-bar';
+UPDATE public.tags SET name = '{"es":"Recogida en el Hotel","en":"Hotel Pickup","pt":"Trânsfer do Hotel / Busco no Hotel"}'::jsonb WHERE slug = 'recogida-en-el-hotel';
+UPDATE public.tags SET name = '{"es":"Guía Bilingüe","en":"Bilingual Guide","pt":"Guia Bilíngue"}'::jsonb WHERE slug = 'guia-bilingue';
+UPDATE public.tags SET name = '{"es":"Sombra a Bordo","en":"Shaded Boat / Shade Available","pt":"Sombra a Bordo"}'::jsonb WHERE slug = 'sombra-a-bordo';
+UPDATE public.tags SET name = '{"es":"Equipamiento Incluido","en":"Gear Included","pt":"Equipamento Incluso"}'::jsonb WHERE slug = 'equipamiento-incluido';
+UPDATE public.tags SET name = '{"es":"Sector North End","en":"North End Area (Downtown)","pt":"Setor North End (Centro)"}'::jsonb WHERE slug = 'sector-north-end';
+UPDATE public.tags SET name = '{"es":"Sector San Luis","en":"San Luis Area","pt":"Setor San Luis"}'::jsonb WHERE slug = 'sector-san-luis';
+UPDATE public.tags SET name = '{"es":"West View / Piscinita","en":"West View / La Piscinita","pt":"West View / La Piscinita"}'::jsonb WHERE slug = 'west-view-piscinita';
+UPDATE public.tags SET name = '{"es":"Express (1-2 horas)","en":"Express Tour (1-2 hours)","pt":"Tour Expresso (1-2 horas)"}'::jsonb WHERE slug = 'express-1-2-horas';
+UPDATE public.tags SET name = '{"es":"Medio Día","en":"Half-Day Tour","pt":"Meio Dia"}'::jsonb WHERE slug = 'medio-dia';
+UPDATE public.tags SET name = '{"es":"Día Completo","en":"Full-Day Tour","pt":"Dia Inteiro"}'::jsonb WHERE slug = 'dia-completo';
+UPDATE public.tags SET name = '{"es":"Atardecer / Sunset","en":"Sunset Tour","pt":"Pôr do Sol / Sunset"}'::jsonb WHERE slug = 'atardecer-sunset';

--- a/database/migrations/057_maritime_activity_report_location_and_dates.sql
+++ b/database/migrations/057_maritime_activity_report_location_and_dates.sql
@@ -1,0 +1,52 @@
+-- Migration: Reportes DIMAR v2 — ubicación por ID, categoría/subcategoría, rango de fechas
+-- Date: 2026-06-09
+
+ALTER TABLE public.maritim_activity_report
+    ADD COLUMN IF NOT EXISTS country_id int4 NULL REFERENCES public.country(id),
+    ADD COLUMN IF NOT EXISTS state_id int4 NULL REFERENCES public.state(id),
+    ADD COLUMN IF NOT EXISTS city_id int4 NULL REFERENCES public.city(id),
+    ADD COLUMN IF NOT EXISTS business_category_id int4 NULL REFERENCES public.tour_business_category(id),
+    ADD COLUMN IF NOT EXISTS subcategory_code varchar(120) NULL,
+    ADD COLUMN IF NOT EXISTS report_start_date date NULL,
+    ADD COLUMN IF NOT EXISTS report_end_date date NULL;
+
+UPDATE public.maritim_activity_report
+SET report_start_date = report_date,
+    report_end_date = report_date
+WHERE report_start_date IS NULL
+  AND report_date IS NOT NULL;
+
+ALTER TABLE public.maritim_activity_report DROP COLUMN IF EXISTS country;
+ALTER TABLE public.maritim_activity_report DROP COLUMN IF EXISTS city;
+ALTER TABLE public.maritim_activity_report DROP COLUMN IF EXISTS department;
+ALTER TABLE public.maritim_activity_report DROP COLUMN IF EXISTS activity;
+ALTER TABLE public.maritim_activity_report DROP COLUMN IF EXISTS report_date;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'fk_maritim_report_subcategory'
+    ) THEN
+        ALTER TABLE public.maritim_activity_report
+            ADD CONSTRAINT fk_maritim_report_subcategory
+            FOREIGN KEY (subcategory_code)
+            REFERENCES public.tour_business_subcategory_mapping(subcategory_code);
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_maritim_activity_report_dates
+    ON public.maritim_activity_report (report_start_date, report_end_date);
+
+CREATE INDEX IF NOT EXISTS idx_maritim_activity_report_location
+    ON public.maritim_activity_report (country_id, state_id, city_id);
+
+CREATE INDEX IF NOT EXISTS idx_maritim_activity_report_subcategory
+    ON public.maritim_activity_report (subcategory_code);
+
+COMMENT ON COLUMN public.maritim_activity_report.country_id IS 'ID del país';
+COMMENT ON COLUMN public.maritim_activity_report.state_id IS 'ID del departamento (state)';
+COMMENT ON COLUMN public.maritim_activity_report.city_id IS 'ID de la ciudad';
+COMMENT ON COLUMN public.maritim_activity_report.business_category_id IS 'ID de tour_business_category';
+COMMENT ON COLUMN public.maritim_activity_report.subcategory_code IS 'Código de subcategoría del tour';
+COMMENT ON COLUMN public.maritim_activity_report.report_start_date IS 'Fecha inicio de vigencia del reporte';
+COMMENT ON COLUMN public.maritim_activity_report.report_end_date IS 'Fecha fin de vigencia del reporte';

--- a/src/main/java/com/tourya/api/constans/enums/CancellationReasonEnum.java
+++ b/src/main/java/com/tourya/api/constans/enums/CancellationReasonEnum.java
@@ -11,9 +11,19 @@ public enum CancellationReasonEnum {
      * No podrá disfrutar el tour
      */
     CANNOT_ATTEND,
-    
+
     /**
-     * Cancelación por lluvia
+     * Enfermedades
+     */
+    ILLNESS,
+
+    /**
+     * Imposibilidad de viajar
+     */
+    INABILITY_TO_TRAVEL,
+
+    /**
+     * Cancelación por lluvia (DIMAR). Solo vía {@code PUT /reservations/{id}/cancel/rain}.
      */
     RAIN
 }

--- a/src/main/java/com/tourya/api/controller/MaritimActivityReportController.java
+++ b/src/main/java/com/tourya/api/controller/MaritimActivityReportController.java
@@ -22,12 +22,6 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.util.List;
 
-/**
- * Controlador REST para gestión de reportes de actividades marítimas DIMAR.
- * 
- * @author Tourya API Team
- * @version 1.0
- */
 @Slf4j
 @RestController
 @RequestMapping("/maritime-activity-reports")
@@ -39,7 +33,10 @@ public class MaritimActivityReportController {
     private final MaritimActivityReportService maritimActivityReportService;
 
     @PostMapping
-    @Operation(summary = "Crear reporte DIMAR", description = "Crea un nuevo reporte de actividad marítima")
+    @Operation(
+            summary = "Crear reporte DIMAR",
+            description = "Crea un reporte con país/departamento/ciudad por ID, categoría y subcategoría del tour, "
+                    + "bandera y rango de fechas (inicio y fin no pueden ser anteriores a hoy).")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Reporte creado exitosamente"),
             @ApiResponse(responseCode = "400", description = "Datos inválidos"),
@@ -48,102 +45,53 @@ public class MaritimActivityReportController {
     public ResponseEntity<MaritimActivityReportResponse> create(
             @Valid @RequestBody MaritimActivityReportRequest request,
             Authentication authentication) {
-        log.info("Creating maritime activity report");
-        
         MaritimActivityReportResponse response = maritimActivityReportService.create(request, authentication);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @GetMapping
     @Operation(summary = "Obtener todos los reportes", description = "Obtiene todos los reportes DIMAR con paginación")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Reportes obtenidos exitosamente"),
-            @ApiResponse(responseCode = "401", description = "No autorizado")
-    })
     public ResponseEntity<PageResponse<MaritimActivityReportResponse>> findAll(
             @Parameter(description = "Número de página (0-based)") @RequestParam(defaultValue = "0") Integer page,
             @Parameter(description = "Tamaño de página") @RequestParam(defaultValue = "10") Integer size) {
-        log.info("Getting all maritime activity reports - page: {}, size: {}", page, size);
-        
-        PageResponse<MaritimActivityReportResponse> response = maritimActivityReportService.findAll(page, size);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(maritimActivityReportService.findAll(page, size));
     }
 
     @GetMapping("/{id}")
-    @Operation(summary = "Obtener reporte por ID", description = "Obtiene un reporte DIMAR específico por su ID")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Reporte encontrado"),
-            @ApiResponse(responseCode = "404", description = "Reporte no encontrado"),
-            @ApiResponse(responseCode = "401", description = "No autorizado")
-    })
-    public ResponseEntity<MaritimActivityReportResponse> findById(
-            @Parameter(description = "ID del reporte") @PathVariable Long id) {
-        log.info("Getting maritime activity report by id: {}", id);
-        
-        MaritimActivityReportResponse response = maritimActivityReportService.findById(id);
-        return ResponseEntity.ok(response);
+    @Operation(summary = "Obtener reporte por ID")
+    public ResponseEntity<MaritimActivityReportResponse> findById(@PathVariable Long id) {
+        return ResponseEntity.ok(maritimActivityReportService.findById(id));
     }
 
     @PutMapping("/{id}")
-    @Operation(summary = "Actualizar reporte", description = "Actualiza un reporte DIMAR existente")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Reporte actualizado exitosamente"),
-            @ApiResponse(responseCode = "404", description = "Reporte no encontrado"),
-            @ApiResponse(responseCode = "400", description = "Datos inválidos"),
-            @ApiResponse(responseCode = "401", description = "No autorizado")
-    })
+    @Operation(summary = "Actualizar reporte")
     public ResponseEntity<MaritimActivityReportResponse> update(
-            @Parameter(description = "ID del reporte") @PathVariable Long id,
+            @PathVariable Long id,
             @Valid @RequestBody MaritimActivityReportRequest request) {
-        log.info("Updating maritime activity report id: {}", id);
-        
-        MaritimActivityReportResponse response = maritimActivityReportService.update(id, request);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(maritimActivityReportService.update(id, request));
     }
 
     @DeleteMapping("/{id}")
-    @Operation(summary = "Eliminar reporte", description = "Elimina un reporte DIMAR por su ID")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "Reporte eliminado exitosamente"),
-            @ApiResponse(responseCode = "404", description = "Reporte no encontrado"),
-            @ApiResponse(responseCode = "401", description = "No autorizado")
-    })
-    public ResponseEntity<Void> delete(
-            @Parameter(description = "ID del reporte") @PathVariable Long id) {
-        log.info("Deleting maritime activity report id: {}", id);
-        
+    @Operation(summary = "Eliminar reporte")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
         maritimActivityReportService.delete(id);
         return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/date")
-    @Operation(summary = "Buscar reportes por fecha", description = "Obtiene todos los reportes DIMAR de una fecha específica")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Reportes obtenidos exitosamente"),
-            @ApiResponse(responseCode = "401", description = "No autorizado")
-    })
-    public ResponseEntity<List<MaritimActivityReportResponse>> findByReportDate(
-            @Parameter(description = "Fecha del reporte (YYYY-MM-DD)") 
+    @Operation(summary = "Buscar reportes vigentes en una fecha")
+    public ResponseEntity<List<MaritimActivityReportResponse>> findActiveOnDate(
+            @Parameter(description = "Fecha (YYYY-MM-DD)")
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate reportDate) {
-        log.info("Getting maritime activity reports by date: {}", reportDate);
-        
-        List<MaritimActivityReportResponse> response = maritimActivityReportService.findByReportDate(reportDate);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(maritimActivityReportService.findActiveOnDate(reportDate));
     }
 
-    @GetMapping("/country-city")
-    @Operation(summary = "Buscar reportes por país y ciudad", description = "Obtiene todos los reportes DIMAR de un país y ciudad específicos")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Reportes obtenidos exitosamente"),
-            @ApiResponse(responseCode = "401", description = "No autorizado")
-    })
-    public ResponseEntity<List<MaritimActivityReportResponse>> findByCountryAndCity(
-            @Parameter(description = "País") @RequestParam String country,
-            @Parameter(description = "Ciudad") @RequestParam String city) {
-        log.info("Getting maritime activity reports by country: {} and city: {}", country, city);
-        
-        List<MaritimActivityReportResponse> response = maritimActivityReportService.findByCountryAndCity(country, city);
-        return ResponseEntity.ok(response);
+    @GetMapping("/location")
+    @Operation(summary = "Buscar reportes por ubicación (IDs)")
+    public ResponseEntity<List<MaritimActivityReportResponse>> findByLocation(
+            @RequestParam("countryId") Integer countryId,
+            @RequestParam("stateId") Integer stateId,
+            @RequestParam("cityId") Integer cityId) {
+        return ResponseEntity.ok(maritimActivityReportService.findByLocation(countryId, stateId, cityId));
     }
 }
-

--- a/src/main/java/com/tourya/api/controller/PublicController.java
+++ b/src/main/java/com/tourya/api/controller/PublicController.java
@@ -48,14 +48,14 @@ public class PublicController {
     @GetMapping("/state/getAllStateByCountryIdList/{countryId}")
     @Operation(operationId = "publicGetStatesByCountry", summary = "Listar estados por país (público)")
     public ResponseEntity<List<StateResponse>> getAllStateByCountryIdList(
-            @PathVariable Integer countryId) {
+            @PathVariable("countryId") Integer countryId) {
         return ResponseEntity.ok(stateService.getAllStateByCountryIdList(countryId));
     }
 
     @GetMapping("/city/getAllCityByStateIdList/{stateId}")
     @Operation(operationId = "publicGetCitiesByState", summary = "Listar ciudades por estado (público)")
     public ResponseEntity<List<CityResponse>> getAllCityByStateIdList(
-            @PathVariable Integer stateId) {
+            @PathVariable("stateId") Integer stateId) {
         return ResponseEntity.ok(cityService.getAllCityByStateIdList(stateId));
     }
 

--- a/src/main/java/com/tourya/api/controller/ReservationController.java
+++ b/src/main/java/com/tourya/api/controller/ReservationController.java
@@ -291,7 +291,10 @@ public class ReservationController {
      * @return ReservationResponse con la reserva cancelada
      */
     @PutMapping("/{reservationId}/cancel")
-    @Operation(summary = "Cancelar reserva", description = "Cancela una reserva según el motivo proporcionado (no puede asistir o por lluvia)")
+    @Operation(
+            summary = "Cancelar reserva",
+            description = "Cancela una reserva según el motivo: CANNOT_ATTEND, ILLNESS o INABILITY_TO_TRAVEL. "
+                    + "La cancelación por lluvia usa PUT /reservations/{reservationId}/cancel/rain")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Reserva cancelada exitosamente"),
             @ApiResponse(responseCode = "404", description = "Reserva no encontrada"),
@@ -305,6 +308,23 @@ public class ReservationController {
         
         ReservationResponse response = reservationService.cancelReservation(reservationId, request, authentication);
         return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{reservationId}/cancel/rain")
+    @Operation(
+            summary = "Cancelar reserva por lluvia (DIMAR)",
+            description = "Cancela la reserva el día del tour cuando existe un reporte marítimo vigente con bandera roja "
+                    + "que coincida con la subcategoría y ubicación del tour. Requiere canRainCancel=true en el listado.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Reserva cancelada por lluvia"),
+            @ApiResponse(responseCode = "404", description = "Reserva no encontrada"),
+            @ApiResponse(responseCode = "400", description = "No aplica cancelación por lluvia")
+    })
+    public ResponseEntity<ReservationResponse> cancelReservationByRain(
+            @Parameter(description = "ID de la reserva") @PathVariable Long reservationId,
+            Authentication authentication) {
+        log.info("Canceling reservation {} by rain", reservationId);
+        return ResponseEntity.ok(reservationService.cancelReservationByRain(reservationId, authentication));
     }
 
     /**

--- a/src/main/java/com/tourya/api/models/MaritimActivityReport.java
+++ b/src/main/java/com/tourya/api/models/MaritimActivityReport.java
@@ -13,9 +13,6 @@ import java.time.LocalDate;
 
 /**
  * Entidad que representa un reporte de actividades marítimas de DIMAR.
- * 
- * @author Tourya API Team
- * @version 1.0
  */
 @Getter
 @Setter
@@ -31,20 +28,31 @@ public class MaritimActivityReport extends BaseEntity {
     @Column(name = "id")
     private Long id;
 
-    @Column(name = "country", nullable = false, length = 100)
-    private String country;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "country_id", nullable = false)
+    private Country country;
 
-    @Column(name = "city", nullable = false, length = 100)
-    private String city;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "state_id", nullable = false)
+    private State state;
 
-    @Column(name = "activity", nullable = false, length = 255)
-    private String activity;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "city_id", nullable = false)
+    private City city;
+
+    @Column(name = "business_category_id", nullable = false)
+    private Integer businessCategoryId;
+
+    @Column(name = "subcategory_code", nullable = false, length = 120)
+    private String subcategoryCode;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "flag", nullable = false, length = 20)
     private MaritimeFlagEnum flag;
 
-    @Column(name = "report_date", nullable = false)
-    private LocalDate reportDate;
-}
+    @Column(name = "report_start_date", nullable = false)
+    private LocalDate reportStartDate;
 
+    @Column(name = "report_end_date", nullable = false)
+    private LocalDate reportEndDate;
+}

--- a/src/main/java/com/tourya/api/models/TranslatedField.java
+++ b/src/main/java/com/tourya/api/models/TranslatedField.java
@@ -82,4 +82,26 @@ public class TranslatedField implements Serializable {
     public static TranslatedField of(String spanish, String english, String portuguese) {
         return new TranslatedField(spanish, english, portuguese);
     }
+
+    /**
+     * Parsea un JSON de traducciones (jsonb de PostgreSQL o string JSON).
+     * Si el valor no es JSON, lo interpreta como texto en español.
+     */
+    public static TranslatedField fromDbValue(Object dbValue) {
+        if (dbValue == null) {
+            return null;
+        }
+        String raw = dbValue.toString().trim();
+        if (raw.isEmpty()) {
+            return null;
+        }
+        if (!raw.startsWith("{")) {
+            return ofSpanish(raw);
+        }
+        try {
+            return new com.fasterxml.jackson.databind.ObjectMapper().readValue(raw, TranslatedField.class);
+        } catch (Exception e) {
+            return ofSpanish(raw);
+        }
+    }
 }

--- a/src/main/java/com/tourya/api/models/request/MaritimActivityReportRequest.java
+++ b/src/main/java/com/tourya/api/models/request/MaritimActivityReportRequest.java
@@ -1,6 +1,7 @@
 package com.tourya.api.models.request;
 
 import com.tourya.api.constans.enums.MaritimeFlagEnum;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -10,28 +11,33 @@ import java.time.LocalDate;
 
 /**
  * Request para crear/actualizar un reporte de actividad marítima DIMAR.
- * 
- * @author Tourya API Team
- * @version 1.0
  */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class MaritimActivityReportRequest {
-    
-    @NotNull(message = "El país es obligatorio")
-    private String country;
-    
-    @NotNull(message = "La ciudad es obligatoria")
-    private String city;
-    
-    @NotNull(message = "La actividad es obligatoria")
-    private String activity;
-    
+
+    @NotNull(message = "El ID del país es obligatorio")
+    private Integer countryId;
+
+    @NotNull(message = "El ID del departamento es obligatorio")
+    private Integer stateId;
+
+    @NotNull(message = "El ID de la ciudad es obligatorio")
+    private Integer cityId;
+
+    @NotNull(message = "El ID de la categoría es obligatorio")
+    private Integer businessCategoryId;
+
+    @NotBlank(message = "El código de subcategoría es obligatorio")
+    private String subcategoryCode;
+
     @NotNull(message = "La bandera es obligatoria")
     private MaritimeFlagEnum flag;
-    
-    @NotNull(message = "La fecha es obligatoria")
-    private LocalDate reportDate;
-}
 
+    @NotNull(message = "La fecha de inicio del reporte es obligatoria")
+    private LocalDate reportStartDate;
+
+    @NotNull(message = "La fecha de fin del reporte es obligatoria")
+    private LocalDate reportEndDate;
+}

--- a/src/main/java/com/tourya/api/models/responses/MaritimActivityReportResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/MaritimActivityReportResponse.java
@@ -11,23 +11,22 @@ import java.time.LocalDateTime;
 
 /**
  * Response para un reporte de actividad marítima DIMAR.
- * 
- * @author Tourya API Team
- * @version 1.0
  */
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class MaritimActivityReportResponse {
-    
+
     private Long id;
-    private String country;
-    private String city;
-    private String activity;
+    private Integer countryId;
+    private Integer stateId;
+    private Integer cityId;
+    private Integer businessCategoryId;
+    private String subcategoryCode;
     private MaritimeFlagEnum flag;
-    private LocalDate reportDate;
+    private LocalDate reportStartDate;
+    private LocalDate reportEndDate;
     private LocalDateTime createdDate;
     private LocalDateTime lastModifiedDate;
 }
-

--- a/src/main/java/com/tourya/api/models/responses/ReservationDetailsResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/ReservationDetailsResponse.java
@@ -73,4 +73,7 @@ public class ReservationDetailsResponse {
 
     // --- Validación de cancelación ---
     private Boolean canCancel;
+
+    /** Cancelación por lluvia (DIMAR): solo el día del tour si hay reporte rojo vigente. */
+    private Boolean canRainCancel;
 }

--- a/src/main/java/com/tourya/api/models/responses/SearchTourCategoryResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/SearchTourCategoryResponse.java
@@ -1,5 +1,6 @@
 package com.tourya.api.models.responses;
 
+import com.tourya.api.models.TranslatedField;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -8,13 +9,13 @@ import java.util.List;
 @Data
 public class SearchTourCategoryResponse {
     private Integer id;
-    private String name;
+    private TranslatedField name;
     private List<SubCategoryResponse> subCategories;
 
     @Data
     @AllArgsConstructor
     public static class SubCategoryResponse {
         private String code;
-        private String name;
+        private TranslatedField name;
     }
 }

--- a/src/main/java/com/tourya/api/models/responses/SearchTourSubCategoryResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/SearchTourSubCategoryResponse.java
@@ -1,5 +1,6 @@
 package com.tourya.api.models.responses;
 
+import com.tourya.api.models.TranslatedField;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -7,5 +8,5 @@ import lombok.Data;
 @AllArgsConstructor
 public class SearchTourSubCategoryResponse {
     private String code;
-    private String name;
+    private TranslatedField name;
 }

--- a/src/main/java/com/tourya/api/models/responses/TourTagResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/TourTagResponse.java
@@ -1,13 +1,16 @@
 package com.tourya.api.models.responses;
 
+import com.tourya.api.models.TranslatedField;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class TourTagResponse {
     private Integer id;
     private String dimension;
-    private String name;
+    private TranslatedField name;
     private String slug;
 }

--- a/src/main/java/com/tourya/api/repository/MaritimActivityReportRepository.java
+++ b/src/main/java/com/tourya/api/repository/MaritimActivityReportRepository.java
@@ -1,7 +1,7 @@
 package com.tourya.api.repository;
 
-import com.tourya.api.models.MaritimActivityReport;
 import com.tourya.api.constans.enums.MaritimeFlagEnum;
+import com.tourya.api.models.MaritimActivityReport;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,46 +9,43 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
-/**
- * Repositorio para la entidad MaritimActivityReport.
- * 
- * @author Tourya API Team
- * @version 1.0
- */
 @Repository
 public interface MaritimActivityReportRepository extends JpaRepository<MaritimActivityReport, Long> {
 
-    /**
-     * Busca reportes por fecha
-     */
-    List<MaritimActivityReport> findByReportDate(LocalDate reportDate);
+    @Query("""
+            SELECT m FROM MaritimActivityReport m
+            WHERE :reportDate BETWEEN m.reportStartDate AND m.reportEndDate
+            ORDER BY m.reportStartDate DESC
+            """)
+    List<MaritimActivityReport> findActiveOnDate(@Param("reportDate") LocalDate reportDate);
 
-    /**
-     * Busca reportes por país y ciudad
-     */
-    List<MaritimActivityReport> findByCountryAndCity(String country, String city);
+    @Query("""
+            SELECT m FROM MaritimActivityReport m
+            WHERE m.country.id = :countryId
+              AND m.state.id = :stateId
+              AND m.city.id = :cityId
+            ORDER BY m.reportStartDate DESC
+            """)
+    List<MaritimActivityReport> findByLocationIds(
+            @Param("countryId") Integer countryId,
+            @Param("stateId") Integer stateId,
+            @Param("cityId") Integer cityId);
 
-    /**
-     * Busca reportes por país, ciudad y fecha
-     */
-    Optional<MaritimActivityReport> findByCountryAndCityAndReportDate(String country, String city, LocalDate reportDate);
-
-    /**
-     * Busca reportes por país, ciudad, actividad y fecha
-     */
-    @Query("SELECT m FROM MaritimActivityReport m WHERE m.country = :country AND m.city = :city AND m.activity = :activity AND m.reportDate = :reportDate")
-    Optional<MaritimActivityReport> findByCountryAndCityAndActivityAndReportDate(
-            @Param("country") String country,
-            @Param("city") String city,
-            @Param("activity") String activity,
-            @Param("reportDate") LocalDate reportDate
-    );
-
-    /**
-     * Busca reportes por bandera
-     */
-    List<MaritimActivityReport> findByFlag(MaritimeFlagEnum flag);
+    @Query("""
+            SELECT m FROM MaritimActivityReport m
+            WHERE m.flag = :flag
+              AND m.subcategoryCode = :subcategoryCode
+              AND :reportDate BETWEEN m.reportStartDate AND m.reportEndDate
+              AND m.country.id = :countryId
+              AND m.state.id = :stateId
+              AND m.city.id = :cityId
+            """)
+    List<MaritimActivityReport> findActiveRedReportsForSubcategoryAndLocation(
+            @Param("flag") MaritimeFlagEnum flag,
+            @Param("subcategoryCode") String subcategoryCode,
+            @Param("reportDate") LocalDate reportDate,
+            @Param("countryId") Integer countryId,
+            @Param("stateId") Integer stateId,
+            @Param("cityId") Integer cityId);
 }
-

--- a/src/main/java/com/tourya/api/repository/TourTagRepository.java
+++ b/src/main/java/com/tourya/api/repository/TourTagRepository.java
@@ -15,7 +15,10 @@ public class TourTagRepository {
     public List<Object[]> getAllTourTags() {
         return entityManager
                 .createNativeQuery("""
-                    SELECT t.id, d.nombre AS dimension, t.nombre, t.slug
+                    SELECT t.id,
+                           d.nombre AS dimension,
+                           COALESCE(t.name, jsonb_build_object('es', t.nombre, 'en', '', 'pt', '')) AS name,
+                           t.slug
                     FROM tags t
                     JOIN tag_dimensions d ON d.id = t.dimension_id
                     ORDER BY d.display_order, t.nombre

--- a/src/main/java/com/tourya/api/repository/impl/SearchTourCategoryRepositoryImpl.java
+++ b/src/main/java/com/tourya/api/repository/impl/SearchTourCategoryRepositoryImpl.java
@@ -1,4 +1,5 @@
 package com.tourya.api.repository.impl;
+import com.tourya.api.models.TranslatedField;
 import com.tourya.api.models.responses.SearchTourCategoryResponse;
 import com.tourya.api.models.responses.SearchTourSubCategoryResponse;
 import com.tourya.api.repository.SearchTourCategoryRepository;
@@ -22,7 +23,8 @@ public class SearchTourCategoryRepositoryImpl implements SearchTourCategoryRepos
     @Override
     public List<SearchTourCategoryResponse> getTourCategories() {
         String sql = """
-                SELECT c.id, c.name, c.display_order, m.subcategory_code, m.display_name
+                SELECT c.id, c.name, c.display_order, m.subcategory_code,
+                       COALESCE(m.name, jsonb_build_object('es', m.display_name, 'en', '', 'pt', '')) AS sub_name
                 FROM public.tour_business_category c
                 LEFT JOIN public.tour_business_subcategory_mapping m
                     ON m.business_category_id = c.id
@@ -37,14 +39,15 @@ public class SearchTourCategoryRepositoryImpl implements SearchTourCategoryRepos
             SearchTourCategoryResponse category = grouped.computeIfAbsent(categoryId, ignored -> {
                 SearchTourCategoryResponse response = new SearchTourCategoryResponse();
                 response.setId(categoryId);
-                response.setName((String) row[1]);
+                response.setName(TranslatedField.fromDbValue(row[1]));
                 response.setSubCategories(new ArrayList<>());
                 return response;
             });
 
             if (row[3] != null) {
                 category.getSubCategories().add(
-                        new SearchTourCategoryResponse.SubCategoryResponse((String) row[3], (String) row[4]));
+                        new SearchTourCategoryResponse.SubCategoryResponse(
+                                (String) row[3], TranslatedField.fromDbValue(row[4])));
             }
         }
 
@@ -54,7 +57,8 @@ public class SearchTourCategoryRepositoryImpl implements SearchTourCategoryRepos
     @Override
     public List<SearchTourSubCategoryResponse> getTourSubCategories() {
         String sql = """
-                SELECT m.subcategory_code, m.display_name
+                SELECT m.subcategory_code,
+                       COALESCE(m.name, jsonb_build_object('es', m.display_name, 'en', '', 'pt', '')) AS sub_name
                 FROM public.tour_business_subcategory_mapping m
                 JOIN public.tour_business_category c
                     ON c.id = m.business_category_id
@@ -65,7 +69,8 @@ public class SearchTourCategoryRepositoryImpl implements SearchTourCategoryRepos
 
         List<SearchTourSubCategoryResponse> response = new ArrayList<>();
         for (Object[] row : results) {
-            response.add(new SearchTourSubCategoryResponse((String) row[0], (String) row[1]));
+            response.add(new SearchTourSubCategoryResponse(
+                    (String) row[0], TranslatedField.fromDbValue(row[1])));
         }
         return response;
     }

--- a/src/main/java/com/tourya/api/services/MaritimActivityReportService.java
+++ b/src/main/java/com/tourya/api/services/MaritimActivityReportService.java
@@ -1,11 +1,20 @@
 package com.tourya.api.services;
 
 import com.tourya.api.common.PageResponse;
+import com.tourya.api.exceptions.OperationNotPermittedException;
 import com.tourya.api.exceptions.ResourceNotFoundException;
+import com.tourya.api.models.City;
+import com.tourya.api.models.Country;
 import com.tourya.api.models.MaritimActivityReport;
+import com.tourya.api.models.State;
 import com.tourya.api.models.request.MaritimActivityReportRequest;
 import com.tourya.api.models.responses.MaritimActivityReportResponse;
+import com.tourya.api.repository.CityRepository;
+import com.tourya.api.repository.CountryRepository;
 import com.tourya.api.repository.MaritimActivityReportRepository;
+import com.tourya.api.repository.StateRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -20,12 +29,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
-/**
- * Servicio para gestión de reportes de actividades marítimas DIMAR.
- * 
- * @author Tourya API Team
- * @version 1.0
- */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -33,50 +36,42 @@ import java.util.stream.Collectors;
 public class MaritimActivityReportService {
 
     private final MaritimActivityReportRepository maritimActivityReportRepository;
+    private final CountryRepository countryRepository;
+    private final StateRepository stateRepository;
+    private final CityRepository cityRepository;
 
-    /**
-     * Crea un nuevo reporte DIMAR.
-     * 
-     * @param request Datos del reporte
-     * @param authentication Usuario autenticado
-     * @return MaritimActivityReportResponse con el reporte creado
-     */
+    @PersistenceContext
+    private EntityManager entityManager;
+
     @Transactional
     public MaritimActivityReportResponse create(MaritimActivityReportRequest request, Authentication authentication) {
-        log.info("Creating maritime activity report: country={}, city={}, activity={}, flag={}, date={}", 
-                request.getCountry(), request.getCity(), request.getActivity(), request.getFlag(), request.getReportDate());
-        
+        validateReportDates(request.getReportStartDate(), request.getReportEndDate());
+        LocationRefs location = resolveAndValidateLocation(request);
+        validateCategoryAndSubcategory(request.getBusinessCategoryId(), request.getSubcategoryCode());
+
         MaritimActivityReport report = MaritimActivityReport.builder()
-                .country(request.getCountry())
-                .city(request.getCity())
-                .activity(request.getActivity())
+                .country(location.country())
+                .state(location.state())
+                .city(location.city())
+                .businessCategoryId(request.getBusinessCategoryId())
+                .subcategoryCode(request.getSubcategoryCode())
                 .flag(request.getFlag())
-                .reportDate(request.getReportDate())
+                .reportStartDate(request.getReportStartDate())
+                .reportEndDate(request.getReportEndDate())
                 .build();
-        
-        report = maritimActivityReportRepository.save(report);
-        
-        return toResponse(report);
+
+        return toResponse(maritimActivityReportRepository.save(report));
     }
 
-    /**
-     * Obtiene todos los reportes con paginación.
-     * 
-     * @param page Número de página (0-based)
-     * @param size Tamaño de página
-     * @return PageResponse con los reportes
-     */
     @Transactional(readOnly = true)
     public PageResponse<MaritimActivityReportResponse> findAll(Integer page, Integer size) {
-        log.info("Getting all maritime activity reports - page: {}, size: {}", page, size);
-        
-        Pageable pageable = PageRequest.of(page, size, Sort.by("reportDate").descending());
+        Pageable pageable = PageRequest.of(page, size, Sort.by("reportStartDate").descending());
         Page<MaritimActivityReport> reportsPage = maritimActivityReportRepository.findAll(pageable);
-        
+
         List<MaritimActivityReportResponse> responses = reportsPage.getContent().stream()
                 .map(this::toResponse)
                 .collect(Collectors.toList());
-        
+
         return PageResponse.<MaritimActivityReportResponse>builder()
                 .content(responses)
                 .number(reportsPage.getNumber())
@@ -88,109 +83,129 @@ public class MaritimActivityReportService {
                 .build();
     }
 
-    /**
-     * Obtiene un reporte por su ID.
-     * 
-     * @param id ID del reporte
-     * @return MaritimActivityReportResponse
-     */
     @Transactional(readOnly = true)
     public MaritimActivityReportResponse findById(Long id) {
-        log.info("Getting maritime activity report by id: {}", id);
-        
         MaritimActivityReport report = maritimActivityReportRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Maritime activity report not found with id: " + id));
-        
         return toResponse(report);
     }
 
-    /**
-     * Actualiza un reporte existente.
-     * 
-     * @param id ID del reporte a actualizar
-     * @param request Datos actualizados del reporte
-     * @return MaritimActivityReportResponse con el reporte actualizado
-     */
     @Transactional
     public MaritimActivityReportResponse update(Long id, MaritimActivityReportRequest request) {
-        log.info("Updating maritime activity report id: {}", id);
-        
         MaritimActivityReport report = maritimActivityReportRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Maritime activity report not found with id: " + id));
-        
-        report.setCountry(request.getCountry());
-        report.setCity(request.getCity());
-        report.setActivity(request.getActivity());
+
+        validateReportDates(request.getReportStartDate(), request.getReportEndDate());
+        LocationRefs location = resolveAndValidateLocation(request);
+        validateCategoryAndSubcategory(request.getBusinessCategoryId(), request.getSubcategoryCode());
+
+        report.setCountry(location.country());
+        report.setState(location.state());
+        report.setCity(location.city());
+        report.setBusinessCategoryId(request.getBusinessCategoryId());
+        report.setSubcategoryCode(request.getSubcategoryCode());
         report.setFlag(request.getFlag());
-        report.setReportDate(request.getReportDate());
-        
-        report = maritimActivityReportRepository.save(report);
-        
-        return toResponse(report);
+        report.setReportStartDate(request.getReportStartDate());
+        report.setReportEndDate(request.getReportEndDate());
+
+        return toResponse(maritimActivityReportRepository.save(report));
     }
 
-    /**
-     * Elimina un reporte por su ID.
-     * 
-     * @param id ID del reporte a eliminar
-     */
     @Transactional
     public void delete(Long id) {
-        log.info("Deleting maritime activity report id: {}", id);
-        
         if (!maritimActivityReportRepository.existsById(id)) {
             throw new ResourceNotFoundException("Maritime activity report not found with id: " + id);
         }
-        
         maritimActivityReportRepository.deleteById(id);
     }
 
-    /**
-     * Busca reportes por fecha.
-     * 
-     * @param reportDate Fecha del reporte
-     * @return Lista de reportes de esa fecha
-     */
     @Transactional(readOnly = true)
-    public List<MaritimActivityReportResponse> findByReportDate(LocalDate reportDate) {
-        log.info("Getting maritime activity reports by date: {}", reportDate);
-        
-        return maritimActivityReportRepository.findByReportDate(reportDate).stream()
+    public List<MaritimActivityReportResponse> findActiveOnDate(LocalDate reportDate) {
+        return maritimActivityReportRepository.findActiveOnDate(reportDate).stream()
                 .map(this::toResponse)
                 .collect(Collectors.toList());
     }
 
-    /**
-     * Busca reportes por país y ciudad.
-     * 
-     * @param country País
-     * @param city Ciudad
-     * @return Lista de reportes
-     */
     @Transactional(readOnly = true)
-    public List<MaritimActivityReportResponse> findByCountryAndCity(String country, String city) {
-        log.info("Getting maritime activity reports by country: {} and city: {}", country, city);
-        
-        return maritimActivityReportRepository.findByCountryAndCity(country, city).stream()
+    public List<MaritimActivityReportResponse> findByLocation(
+            Integer countryId, Integer stateId, Integer cityId) {
+        return maritimActivityReportRepository.findByLocationIds(countryId, stateId, cityId).stream()
                 .map(this::toResponse)
                 .collect(Collectors.toList());
     }
 
-    /**
-     * Convierte una entidad a Response DTO.
-     */
+    private void validateReportDates(LocalDate reportStartDate, LocalDate reportEndDate) {
+        LocalDate today = LocalDate.now();
+        if (reportStartDate.isBefore(today)) {
+            throw new OperationNotPermittedException(
+                    "La fecha de inicio del reporte no puede ser anterior a hoy.");
+        }
+        if (reportEndDate.isBefore(today)) {
+            throw new OperationNotPermittedException(
+                    "La fecha de fin del reporte no puede ser anterior a hoy.");
+        }
+        if (reportEndDate.isBefore(reportStartDate)) {
+            throw new OperationNotPermittedException(
+                    "La fecha de fin del reporte no puede ser anterior a la fecha de inicio.");
+        }
+    }
+
+    private LocationRefs resolveAndValidateLocation(MaritimActivityReportRequest request) {
+        Country country = countryRepository.findById(request.getCountryId())
+                .orElseThrow(() -> new ResourceNotFoundException("Country not found with id: " + request.getCountryId()));
+        State state = stateRepository.findById(request.getStateId())
+                .orElseThrow(() -> new ResourceNotFoundException("State not found with id: " + request.getStateId()));
+        City city = cityRepository.findById(request.getCityId())
+                .orElseThrow(() -> new ResourceNotFoundException("City not found with id: " + request.getCityId()));
+
+        if (!state.getCountry().getId().equals(country.getId())) {
+            throw new OperationNotPermittedException("El departamento no pertenece al país indicado.");
+        }
+        if (!city.getState().getId().equals(state.getId())) {
+            throw new OperationNotPermittedException("La ciudad no pertenece al departamento indicado.");
+        }
+
+        return new LocationRefs(country, state, city);
+    }
+
+    private void validateCategoryAndSubcategory(Integer businessCategoryId, String subcategoryCode) {
+        Number categoryCount = (Number) entityManager.createNativeQuery(
+                        "SELECT COUNT(*) FROM public.tour_business_category WHERE id = :id")
+                .setParameter("id", businessCategoryId)
+                .getSingleResult();
+        if (categoryCount.longValue() == 0) {
+            throw new ResourceNotFoundException("Business category not found with id: " + businessCategoryId);
+        }
+
+        Number mappingCount = (Number) entityManager.createNativeQuery("""
+                        SELECT COUNT(*)
+                        FROM public.tour_business_subcategory_mapping
+                        WHERE subcategory_code = :code AND business_category_id = :categoryId
+                        """)
+                .setParameter("code", subcategoryCode)
+                .setParameter("categoryId", businessCategoryId)
+                .getSingleResult();
+        if (mappingCount.longValue() == 0) {
+            throw new OperationNotPermittedException(
+                    "La subcategoría no pertenece a la categoría indicada.");
+        }
+    }
+
     private MaritimActivityReportResponse toResponse(MaritimActivityReport report) {
         return MaritimActivityReportResponse.builder()
                 .id(report.getId())
-                .country(report.getCountry())
-                .city(report.getCity())
-                .activity(report.getActivity())
+                .countryId(report.getCountry().getId())
+                .stateId(report.getState().getId())
+                .cityId(report.getCity().getId())
+                .businessCategoryId(report.getBusinessCategoryId())
+                .subcategoryCode(report.getSubcategoryCode())
                 .flag(report.getFlag())
-                .reportDate(report.getReportDate())
+                .reportStartDate(report.getReportStartDate())
+                .reportEndDate(report.getReportEndDate())
                 .createdDate(report.getCreatedDate())
                 .lastModifiedDate(report.getLastModifiedDate())
                 .build();
     }
+
+    private record LocationRefs(Country country, State state, City city) {}
 }
-
-

--- a/src/main/java/com/tourya/api/services/ReservationService.java
+++ b/src/main/java/com/tourya/api/services/ReservationService.java
@@ -427,22 +427,6 @@ public class ReservationService {
     }
 
     /**
-     * Coincidencia entre la actividad cargada en el reporte DIMAR y la subcategoría del tour (p. ej. {@code paseo_al_cayo}).
-     */
-    private boolean maritimReportActivityMatchesTourSubcategory(MaritimActivityReport report, Tour tour) {
-        if (report == null || report.getActivity() == null || tour.getSubCategory() == null) {
-            return false;
-        }
-        String sub = tour.getSubCategory().getValue();
-        String act = report.getActivity().trim();
-        if (act.equalsIgnoreCase(sub)) {
-            return true;
-        }
-        String normalized = act.toLowerCase().replace(' ', '_').replace('-', '_');
-        return normalized.equalsIgnoreCase(sub);
-    }
-
-    /**
      * Rellena en la respuesta los datos del pagador desde la entidad {@link Payment}.
      */
     private void enrichPayerFromPayment(ReservationResponse response, Reservation reservation) {
@@ -953,6 +937,14 @@ public class ReservationService {
                         reservation.getReservationId(), e.getMessage());
                 reservation.setCanCancel(false);
             }
+
+            try {
+                reservation.setCanRainCancel(computeCanRainCancel(reservation.getReservationId(), connectedUser));
+            } catch (Exception e) {
+                log.warn("Error validating rain cancel for reservation {}: {}",
+                        reservation.getReservationId(), e.getMessage());
+                reservation.setCanRainCancel(false);
+            }
         }
 
         Long total =
@@ -1038,18 +1030,12 @@ public class ReservationService {
             throw new OperationNotPermittedException("No se encontró política de cancelación para este tour.");
         }
 
-        TourCancellationPolicy policy = policies.get(0);
         LocalDate today = LocalDate.now();
-
-        // Obtener la fecha seleccionada por el usuario desde ShoppingCartItem
-        LocalDate tourDate = (item.getScheduleDate() != null)
-                ? item.getScheduleDate()
-                : schedule.getScheduleDate(); // Fallback si no hay fecha en ShoppingCartItem
 
         // Validar según el motivo de cancelación
         boolean canCancel = false;
 
-        if (request.getCancellationReason() == CancellationReasonEnum.CANNOT_ATTEND) {
+        if (isPolicyBasedCancellationReason(request.getCancellationReason())) {
             // Alineado con validateCancelReservation: si no hay fecha máxima persistida, no bloqueamos por ventana
             if (reservation.getMaxCancellationDate() == null) {
                 canCancel = true;
@@ -1063,33 +1049,10 @@ public class ReservationService {
                                 + reservation.getMaxCancellationDate() + ") ya pasó.");
             }
         } else if (request.getCancellationReason() == CancellationReasonEnum.RAIN) {
-            if (!policy.isAllowsRainRefund()) {
-                throw new OperationNotPermittedException("La cancelación por lluvia no está habilitada para este tour.");
-            }
-            if (tourDate == null) {
-                throw new OperationNotPermittedException("No se pudo determinar la fecha del tour para validar la cancelación por lluvia.");
-            }
-            if (!today.equals(tourDate)) {
-                throw new OperationNotPermittedException(
-                        "La cancelación por lluvia solo es permitida el día del tour.");
-            }
-            if (tour.getSubCategory() == null) {
-                throw new OperationNotPermittedException(
-                        "El tour no tiene subcategoría definida; no aplica la cancelación por lluvia con reporte DIMAR.");
-            }
-            List<MaritimActivityReport> reports = maritimActivityReportRepository.findByReportDate(today);
-            if (reports.isEmpty()) {
-                throw new OperationNotPermittedException("No hay reporte marítimo (DIMAR) registrado para hoy.");
-            }
-            boolean hasMatchingRed = reports.stream()
-                    .anyMatch(r -> r.getFlag() == MaritimeFlagEnum.RED
-                            && maritimReportActivityMatchesTourSubcategory(r, tour));
-            if (!hasMatchingRed) {
-                throw new OperationNotPermittedException(
-                        "No aplica cancelación por lluvia: se requiere un reporte de hoy con bandera roja "
-                                + "y una actividad que coincida con la subcategoría del tour.");
-            }
-            canCancel = true;
+            throw new OperationNotPermittedException(
+                    "La cancelación por lluvia debe realizarse con PUT /reservations/{reservationId}/cancel/rain");
+        } else {
+            throw new OperationNotPermittedException("Motivo de cancelación no válido.");
         }
 
         // Si todas las validaciones pasan, cancelar la reserva y crear crédito
@@ -1126,6 +1089,134 @@ public class ReservationService {
         }
         
         return response;
+    }
+
+    private boolean isPolicyBasedCancellationReason(CancellationReasonEnum reason) {
+        return reason == CancellationReasonEnum.CANNOT_ATTEND
+                || reason == CancellationReasonEnum.ILLNESS
+                || reason == CancellationReasonEnum.INABILITY_TO_TRAVEL;
+    }
+
+    /**
+     * Cancela una reserva por lluvia (DIMAR). Endpoint dedicado; no usa {@link #cancelReservation}.
+     */
+    @Transactional
+    public ReservationResponse cancelReservationByRain(Long reservationId, Authentication authentication) {
+        log.info("Canceling reservation {} by rain (DIMAR)", reservationId);
+
+        User user = (User) authentication.getPrincipal();
+        Reservation reservation = reservationRepository.findByIdForUpdate(reservationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Reservation not found with id: " + reservationId));
+
+        if (reservation.getItemId() == null) {
+            throw new OperationNotPermittedException("La reserva no tiene un ítem de carrito asociado; no se puede cancelar.");
+        }
+
+        ShoppingCartItem item = shoppingCartItemRepository.findById(reservation.getItemId())
+                .orElseThrow(() -> new ResourceNotFoundException("Shopping cart item not found"));
+
+        if (!item.getShoppingCart().getUser().getId().equals(user.getId())) {
+            throw new OperationNotPermittedException("No tienes permiso para cancelar esta reserva.");
+        }
+
+        if (reservation.getDeliveryStatus() == DeliveryStatusEnum.CANCELED) {
+            throw new OperationNotPermittedException("La reserva ya está cancelada.");
+        }
+        if (reservation.getDeliveryStatus() == DeliveryStatusEnum.DELIVERED) {
+            throw new OperationNotPermittedException("No se puede cancelar una reserva completada.");
+        }
+
+        if (!computeCanRainCancel(reservationId, authentication)) {
+            throw new OperationNotPermittedException(
+                    "No aplica cancelación por lluvia: se requiere política habilitada, tour el día de hoy "
+                            + "y reporte DIMAR vigente con bandera roja para la subcategoría y ubicación del tour.");
+        }
+
+        TourSchedule schedule = item.getTourSchedule();
+        Tour tour = tourRepository.findById(schedule.getTourId())
+                .orElseThrow(() -> new ResourceNotFoundException("Tour not found"));
+
+        reservation.setDeliveryStatus(DeliveryStatusEnum.CANCELED);
+        reservation.setCancellationReason(CancellationReasonEnum.RAIN);
+        reservation.setCancellationDate(LocalDateTime.now());
+        reservation = reservationRepository.save(reservation);
+
+        if (item.getSlot() != null && item.getSlot().getId() != null) {
+            tourScheduleSlotAvailabilityService.recalculate(item.getSlot().getId());
+        }
+
+        Credit credit = createCreditForReservation(reservation, tour);
+        log.info("Reservation {} canceled by rain successfully", reservationId);
+
+        ReservationResponse response = reservationMapper.toResponse(reservation);
+        enrichReservationResponse(response, reservation);
+        if (credit != null) {
+            response.setCredit(CreditResponse.builder()
+                    .id(credit.getId())
+                    .reservationId(credit.getReservationId())
+                    .amount(credit.getAmount())
+                    .creationDate(credit.getCreationDate())
+                    .expirationDate(credit.getExpirationDate())
+                    .status(credit.getStatus())
+                    .build());
+        }
+        return response;
+    }
+
+    private boolean computeCanRainCancel(Long reservationId, Authentication authentication) {
+        User user = (User) authentication.getPrincipal();
+
+        Reservation reservation = reservationRepository.findById(reservationId).orElse(null);
+        if (reservation == null || reservation.getItemId() == null) {
+            return false;
+        }
+
+        ShoppingCartItem item = shoppingCartItemRepository.findById(reservation.getItemId()).orElse(null);
+        if (item == null || item.getShoppingCart() == null
+                || !item.getShoppingCart().getUser().getId().equals(user.getId())) {
+            return false;
+        }
+
+        if (reservation.getDeliveryStatus() == DeliveryStatusEnum.CANCELED
+                || reservation.getDeliveryStatus() == DeliveryStatusEnum.DELIVERED) {
+            return false;
+        }
+
+        TourSchedule schedule = item.getTourSchedule();
+        if (schedule == null || schedule.getTourId() == null) {
+            return false;
+        }
+
+        Tour tour = tourRepository.findById(schedule.getTourId()).orElse(null);
+        if (tour == null || tour.getSubCategory() == null) {
+            return false;
+        }
+
+        List<TourCancellationPolicy> policies = tourCancellationPolicyRepository.findByTourId(tour.getId());
+        if (policies.isEmpty() || !policies.get(0).isAllowsRainRefund()) {
+            return false;
+        }
+
+        LocalDate tourDate = item.getScheduleDate() != null ? item.getScheduleDate() : schedule.getScheduleDate();
+        LocalDate today = LocalDate.now();
+        if (tourDate == null || !today.equals(tourDate)) {
+            return false;
+        }
+
+        List<TourAddress> addresses = tourAddressRepository.findByTourId(tour.getId());
+        if (addresses.isEmpty()) {
+            return false;
+        }
+        TourAddress address = addresses.get(0);
+
+        return !maritimActivityReportRepository.findActiveRedReportsForSubcategoryAndLocation(
+                MaritimeFlagEnum.RED,
+                tour.getSubCategory().getValue(),
+                today,
+                address.getCountry().getId(),
+                address.getState().getId(),
+                address.getCity().getId()
+        ).isEmpty();
     }
     
     /**
@@ -1251,7 +1342,6 @@ public class ReservationService {
      * Valida si una reserva puede ser cancelada (sin hacer cambios).
      * Bloquea canceladas y completadas (DELIVERED). Una reserva en {@code RESCHEDULED} puede cancelarse
      * si la ventana {@code maxCancellationDate} aún aplica (o política equivalente).
-     * La cancelación por lluvia (DIMAR) se valida en el endpoint de cancelación con motivo RAIN.
      */
     @Transactional(readOnly = true)
     public com.tourya.api.models.responses.CancelValidationResponse validateCancelReservation(Long reservationId, Authentication authentication) {

--- a/src/main/java/com/tourya/api/services/TourTagService.java
+++ b/src/main/java/com/tourya/api/services/TourTagService.java
@@ -1,5 +1,6 @@
 package com.tourya.api.services;
 
+import com.tourya.api.models.TranslatedField;
 import com.tourya.api.models.responses.TourTagResponse;
 import com.tourya.api.repository.TourTagRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +21,7 @@ public class TourTagService {
                 .map(row -> new TourTagResponse(
                         ((Number) row[0]).intValue(),
                         (String) row[1],
-                        (String) row[2],
+                        TranslatedField.fromDbValue(row[2]),
                         (String) row[3]
                 ))
                 .collect(Collectors.toList());


### PR DESCRIPTION
- Reportes DIMAR con ubicacion por ID, categoria/subcategoria y rango de fechas

- Filtros publicos tags/categorias/subcategorias con name multilenguaje (es/en/pt)

- canRainCancel en GET /reservations y endpoint PUT /reservations/{id}/cancel/rain

- Motivos cancelacion: ILLNESS e INABILITY_TO_TRAVEL; RAIN solo por endpoint dedicado

- Fix @PathVariable explicitos en combos publicos de pais/departamento/ciudad

Migraciones: 055, 056, 057