### PR TITLE
feat: ajustes Luis i18n, carrito/pago y fix schedules 500

### DIFF
--- a/MIGRACIONES_A_EJECUTAR.txt
+++ b/MIGRACIONES_A_EJECUTAR.txt
@@ -99,3 +99,16 @@
 22. `database/migrations/061_sp_get_provider_reservations_cleanup_overloads.sql`
     - LOCAL: si GET /reservations falla con bad SQL grammar. Borra firmas viejas del SP y deja la de 5 params.
 
+### 9) Ajustes front Luis — i18n motivos reseña + subcategorías (25/06/2026)
+23. `database/migrations/062_subcategory_i18n_remove_parentheses.sql`
+    - Quita textos entre paréntesis en subcategorías (naranja en doc Luis)
+    - Requiere 055 y 056 ya ejecutadas
+
+24. `database/migrations/063_review_reason_catalog_i18n.sql`
+    - Tabla `review_reason_catalog` con motivos positivos/negativos en es/en/pt
+    - Alimenta GET `/public/review/reasons` y `/public/review/reasons/by-rating`
+
+25. `database/migrations/064_subcategory_remove_all_parentheses.sql`
+    - **EJECUTAR EN EC2** si siguen viéndose paréntesis en subcategorías
+    - Corrige `vuelta_a_la_isla_city_tour`, `aquanautas`, `display_name` y limpia el resto
+    - (062 tenía error: dejó "(City Tour)" en ES)

--- a/database/migrations/062_subcategory_i18n_remove_parentheses.sql
+++ b/database/migrations/062_subcategory_i18n_remove_parentheses.sql
@@ -1,0 +1,38 @@
+-- Migration: Quitar textos entre paréntesis en subcategorías (ajustes front Luis - naranja)
+-- Date: 2026-06-25
+-- Requiere: 055 y 056 ya ejecutadas (columna tour_business_subcategory_mapping.name jsonb)
+
+-- Paseo al cayo: PT sin "(Cayo)"
+UPDATE public.tour_business_subcategory_mapping
+SET name = '{"es":"Paseo al cayo","en":"Cay / Islet Tour","pt":"Passeio ao Ilhéu"}'::jsonb
+WHERE subcategory_code = 'paseo_al_cayo';
+
+-- Vuelta a la isla: sin paréntesis en ningún idioma; EN solo "City Tour"
+UPDATE public.tour_business_subcategory_mapping
+SET
+    display_name = 'Vuelta a la isla',
+    name = '{"es":"Vuelta a la isla","en":"City Tour","pt":"Volta à Ilha"}'::jsonb
+WHERE subcategory_code = 'vuelta_a_la_isla_city_tour';
+
+-- Snorkeling: PT solo "Snorkeling"
+UPDATE public.tour_business_subcategory_mapping
+SET name = '{"es":"Snorkeling","en":"Snorkeling","pt":"Snorkeling"}'::jsonb
+WHERE subcategory_code = 'snorkeling';
+
+-- Aquanautas: sin paréntesis ni sufijos "/ Sea Trek"
+UPDATE public.tour_business_subcategory_mapping
+SET name = '{"es":"Aquanautas","en":"Helmet Diving","pt":"Caminhada Subaquática"}'::jsonb
+WHERE subcategory_code = 'aquanautas';
+
+-- Otros enumerados con paréntesis innecesarios en EN/PT
+UPDATE public.tour_business_subcategory_mapping
+SET name = '{"es":"Paddle board","en":"Paddleboarding","pt":"Stand Up Paddle"}'::jsonb
+WHERE subcategory_code = 'paddle_board';
+
+UPDATE public.tour_business_subcategory_mapping
+SET name = '{"es":"Moto","en":"Motorbike Rental","pt":"Aluguel de Moto"}'::jsonb
+WHERE subcategory_code = 'moto';
+
+UPDATE public.tour_business_subcategory_mapping
+SET name = '{"es":"Carro playero","en":"Golf Cart Rental","pt":"Aluguel de Carrinho de Golfe"}'::jsonb
+WHERE subcategory_code = 'carro_playero';

--- a/database/migrations/063_review_reason_catalog_i18n.sql
+++ b/database/migrations/063_review_reason_catalog_i18n.sql
@@ -1,0 +1,35 @@
+-- Migration: Catálogo de motivos de reseña en 3 idiomas (es/en/pt)
+-- Date: 2026-06-25
+-- Endpoint: GET /api/v1/public/review/reasons
+
+CREATE TABLE IF NOT EXISTS public.review_reason_catalog (
+    id          SERIAL PRIMARY KEY,
+    reason_type VARCHAR(20) NOT NULL,
+    reason_id   INTEGER     NOT NULL,
+    label       jsonb       NOT NULL,
+    CONSTRAINT uq_review_reason_catalog_type_id UNIQUE (reason_type, reason_id)
+);
+
+COMMENT ON TABLE public.review_reason_catalog IS 'Motivos de reseña positivos/negativos con traducciones es/en/pt';
+
+-- POSITIVE (reason_id 1..7)
+INSERT INTO public.review_reason_catalog (reason_type, reason_id, label) VALUES
+('POSITIVE', 1, '{"es":"Servicio excepcional del guía","en":"Exceptional service from the guide","pt":"Serviço excepcional do guia"}'),
+('POSITIVE', 2, '{"es":"Puntualidad del proveedor","en":"Provider''s punctuality","pt":"Pontualidade do prestador de serviços"}'),
+('POSITIVE', 3, '{"es":"Buena organización del tour","en":"Good tour organization","pt":"Boa organização do passeio"}'),
+('POSITIVE', 4, '{"es":"Excelente relación calidad-precio","en":"Excellent value for money","pt":"Excelente custo-benefício"}'),
+('POSITIVE', 5, '{"es":"Comodidad del transporte","en":"Comfort of transportation","pt":"Conforto do transporte"}'),
+('POSITIVE', 6, '{"es":"Buena atención al cliente","en":"Good customer service","pt":"Bom atendimento ao cliente"}'),
+('POSITIVE', 7, '{"es":"Recomendable para otros viajeros","en":"Would recommend to other travelers","pt":"Recomendável para outros viajantes"}')
+ON CONFLICT (reason_type, reason_id) DO UPDATE SET label = EXCLUDED.label;
+
+-- NEGATIVE (reason_id 1..7)
+INSERT INTO public.review_reason_catalog (reason_type, reason_id, label) VALUES
+('NEGATIVE', 1, '{"es":"Retraso o impuntualidad","en":"Delays or lack of punctuality","pt":"Atraso ou falta de pontualidade"}'),
+('NEGATIVE', 2, '{"es":"Guía poco amable o desinformado","en":"Unfriendly or uninformed guide","pt":"Guia pouco simpático ou mal informado"}'),
+('NEGATIVE', 3, '{"es":"Mala comunicación con el operador turístico","en":"Poor communication with the tour operator","pt":"Má comunicação com a operadora de turismo"}'),
+('NEGATIVE', 4, '{"es":"El tour no correspondía a la descripción","en":"Tour did not match the description","pt":"O passeio não correspondia à descrição"}'),
+('NEGATIVE', 5, '{"es":"Problemas con el transporte","en":"Problems with transportation","pt":"Problemas com o transporte"}'),
+('NEGATIVE', 6, '{"es":"Mala relación calidad-precio","en":"Poor value for money","pt":"Má relação custo-benefício"}'),
+('NEGATIVE', 7, '{"es":"No cumplieron con lo que incluye el tour","en":"Did not deliver what the tour included","pt":"Não cumpriram o que estava incluído no passeio"}')
+ON CONFLICT (reason_type, reason_id) DO UPDATE SET label = EXCLUDED.label;

