### PR TITLE
fix(security): cerrar exposicion de Actuator (SEC-03)

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,14 +14,16 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 payment.wompi.integrity.secret=test_integrity_PnLqXgX3tMbgvUqpXOKnZvfikb3oSV8y
 
 
-# Habilitar todos los endpoints de Actuator
-management.endpoints.web.exposure.include=*
+# Actuator: exponer solo endpoints publicos necesarios (health, info)
+# No exponer *, evita filtrar env, beans, mappings, heapdump, threaddump, etc.
+management.endpoints.web.exposure.include=health,info
 
 # Configurar el contexto base para los endpoints de Actuator
 management.endpoints.web.base-path=/actuator
 
-# Configurar el estado de salud
-management.endpoint.health.show-details=always
+# Mostrar detalles de health solo si el request esta autenticado (evita leak de estado interno)
+management.endpoint.health.show-details=when_authorized
+management.endpoint.health.show-components=when_authorized
 management.health.db.enabled=true
 management.health.diskspace.enabled=true
 management.health.ping.enabled=true


### PR DESCRIPTION
- Cambiar management.endpoints.web.exposure.include de '*' a 'health,info'. El wildcard exponia env, beans, mappings, heapdump, threaddump, loggers, metrics, etc. Todos accesibles sin autenticacion.

- management.endpoint.health.show-details cambiado de 'always' a 'when_authorized' para evitar filtrar estado interno (URL de BD, version del driver, etc.) en /actuator/health publico.

- Agregado management.endpoint.health.show-components=when_authorized para consistencia.

Los health checks activos (db, diskspace, ping) siguen funcionando. El endpoint /actuator/health continua respondiendo UP/DOWN publicamente para monitoreo (Cloud Run health probe).