--- a/database/migrations/064_subcategory_remove_all_parentheses.sql
+++ b/database/migrations/064_subcategory_remove_all_parentheses.sql
@@ -1,0 +1,60 @@
+-- Migration: Eliminar TODOS los paréntesis en subcategorías (name jsonb + display_name)
+-- Date: 2026-06-27
+-- Corrige 062 que dejó "(City Tour)" en ES y no actualizó display_name
+
+-- =============================================================================
+-- Correcciones explícitas (tabla Luis / doc front)
+-- =============================================================================
+
+UPDATE public.tour_business_subcategory_mapping
+SET
+    display_name = 'Vuelta a la isla',
+    name = '{"es":"Vuelta a la isla","en":"City Tour","pt":"Volta à Ilha"}'::jsonb
+WHERE subcategory_code = 'vuelta_a_la_isla_city_tour';
+
+UPDATE public.tour_business_subcategory_mapping
+SET
+    name = '{"es":"Aquanautas","en":"Helmet Diving","pt":"Caminhada Subaquática"}'::jsonb
+WHERE subcategory_code = 'aquanautas';
+
+UPDATE public.tour_business_subcategory_mapping
+SET
+    name = '{"es":"Paseo al cayo","en":"Cay / Islet Tour","pt":"Passeio ao Ilhéu"}'::jsonb
+WHERE subcategory_code = 'paseo_al_cayo';
+
+UPDATE public.tour_business_subcategory_mapping
+SET
+    name = '{"es":"Snorkeling","en":"Snorkeling","pt":"Snorkeling"}'::jsonb
+WHERE subcategory_code = 'snorkeling';
+
+UPDATE public.tour_business_subcategory_mapping
+SET
+    name = '{"es":"Paddle board","en":"Paddleboarding","pt":"Stand Up Paddle"}'::jsonb
+WHERE subcategory_code = 'paddle_board';
+
+UPDATE public.tour_business_subcategory_mapping
+SET
+    name = '{"es":"Moto","en":"Motorbike Rental","pt":"Aluguel de Moto"}'::jsonb
+WHERE subcategory_code = 'moto';
+
+UPDATE public.tour_business_subcategory_mapping
+SET
+    name = '{"es":"Carro playero","en":"Golf Cart Rental","pt":"Aluguel de Carrinho de Golfe"}'::jsonb
+WHERE subcategory_code = 'carro_playero';
+
+-- =============================================================================
+-- Limpieza general: quitar " (texto)" en cualquier subcategoría restante
+-- =============================================================================
+
+UPDATE public.tour_business_subcategory_mapping
+SET
+    display_name = trim(regexp_replace(display_name, ' \([^)]*\)', '', 'g')),
+    name = jsonb_build_object(
+        'es', trim(regexp_replace(COALESCE(name->>'es', ''), ' \([^)]*\)', '', 'g')),
+        'en', trim(regexp_replace(COALESCE(name->>'en', ''), ' \([^)]*\)', '', 'g')),
+        'pt', trim(regexp_replace(COALESCE(name->>'pt', ''), ' \([^)]*\)', '', 'g'))
+    )
+WHERE display_name ~ '\([^)]*\)'
+   OR COALESCE(name->>'es', '') ~ '\([^)]*\)'
+   OR COALESCE(name->>'en', '') ~ '\([^)]*\)'
+   OR COALESCE(name->>'pt', '') ~ '\([^)]*\)';

--- a/src/main/java/com/tourya/api/_utils/PayloadIdUtils.java
+++ b/src/main/java/com/tourya/api/_utils/PayloadIdUtils.java
@@ -1,0 +1,24 @@
+package com.tourya.api._utils;
+
+/**
+ * El front suele enviar {@code 0} o {@code ""} cuando el registro aún no tiene id en BD.
+ */
+public final class PayloadIdUtils {
+
+    private PayloadIdUtils() {
+    }
+
+    /** Id ausente o placeholder del front (0, negativo). */
+    public static boolean isTransientId(Integer id) {
+        return id == null || id <= 0;
+    }
+
+    /** Id que puede usarse para buscar/actualizar en BD. */
+    public static boolean isPersistedId(Integer id) {
+        return !isTransientId(id);
+    }
+
+    public static Integer normalizeId(Integer id) {
+        return isTransientId(id) ? null : id;
+    }
+}

--- a/src/main/java/com/tourya/api/config/EmptyStringAsNullIntegerDeserializer.java
+++ b/src/main/java/com/tourya/api/config/EmptyStringAsNullIntegerDeserializer.java
@@ -1,0 +1,28 @@
+package com.tourya.api.config;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.tourya.api._utils.PayloadIdUtils;
+
+import java.io.IOException;
+
+/**
+ * Normaliza ids del front: {@code ""} y {@code 0} se interpretan como null (registro nuevo).
+ */
+public class EmptyStringAsNullIntegerDeserializer extends JsonDeserializer<Integer> {
+
+    @Override
+    public Integer deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        JsonToken token = p.currentToken();
+        if (token == JsonToken.VALUE_STRING && p.getText().trim().isEmpty()) {
+            return null;
+        }
+        if (token == JsonToken.VALUE_NULL) {
+            return null;
+        }
+        int value = p.getValueAsInt();
+        return PayloadIdUtils.isTransientId(value) ? null : value;
+    }
+}

--- a/src/main/java/com/tourya/api/controller/ReferenceController.java
+++ b/src/main/java/com/tourya/api/controller/ReferenceController.java
@@ -1,5 +1,6 @@
 package com.tourya.api.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 
@@ -10,6 +11,7 @@ import java.util.*;
 
 @RestController
 @RequestMapping("/reference")
+@Tag(name = "Reference")
 public class ReferenceController {
 
     // 🔑 Secreto de integridad leído desde application.properties

--- a/src/main/java/com/tourya/api/controller/RequestProviderGalleryController.java
+++ b/src/main/java/com/tourya/api/controller/RequestProviderGalleryController.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tourya.api.models.request.RequestProviderGalleryMetadata;
 import com.tourya.api.models.responses.RequestProviderGalleryResponse;
 import com.tourya.api.services.RequestProviderGalleryService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/requestProvider/{requestId}/gallery")
 @RequiredArgsConstructor
+@Tag(name = "RequestProviderGallery")
 public class RequestProviderGalleryController {
 
     private final RequestProviderGalleryService requestProviderGalleryService;

--- a/src/main/java/com/tourya/api/controller/TestController.java
+++ b/src/main/java/com/tourya/api/controller/TestController.java
@@ -1,5 +1,6 @@
 package com.tourya.api.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,6 +11,7 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1")
+@Tag(name = "Test")
 public class TestController {
 
     @GetMapping("/connectionTest")

--- a/src/main/java/com/tourya/api/controller/TourGalleryController.java
+++ b/src/main/java/com/tourya/api/controller/TourGalleryController.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tourya.api.models.request.TourGalleryRequest;
 import com.tourya.api.models.responses.TourGalleryResponse;
 import com.tourya.api.services.TourGalleryService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +20,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/tours/{tourId}/gallery")
 @RequiredArgsConstructor
+@Tag(name = "TourGallery")
 public class TourGalleryController {
 
     private final TourGalleryService tourGalleryService;

--- a/src/main/java/com/tourya/api/controller/TourIncludesExcludesController.java
+++ b/src/main/java/com/tourya/api/controller/TourIncludesExcludesController.java
@@ -4,6 +4,7 @@ import com.tourya.api.constans.enums.IncludeExcludeTypeEnum;
 import com.tourya.api.models.request.TourIncludesExcludesRequest;
 import com.tourya.api.models.responses.TourIncludesExcludesResponse;
 import com.tourya.api.services.TourIncludesExcludesService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -14,6 +15,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/tours/{tourId}/includes-excludes")
 @RequiredArgsConstructor
+@Tag(name = "TourIncludesExcludes")
 public class TourIncludesExcludesController {
 
     private final TourIncludesExcludesService tourIncludesExcludesService;

--- a/src/main/java/com/tourya/api/controller/TourItineraryController.java
+++ b/src/main/java/com/tourya/api/controller/TourItineraryController.java
@@ -4,6 +4,7 @@ package com.tourya.api.controller;
 import com.tourya.api.models.responses.TourItineraryResponse;
 import com.tourya.api.models.request.TourItineraryRequest;
 import com.tourya.api.services.TourItineraryService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -14,6 +15,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/tours/{tourId}/itinerary")
 @RequiredArgsConstructor
+@Tag(name = "TourItinerary")
 public class TourItineraryController {
 
     private final TourItineraryService tourItineraryService;

--- a/src/main/java/com/tourya/api/controller/TourMainAttractionController.java
+++ b/src/main/java/com/tourya/api/controller/TourMainAttractionController.java
@@ -3,6 +3,7 @@ package com.tourya.api.controller;
 import com.tourya.api.models.request.TourMainAttractionRequest;
 import com.tourya.api.models.responses.TourMainAttractionResponse;
 import com.tourya.api.services.TourMainAttractionService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -13,6 +14,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/tours/{tourId}/main-attractions")
 @RequiredArgsConstructor
+@Tag(name = "TourMainAttraction")
 public class TourMainAttractionController {
 
     private final TourMainAttractionService tourMainAttractionService;

--- a/src/main/java/com/tourya/api/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/tourya/api/handler/GlobalExceptionHandler.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.OffsetDateTime;
 import java.util.HashMap;
@@ -129,6 +130,15 @@ public class GlobalExceptionHandler {
                 .error(VALIDATION_FAILURE.getDescription())
                 .build();
         return buildErrorResponse(exceptionResponse, BAD_REQUEST);
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<Object> handleResponseStatusException(ResponseStatusException exp) {
+        ExceptionResponse exceptionResponse = ExceptionResponse.builder()
+                .message(exp.getReason() != null ? exp.getReason() : exp.getStatusCode().toString())
+                .error(exp.getReason())
+                .build();
+        return buildErrorResponse(exceptionResponse, org.springframework.http.HttpStatus.valueOf(exp.getStatusCode().value()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/tourya/api/models/ReviewReasonCatalog.java
+++ b/src/main/java/com/tourya/api/models/ReviewReasonCatalog.java
@@ -1,0 +1,32 @@
+package com.tourya.api.models;
+
+import com.tourya.api.config.TranslatedFieldConverter;
+import com.tourya.api.constans.enums.ReviewReasonTypeEnum;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "review_reason_catalog")
+public class ReviewReasonCatalog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reason_type", nullable = false, length = 20)
+    private ReviewReasonTypeEnum reasonType;
+
+    @Column(name = "reason_id", nullable = false)
+    private Integer reasonId;
+
+    @Convert(converter = TranslatedFieldConverter.class)
+    @Column(name = "label", columnDefinition = "jsonb", nullable = false)
+    @org.hibernate.annotations.JdbcTypeCode(org.hibernate.type.SqlTypes.JSON)
+    private TranslatedField label;
+}

--- a/src/main/java/com/tourya/api/models/request/TourScheduleConfigDto.java
+++ b/src/main/java/com/tourya/api/models/request/TourScheduleConfigDto.java
@@ -1,5 +1,7 @@
 package com.tourya.api.models.request;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.tourya.api.config.EmptyStringAsNullIntegerDeserializer;
 import jakarta.validation.Valid;
 import lombok.Data;
 

--- a/src/main/java/com/tourya/api/models/request/TourScheduleConfigPriceDto.java
+++ b/src/main/java/com/tourya/api/models/request/TourScheduleConfigPriceDto.java
@@ -1,5 +1,7 @@
 package com.tourya.api.models.request;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.tourya.api.config.EmptyStringAsNullIntegerDeserializer;
 import com.tourya.api.constans.enums.AgePriceType;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -9,6 +11,7 @@ import java.math.BigDecimal;
 
 @Data
 public class TourScheduleConfigPriceDto {
+    @JsonDeserialize(using = EmptyStringAsNullIntegerDeserializer.class)
     private Integer id; // Agregado para permitir actualizaciones (identificar precios existentes)
     @NotNull(message = "El tipo de edad no puede ser nulo")
     private AgePriceType ageType;

--- a/src/main/java/com/tourya/api/models/request/TourScheduleConfigSlotDto.java
+++ b/src/main/java/com/tourya/api/models/request/TourScheduleConfigSlotDto.java
@@ -1,5 +1,7 @@
 package com.tourya.api.models.request;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.tourya.api.config.EmptyStringAsNullIntegerDeserializer;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -10,6 +12,7 @@ import java.util.List;
 
 @Data
 public class TourScheduleConfigSlotDto {
+    @JsonDeserialize(using = EmptyStringAsNullIntegerDeserializer.class)
     private Integer id; // Agregado para permitir actualizaciones (identificar slots existentes)
     @NotNull(message = "La hora de inicio del slot no puede ser nula")
     private LocalTime startTime;

--- a/src/main/java/com/tourya/api/models/responses/ReservationResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/ReservationResponse.java
@@ -9,6 +9,7 @@ import lombok.experimental.SuperBuilder;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -56,7 +57,13 @@ public class ReservationResponse {
     private String duration;
     private LocalDateTime checkInDate;
     private LocalDateTime returnDate;
+    /** Hora inicio del slot reservado (ej. 09:00). */
+    private LocalTime slotStartTime;
+    /** Hora fin del slot reservado (ej. 17:00). */
+    private LocalTime slotEndTime;
     private String destination;
+    /** Puntos de encuentro configurados en el tour (incluye {@code address}). */
+    private List<TourAddressResponse> locations = new ArrayList<>();
     private Double price;
     /** Total que recibe el proveedor (suma de subtotales por ageType). */
     private BigDecimal providerTotalAmount;
@@ -65,6 +72,10 @@ public class ReservationResponse {
     private String travellers;
     private List<String> activities;
     private List<String> extraServices;
+    /** Actividades incluidas en el tour (i18n). Usar este campo, no {@code activities}. */
+    private List<TourIncludesExcludesResponse> includes = new ArrayList<>();
+    /** Actividades excluidas del tour (i18n). */
+    private List<TourIncludesExcludesResponse> excludes = new ArrayList<>();
     
     // Campos de cancelación y re-agendamiento
     private java.time.LocalDate maxCancellationDate;

--- a/src/main/java/com/tourya/api/models/responses/ReviewReasonCatalogResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/ReviewReasonCatalogResponse.java
@@ -1,6 +1,7 @@
 package com.tourya.api.models.responses;
 
 import com.tourya.api.constans.enums.ReviewReasonTypeEnum;
+import com.tourya.api.models.TranslatedField;
 import lombok.Builder;
 import lombok.Data;
 
@@ -21,7 +22,7 @@ public class ReviewReasonCatalogResponse {
     @Builder
     public static class Item {
         private Integer id; // 1..7 dentro de su tipo
-        private String label;
+        private TranslatedField label;
         private ReviewReasonTypeEnum type;
     }
 }

--- a/src/main/java/com/tourya/api/models/responses/ShoppingCartItemResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/ShoppingCartItemResponse.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 /**
@@ -30,6 +31,10 @@ public class ShoppingCartItemResponse {
     private Integer tourScheduleId;
     private String tourName;
     private Integer slotId;
+    private LocalTime slotStartTime;
+    private LocalTime slotEndTime;
+    private String city;
+    private String department;
     private TourGalleryResponse profilePicture;
     private BigDecimal totalPrice;
     private BigDecimal providerTotalPrice;

--- a/src/main/java/com/tourya/api/repository/ReviewReasonCatalogRepository.java
+++ b/src/main/java/com/tourya/api/repository/ReviewReasonCatalogRepository.java
@@ -1,0 +1,12 @@
+package com.tourya.api.repository;
+
+import com.tourya.api.constans.enums.ReviewReasonTypeEnum;
+import com.tourya.api.models.ReviewReasonCatalog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReviewReasonCatalogRepository extends JpaRepository<ReviewReasonCatalog, Integer> {
+
+    List<ReviewReasonCatalog> findByReasonTypeOrderByReasonIdAsc(ReviewReasonTypeEnum reasonType);
+}

--- a/src/main/java/com/tourya/api/services/PaymentService.java
+++ b/src/main/java/com/tourya/api/services/PaymentService.java
@@ -6,10 +6,14 @@ import com.tourya.api._utils.TourDurationUtils;
 import com.tourya.api.models.request.CreatePaymentRequest;
 import com.tourya.api.models.mapper.ReservationMapper;
 import com.tourya.api.models.mapper.ReservationPriceBreakdownMapper;
+import com.tourya.api.models.mapper.TourAddressMapper;
+import com.tourya.api.models.mapper.TourIncludesExcludesMapper;
 import com.tourya.api.models.responses.PaymentCreditItemResponse;
 import com.tourya.api.models.responses.PaymentResponse;
 import com.tourya.api.models.responses.ReservationResponse;
 import com.tourya.api.models.responses.PayerResponse;
+import com.tourya.api.models.responses.TourAddressResponse;
+import com.tourya.api.models.responses.TourIncludesExcludesResponse;
 import com.tourya.api.repository.*;
 import com.tourya.api.constans.enums.IncludeExcludeTypeEnum;
 import com.tourya.api.constans.enums.CancellationPolicyTypeEnum;
@@ -62,6 +66,8 @@ public class PaymentService {
     private final ReservationPriceBreakdownMapper reservationPriceBreakdownMapper;
     private final ReservationMapper reservationMapper;
     private final TourPrincipalOperatorService tourPrincipalOperatorService;
+    private final TourAddressMapper tourAddressMapper;
+    private final TourIncludesExcludesMapper tourIncludesExcludesMapper;
 
     /**
      * Crea un pago y automáticamente genera la reserva con sus items.
@@ -501,17 +507,15 @@ public class PaymentService {
                 response.setReturnDate(returnDate);
             }
         }
-        
-        // Destination
-        List<TourAddress> addresses = tourAddressRepository.findByTourId(tourId);
-        if (addresses != null && !addresses.isEmpty()) {
-            TourAddress firstAddress = addresses.get(0);
-            if (firstAddress.getCity() != null && firstAddress.getCity().getName() != null) {
-                response.setDestination(firstAddress.getCity().getName());
-            } else if (firstAddress.getLocation() != null && firstAddress.getLocation().getEs() != null) {
-                response.setDestination(firstAddress.getLocation().getEs());
-            }
+
+        if (item.getSlot() != null) {
+            response.setSlotStartTime(item.getSlot().getStartTime());
+            response.setSlotEndTime(item.getSlot().getEndTime());
         }
+        
+        // Destination y puntos de encuentro
+        List<TourAddress> addresses = tourAddressRepository.findByTourId(tourId);
+        applyTourLocations(response, addresses);
         
         // Precio
         if (item.getTotalPrice() != null) {
@@ -543,7 +547,7 @@ public class PaymentService {
             response.setActivities(activities);
         }
         
-        // Servicios extra (includes) - USANDO .toList() como ReservationService
+        // Servicios extra (includes) - compatibilidad legacy en español
         List<String> extraServices = tourIncludesExcludesRepository.findByTourIdAndType(tourId, IncludeExcludeTypeEnum.INCLUDE).stream()
                 .filter(inc -> inc.getDescription() != null && inc.getDescription().getEs() != null)
                 .map(inc -> inc.getDescription().getEs())
@@ -552,7 +556,41 @@ public class PaymentService {
             response.setExtraServices(extraServices);
         }
 
+        applyIncludesExcludes(response, tourId);
+
         enrichTourOperator(response, tour);
+    }
+
+    private void applyIncludesExcludes(ReservationResponse response, Integer tourId) {
+        List<TourIncludesExcludesResponse> includes = tourIncludesExcludesRepository
+                .findByTourIdAndType(tourId, IncludeExcludeTypeEnum.INCLUDE).stream()
+                .map(tourIncludesExcludesMapper::tourIncludesExcludesResponse)
+                .toList();
+        List<TourIncludesExcludesResponse> excludes = tourIncludesExcludesRepository
+                .findByTourIdAndType(tourId, IncludeExcludeTypeEnum.EXCLUDE).stream()
+                .map(tourIncludesExcludesMapper::tourIncludesExcludesResponse)
+                .toList();
+        if (!includes.isEmpty()) {
+            response.setIncludes(includes);
+        }
+        if (!excludes.isEmpty()) {
+            response.setExcludes(excludes);
+        }
+    }
+
+    private void applyTourLocations(ReservationResponse response, List<TourAddress> addresses) {
+        if (addresses == null || addresses.isEmpty()) {
+            return;
+        }
+        response.setLocations(addresses.stream()
+                .map(tourAddressMapper::toTourAddressResponse)
+                .toList());
+        TourAddress firstAddress = addresses.get(0);
+        if (firstAddress.getCity() != null && firstAddress.getCity().getName() != null) {
+            response.setDestination(firstAddress.getCity().getName());
+        } else if (firstAddress.getLocation() != null && firstAddress.getLocation().getEs() != null) {
+            response.setDestination(firstAddress.getLocation().getEs());
+        }
     }
 
     private void enrichTourOperator(ReservationResponse response, Tour tour) {

--- a/src/main/java/com/tourya/api/services/ReservationService.java
+++ b/src/main/java/com/tourya/api/services/ReservationService.java
@@ -19,6 +19,8 @@ import com.tourya.api.exceptions.ResourceNotFoundException;
 import com.tourya.api.models.*;
 import com.tourya.api.models.mapper.ReservationMapper;
 import com.tourya.api.models.mapper.ReservationPriceBreakdownMapper;
+import com.tourya.api.models.mapper.TourAddressMapper;
+import com.tourya.api.models.mapper.TourIncludesExcludesMapper;
 import com.tourya.api.models.responses.ReservationPriceBreakdownResponse;
 import com.tourya.api._utils.TourDurationUtils;
 import com.tourya.api._utils.Utils;
@@ -28,6 +30,7 @@ import com.tourya.api.models.request.RescheduleReservationRequest;
 import com.tourya.api.models.responses.ReservationDetailsResponse;
 import com.tourya.api.models.responses.ReservationResponse;
 import com.tourya.api.models.responses.CreditResponse;
+import com.tourya.api.models.responses.TourIncludesExcludesResponse;
 import com.tourya.api.models.responses.CreateTemporalReservationHoldResponse;
 import com.tourya.api.models.responses.RescheduleValidationResponse;
 import com.tourya.api.models.responses.RescheduleResponse;
@@ -98,6 +101,8 @@ public class ReservationService {
     private final ReservationPriceBreakdownMapper reservationPriceBreakdownMapper;
     private final TouristProfileRepository touristProfileRepository;
     private final TourPrincipalOperatorService tourPrincipalOperatorService;
+    private final TourAddressMapper tourAddressMapper;
+    private final TourIncludesExcludesMapper tourIncludesExcludesMapper;
 
     /**
      * Método createReservation removido - las reservas se crean automáticamente con los pagos
@@ -280,17 +285,15 @@ public class ReservationService {
                 response.setReturnDate(ret);
             }
         }
-        
-        // Destination
-        List<TourAddress> addresses = tourAddressRepository.findByTourId(tourId);
-        if (addresses != null && !addresses.isEmpty()) {
-            TourAddress firstAddress = addresses.get(0);
-            if (firstAddress.getCity() != null && firstAddress.getCity().getName() != null) {
-                response.setDestination(firstAddress.getCity().getName());
-            } else if (firstAddress.getLocation() != null && firstAddress.getLocation().getEs() != null) {
-                response.setDestination(firstAddress.getLocation().getEs());
-            }
+
+        if (item.getSlot() != null) {
+            response.setSlotStartTime(item.getSlot().getStartTime());
+            response.setSlotEndTime(item.getSlot().getEndTime());
         }
+        
+        // Destination y puntos de encuentro
+        List<TourAddress> addresses = tourAddressRepository.findByTourId(tourId);
+        applyTourLocations(response, addresses);
         
         // Precio
         if (item.getTotalPrice() != null) {
@@ -322,7 +325,7 @@ public class ReservationService {
             response.setActivities(activities);
         }
         
-        // Servicios extra (includes)
+        // Servicios extra (includes) - compatibilidad legacy en español
         List<String> extraServices = tourIncludesExcludesRepository.findByTourIdAndType(tourId, IncludeExcludeTypeEnum.INCLUDE).stream()
                 .filter(inc -> inc.getDescription() != null && inc.getDescription().getEs() != null)
                 .map(inc -> inc.getDescription().getEs())
@@ -331,12 +334,46 @@ public class ReservationService {
             response.setExtraServices(extraServices);
         }
 
+        applyIncludesExcludes(response, tourId);
+
         response.setTourOperator(tourPrincipalOperatorService.resolveForTour(tour));
         
         // maxCancellationDate y maxReschedulingDate vienen directamente de la BD (ya están en el mapper)
         // No se calculan dinámicamente porque se guardan en la tabla reservation
 
         logIfPaymentPayerDiffersFromCartUser(reservation, item);
+    }
+
+    private void applyTourLocations(ReservationResponse response, List<TourAddress> addresses) {
+        if (addresses == null || addresses.isEmpty()) {
+            return;
+        }
+        response.setLocations(addresses.stream()
+                .map(tourAddressMapper::toTourAddressResponse)
+                .toList());
+        TourAddress firstAddress = addresses.get(0);
+        if (firstAddress.getCity() != null && firstAddress.getCity().getName() != null) {
+            response.setDestination(firstAddress.getCity().getName());
+        } else if (firstAddress.getLocation() != null && firstAddress.getLocation().getEs() != null) {
+            response.setDestination(firstAddress.getLocation().getEs());
+        }
+    }
+
+    private void applyIncludesExcludes(ReservationResponse response, Integer tourId) {
+        List<TourIncludesExcludesResponse> includes = tourIncludesExcludesRepository
+                .findByTourIdAndType(tourId, IncludeExcludeTypeEnum.INCLUDE).stream()
+                .map(tourIncludesExcludesMapper::tourIncludesExcludesResponse)
+                .toList();
+        List<TourIncludesExcludesResponse> excludes = tourIncludesExcludesRepository
+                .findByTourIdAndType(tourId, IncludeExcludeTypeEnum.EXCLUDE).stream()
+                .map(tourIncludesExcludesMapper::tourIncludesExcludesResponse)
+                .toList();
+        if (!includes.isEmpty()) {
+            response.setIncludes(includes);
+        }
+        if (!excludes.isEmpty()) {
+            response.setExcludes(excludes);
+        }
     }
 
     private Integer resolveTourIdFromCartItem(ShoppingCartItem item) {
@@ -389,14 +426,8 @@ public class ReservationService {
                 }
                 response.setDuration(TourDurationUtils.resolveDurationLabel(tour));
                 List<TourAddress> addresses = tourAddressRepository.findByTourId(tid);
-                if (addresses != null && !addresses.isEmpty()) {
-                    TourAddress firstAddress = addresses.get(0);
-                    if (firstAddress.getCity() != null && firstAddress.getCity().getName() != null) {
-                        response.setDestination(firstAddress.getCity().getName());
-                    } else if (firstAddress.getLocation() != null && firstAddress.getLocation().getEs() != null) {
-                        response.setDestination(firstAddress.getLocation().getEs());
-                    }
-                }
+                applyTourLocations(response, addresses);
+                applyIncludesExcludes(response, tid);
                 List<String> activities = tourMainAttractionRepository.findByTourId(tid).stream()
                         .filter(attr -> attr.getDescription() != null && attr.getDescription().getEs() != null)
                         .map(attr -> attr.getDescription().getEs())

--- a/src/main/java/com/tourya/api/services/ReviewReasonCatalogService.java
+++ b/src/main/java/com/tourya/api/services/ReviewReasonCatalogService.java
@@ -1,32 +1,50 @@
 package com.tourya.api.services;
 
 import com.tourya.api.constans.enums.ReviewReasonTypeEnum;
+import com.tourya.api.models.ReviewReasonCatalog;
+import com.tourya.api.models.TranslatedField;
 import com.tourya.api.models.responses.ReviewReasonCatalogResponse;
 import com.tourya.api.models.responses.ReviewReasonListResponse;
+import com.tourya.api.repository.ReviewReasonCatalogRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class ReviewReasonCatalogService {
+
+    private final ReviewReasonCatalogRepository reviewReasonCatalogRepository;
 
     public ReviewReasonCatalogResponse getCatalog() {
         return ReviewReasonCatalogResponse.builder()
-                .positive(positiveReasons())
-                .negative(negativeReasons())
+                .positive(toItems(ReviewReasonTypeEnum.POSITIVE))
+                .negative(toItems(ReviewReasonTypeEnum.NEGATIVE))
                 .build();
     }
 
     public ReviewReasonListResponse getReasonsForRating(BigDecimal rating) {
         ReviewReasonTypeEnum type = inferType(rating);
-        List<ReviewReasonCatalogResponse.Item> reasons = (type == ReviewReasonTypeEnum.POSITIVE)
-                ? positiveReasons()
-                : negativeReasons();
         return ReviewReasonListResponse.builder()
                 .type(type)
-                .reasons(reasons)
+                .reasons(toItems(type))
                 .build();
+    }
+
+    private List<ReviewReasonCatalogResponse.Item> toItems(ReviewReasonTypeEnum type) {
+        List<ReviewReasonCatalog> rows = reviewReasonCatalogRepository.findByReasonTypeOrderByReasonIdAsc(type);
+        if (rows.isEmpty()) {
+            return fallbackItems(type);
+        }
+        return rows.stream()
+                .map(row -> ReviewReasonCatalogResponse.Item.builder()
+                        .id(row.getReasonId())
+                        .label(row.getLabel())
+                        .type(row.getReasonType())
+                        .build())
+                .toList();
     }
 
     private ReviewReasonTypeEnum inferType(BigDecimal rating) {
@@ -36,28 +54,41 @@ public class ReviewReasonCatalogService {
                 : ReviewReasonTypeEnum.NEGATIVE;
     }
 
-    private List<ReviewReasonCatalogResponse.Item> positiveReasons() {
+    /** Fallback si la migración 063 aún no se ejecutó en la BD. */
+    private List<ReviewReasonCatalogResponse.Item> fallbackItems(ReviewReasonTypeEnum type) {
+        if (type == ReviewReasonTypeEnum.POSITIVE) {
+            return List.of(
+                    reason(1, type, "Servicio excepcional del guía", "Exceptional service from the guide", "Serviço excepcional do guia"),
+                    reason(2, type, "Puntualidad del proveedor", "Provider's punctuality", "Pontualidade do prestador de serviços"),
+                    reason(3, type, "Buena organización del tour", "Good tour organization", "Boa organização do passeio"),
+                    reason(4, type, "Excelente relación calidad-precio", "Excellent value for money", "Excelente custo-benefício"),
+                    reason(5, type, "Comodidad del transporte", "Comfort of transportation", "Conforto do transporte"),
+                    reason(6, type, "Buena atención al cliente", "Good customer service", "Bom atendimento ao cliente"),
+                    reason(7, type, "Recomendable para otros viajeros", "Would recommend to other travelers", "Recomendável para outros viajantes")
+            );
+        }
         return List.of(
-                ReviewReasonCatalogResponse.Item.builder().id(1).label("Servicio excepcional del guía").type(ReviewReasonTypeEnum.POSITIVE).build(),
-                ReviewReasonCatalogResponse.Item.builder().id(2).label("Puntualidad del proveedor").type(ReviewReasonTypeEnum.POSITIVE).build(),
-                ReviewReasonCatalogResponse.Item.builder().id(3).label("Buena organización del tour").type(ReviewReasonTypeEnum.POSITIVE).build(),
-                ReviewReasonCatalogResponse.Item.builder().id(4).label("Excelente relación calidad-precio").type(ReviewReasonTypeEnum.POSITIVE).build(),
-                ReviewReasonCatalogResponse.Item.builder().id(5).label("Comodidad del transporte").type(ReviewReasonTypeEnum.POSITIVE).build(),
-                ReviewReasonCatalogResponse.Item.builder().id(6).label("Buena atención al cliente").type(ReviewReasonTypeEnum.POSITIVE).build(),
-                ReviewReasonCatalogResponse.Item.builder().id(7).label("Recomendable para otros viajeros").type(ReviewReasonTypeEnum.POSITIVE).build()
+                reason(1, type, "Retraso o impuntualidad", "Delays or lack of punctuality", "Atraso ou falta de pontualidade"),
+                reason(2, type, "Guía poco amable o desinformado", "Unfriendly or uninformed guide", "Guia pouco simpático ou mal informado"),
+                reason(3, type, "Mala comunicación con el operador turístico", "Poor communication with the tour operator", "Má comunicação com a operadora de turismo"),
+                reason(4, type, "El tour no correspondía a la descripción", "Tour did not match the description", "O passeio não correspondia à descrição"),
+                reason(5, type, "Problemas con el transporte", "Problems with transportation", "Problemas com o transporte"),
+                reason(6, type, "Mala relación calidad-precio", "Poor value for money", "Má relação custo-benefício"),
+                reason(7, type, "No cumplieron con lo que incluye el tour", "Did not deliver what the tour included", "Não cumpriram o que estava incluído no passeio")
         );
     }
 
-    private List<ReviewReasonCatalogResponse.Item> negativeReasons() {
-        return List.of(
-                ReviewReasonCatalogResponse.Item.builder().id(1).label("Retraso o impuntualidad").type(ReviewReasonTypeEnum.NEGATIVE).build(),
-                ReviewReasonCatalogResponse.Item.builder().id(2).label("Guía poco amable o desinformado").type(ReviewReasonTypeEnum.NEGATIVE).build(),
-                ReviewReasonCatalogResponse.Item.builder().id(3).label("Mala comunicación con el operador turístico").type(ReviewReasonTypeEnum.NEGATIVE).build(),
-                ReviewReasonCatalogResponse.Item.builder().id(4).label("El tour no correspondía a la descripción").type(ReviewReasonTypeEnum.NEGATIVE).build(),
-                ReviewReasonCatalogResponse.Item.builder().id(5).label("Problemas con el transporte").type(ReviewReasonTypeEnum.NEGATIVE).build(),
-                ReviewReasonCatalogResponse.Item.builder().id(6).label("Mala relación calidad-precio").type(ReviewReasonTypeEnum.NEGATIVE).build(),
-                ReviewReasonCatalogResponse.Item.builder().id(7).label("No cumplieron con lo que incluye el tour").type(ReviewReasonTypeEnum.NEGATIVE).build()
-        );
+    private ReviewReasonCatalogResponse.Item reason(
+            int id,
+            ReviewReasonTypeEnum type,
+            String es,
+            String en,
+            String pt
+    ) {
+        return ReviewReasonCatalogResponse.Item.builder()
+                .id(id)
+                .label(TranslatedField.of(es, en, pt))
+                .type(type)
+                .build();
     }
 }
-

--- a/src/main/java/com/tourya/api/services/ShoppingCartService.java
+++ b/src/main/java/com/tourya/api/services/ShoppingCartService.java
@@ -32,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
@@ -65,6 +66,7 @@ public class ShoppingCartService {
     private final CountryRepository countryRepository;
     private final StateRepository stateRepository;
     private final CityRepository cityRepository;
+    private final TourAddressRepository tourAddressRepository;
 
     /**
      * Crea un nuevo carrito de compras para un usuario.
@@ -680,6 +682,15 @@ public class ShoppingCartService {
                     Integer tourScheduleId = null;
                     String tourName = null;
                     TourGalleryResponse profilePicture = null;
+                    LocalTime slotStartTime = null;
+                    LocalTime slotEndTime = null;
+                    String city = null;
+                    String department = null;
+
+                    if (item.getSlot() != null) {
+                        slotStartTime = item.getSlot().getStartTime();
+                        slotEndTime = item.getSlot().getEndTime();
+                    }
 
                     if ("SERVICE".equalsIgnoreCase(item.getProductType())) {
                         // Cuando es SERVICE, obtener el nombre del servicio
@@ -701,6 +712,19 @@ public class ShoppingCartService {
                                 profilePicture = resolveProfilePicture(item.getTourSchedule().getTourId());
                             }
                         }
+                        Integer tourId = resolveTourIdFromCartItem(item);
+                        if (tourId != null) {
+                            List<TourAddress> addresses = tourAddressRepository.findByTourId(tourId);
+                            if (addresses != null && !addresses.isEmpty()) {
+                                TourAddress first = addresses.get(0);
+                                if (first.getCity() != null) {
+                                    city = first.getCity().getName();
+                                    if (first.getCity().getState() != null) {
+                                        department = first.getCity().getState().getName();
+                                    }
+                                }
+                            }
+                        }
                     }
 
                     return ShoppingCartItemResponse.builder()
@@ -712,6 +736,10 @@ public class ShoppingCartService {
                             .tourScheduleId(tourScheduleId)
                             .tourName(tourName)
                             .slotId(item.getSlot() != null ? item.getSlot().getId() : null)
+                            .slotStartTime(slotStartTime)
+                            .slotEndTime(slotEndTime)
+                            .city(city)
+                            .department(department)
                             .profilePicture(profilePicture)
                             .totalPrice(item.getTotalPrice())
                             .providerTotalPrice(itemProviderTotal)
@@ -888,5 +916,17 @@ public class ShoppingCartService {
                 totalDeleted, user.getId(), activeCarts.size());
         
         return totalDeleted;
+    }
+
+    private Integer resolveTourIdFromCartItem(ShoppingCartItem item) {
+        if (item.getTourSchedule() != null && item.getTourSchedule().getTourId() != null) {
+            return item.getTourSchedule().getTourId();
+        }
+        if (item.getProductType() != null
+                && "TOUR".equalsIgnoreCase(item.getProductType())
+                && item.getProductId() != null) {
+            return item.getProductId();
+        }
+        return null;
     }
 }

--- a/src/main/java/com/tourya/api/services/TourScheduleConfigGeneralService.java
+++ b/src/main/java/com/tourya/api/services/TourScheduleConfigGeneralService.java
@@ -1,5 +1,6 @@
 package com.tourya.api.services;
 
+import com.tourya.api._utils.PayloadIdUtils;
 import com.tourya.api._utils.TouryaPriceCalculator;
 import com.tourya.api._utils.Utils;
 import com.tourya.api.common.PageResponse;
@@ -70,11 +71,17 @@ public class TourScheduleConfigGeneralService {
         List<Role> roleList = user.getRoles();
         Provider provider = providerService.findByUserAndStatusActive(user);
 
-        if (request.getTourId() == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "tourId is required.");
+        boolean isTemplate = Boolean.TRUE.equals(request.getIsTemplate());
+
+        if (!isTemplate && request.getTourId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "tourId is required when isTemplate is false.");
         }
-        Tour tour = getTour(request.getTourId(), provider.getId());
-        requireTourAcceptedForProviderSchedule(tour, roleList);
+
+        Tour tour = null;
+        if (request.getTourId() != null) {
+            tour = getTour(request.getTourId(), provider.getId());
+            requireTourAcceptedForProviderSchedule(tour, roleList);
+        }
 
         // 1. Construir el grafo de entidades a partir del DTO
         TourScheduleConfig config = buildConfigFromRequest(request, provider, tour);
@@ -97,8 +104,12 @@ public class TourScheduleConfigGeneralService {
         config.setLabel(request.getLabel());
         config.setProvider(provider);
         config.setProviderId(provider.getId());
-        config.setTour(tour);
-        config.setTourId(tour.getId());
+        if (tour != null) {
+            config.setTour(tour);
+            config.setTourId(tour.getId());
+        } else {
+            config.setTourId(null);
+        }
 
         config.setDaysOfWeek(new ArrayList<>(request.getDaysOfWeek()));
         config.setIsTemplate(request.getIsTemplate());
@@ -216,26 +227,42 @@ public class TourScheduleConfigGeneralService {
     private void manageSlotsUpdate(TourScheduleConfig existingConfig, Set<TourScheduleConfigSlotDto> requestedSlots,
             List<Role> roleList) {
         Map<Integer, TourScheduleConfigSlot> existingSlotsMap = existingConfig.getSlots().stream()
-                .filter(s -> s.getId() != null)
+                .filter(s -> PayloadIdUtils.isPersistedId(s.getId()))
                 .collect(Collectors.toMap(TourScheduleConfigSlot::getId, Function.identity()));
 
         Set<TourScheduleConfigSlot> newOrUpdatedSlots = new HashSet<>();
+        Set<Integer> handledSlotIds = new HashSet<>();
         Tour tourForConfig = existingConfig.getTourId() != null
                 ? tourRepository.findById(existingConfig.getTourId()).orElse(null)
                 : null;
 
         if (requestedSlots != null) {
             for (TourScheduleConfigSlotDto slotDto : requestedSlots) {
-                TourScheduleConfigSlot currentSlot;
-                boolean isNewSlot = slotDto.getId() == null || !existingSlotsMap.containsKey(slotDto.getId());
-                if (!isNewSlot) {
-                    currentSlot = existingSlotsMap.get(slotDto.getId());
+                Integer requestedSlotId = PayloadIdUtils.normalizeId(slotDto.getId());
+                TourScheduleConfigSlot currentSlot = null;
+                boolean isNewSlot;
+
+                if (PayloadIdUtils.isPersistedId(requestedSlotId)
+                        && existingSlotsMap.containsKey(requestedSlotId)) {
+                    currentSlot = existingSlotsMap.get(requestedSlotId);
+                    isNewSlot = false;
                 } else {
-                    currentSlot = new TourScheduleConfigSlot();
-                    currentSlot.setConfig(existingConfig);
-                    currentSlot.setBookings(0);
-                    currentSlot.setAvailability(0);
+                    currentSlot = findExistingSlotByTime(existingConfig, slotDto, handledSlotIds);
+                    if (currentSlot != null) {
+                        isNewSlot = false;
+                    } else {
+                        currentSlot = new TourScheduleConfigSlot();
+                        currentSlot.setConfig(existingConfig);
+                        currentSlot.setBookings(0);
+                        currentSlot.setAvailability(0);
+                        isNewSlot = true;
+                    }
                 }
+
+                if (currentSlot.getId() != null) {
+                    handledSlotIds.add(currentSlot.getId());
+                }
+
                 currentSlot.setStartTime(slotDto.getStartTime());
                 currentSlot.setEndTime(slotDto.getEndTime());
                 currentSlot.setCapacity(slotDto.getCapacity());
@@ -263,6 +290,23 @@ public class TourScheduleConfigGeneralService {
         existingConfig.getSlots().addAll(newOrUpdatedSlots);
     }
 
+    private TourScheduleConfigSlot findExistingSlotByTime(
+            TourScheduleConfig config,
+            TourScheduleConfigSlotDto slotDto,
+            Set<Integer> alreadyHandled) {
+        if (slotDto.getStartTime() == null || slotDto.getEndTime() == null || config.getSlots() == null) {
+            return null;
+        }
+        return config.getSlots().stream()
+                .filter(s -> s.getStartTime() != null
+                        && s.getEndTime() != null
+                        && s.getStartTime().equals(slotDto.getStartTime())
+                        && s.getEndTime().equals(slotDto.getEndTime())
+                        && (s.getId() == null || !alreadyHandled.contains(s.getId())))
+                .findFirst()
+                .orElse(null);
+    }
+
     private void updateSlotPrices(TourScheduleConfigSlot slot, Set<TourScheduleConfigPriceDto> incomingPriceDtos,
             BigDecimal slotPorcentajeTourya, List<Role> roleList) {
         validateSlotPrices(incomingPriceDtos, roleList);
@@ -276,6 +320,7 @@ public class TourScheduleConfigGeneralService {
 
         Set<Integer> incomingPriceIds = incomingPriceDtos.stream()
                 .map(TourScheduleConfigPriceDto::getId)
+                .map(PayloadIdUtils::normalizeId)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
         Set<AgePriceType> incomingAgeTypes = incomingPriceDtos.stream()
@@ -309,9 +354,10 @@ public class TourScheduleConfigGeneralService {
 
     private static TourScheduleConfigPrice findExistingPrice(TourScheduleConfigSlot slot,
             TourScheduleConfigPriceDto priceDto) {
-        if (priceDto.getId() != null) {
+        Integer requestedPriceId = PayloadIdUtils.normalizeId(priceDto.getId());
+        if (PayloadIdUtils.isPersistedId(requestedPriceId)) {
             TourScheduleConfigPrice byId = slot.getPrices().stream()
-                    .filter(p -> Objects.equals(p.getId(), priceDto.getId()))
+                    .filter(p -> Objects.equals(p.getId(), requestedPriceId))
                     .findFirst()
                     .orElse(null);
             if (byId != null) {
@@ -871,6 +917,7 @@ public class TourScheduleConfigGeneralService {
     public List<TourScheduleBulkResponse> saveOrUpdateTourSchedules(List<TourScheduleRequest> scheduleRequests,
             Authentication connectedUser) {
         List<TourScheduleBulkResponse> responses = new ArrayList<>();
+        Set<Integer> configsUpdatedInBatch = new HashSet<>();
 
         for (TourScheduleRequest dto : scheduleRequests) {
             Tour tourForSchedule = tourRepository.findById(dto.getTourId()).orElse(null);
@@ -887,11 +934,11 @@ public class TourScheduleConfigGeneralService {
             if (existingScheduleOpt.isPresent()) {
                 schedule = existingScheduleOpt.get();
                 config = resolveConfigForBulk(
-                        dto.getConfig(), dto.getTourId(), schedule.getConfigId(), connectedUser);
+                        dto.getConfig(), dto.getTourId(), schedule.getConfigId(), connectedUser, configsUpdatedInBatch);
                 schedule.setConfig(config);
                 updateScheduleProperties(schedule, dto);
             } else {
-                config = resolveConfigForBulk(dto.getConfig(), dto.getTourId(), null, connectedUser);
+                config = resolveConfigForBulk(dto.getConfig(), dto.getTourId(), null, connectedUser, configsUpdatedInBatch);
                 schedule = createScheduleFromDto(dto, config);
             }
 
@@ -912,12 +959,14 @@ public class TourScheduleConfigGeneralService {
             TourScheduleConfigDto configDto,
             Integer tourId,
             Integer currentScheduleConfigId,
-            Authentication connectedUser) {
+            Authentication connectedUser,
+            Set<Integer> configsUpdatedInBatch) {
         if (configDto == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "config is required.");
         }
 
-        Integer targetConfigId = configDto.getId() != null ? configDto.getId() : currentScheduleConfigId;
+        Integer normalizedConfigId = PayloadIdUtils.normalizeId(configDto.getId());
+        final Integer targetConfigId = normalizedConfigId != null ? normalizedConfigId : currentScheduleConfigId;
 
         if (targetConfigId != null) {
             TourScheduleConfig config = tourScheduleConfigRepository.findByIdWithSlots(targetConfigId)
@@ -927,9 +976,10 @@ public class TourScheduleConfigGeneralService {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                         "Config " + targetConfigId + " does not belong to tour " + tourId);
             }
-            if (hasConfigPayload(configDto)) {
+            if (hasConfigPayload(configDto) && !configsUpdatedInBatch.contains(targetConfigId)) {
                 TourScheduleConfigCreationRequest request = mapDtoToCreationRequest(configDto, tourId);
                 TourScheduleConfigResponse updated = updateTourScheduleConfig(targetConfigId, request, connectedUser);
+                configsUpdatedInBatch.add(targetConfigId);
                 return tourScheduleConfigRepository.findByIdWithSlots(updated.getId())
                         .orElseThrow(() -> new ResourceNotFoundException(
                                 "Config not found after update: " + updated.getId()));


### PR DESCRIPTION
- Fix POST /tour-schedules/config (plantillas) y /batch (id 0 y config duplicada)

- Motivos reseña i18n, subcategorías sin paréntesis (migraciones 062-064)

- Carrito: slotStartTime/EndTime, city/department; pago: locations/includes/excludes

- Tags Swagger unificados en controladores sin @Tag