### PR TITLE
fix(security): prevenir replay del token de activacion (SEC-04)

### DIFF
--- a/src/main/java/com/tourya/api/config/auth/AuthenticationService.java
+++ b/src/main/java/com/tourya/api/config/auth/AuthenticationService.java
@@ -132,10 +132,18 @@ public class AuthenticationService {
                 .build();
     }
 
+    @Transactional
     public void activateAccount(String token) throws MessagingException {
         Token savedToken = tokenRepository.findByToken(token)
                 // todo exception has to be defined
                 .orElseThrow(() -> new RuntimeException("Invalid token"));
+
+        // Prevenir replay: un token ya validado no puede reutilizarse.
+        // Mismo mensaje que "token no encontrado" para no filtrar informacion al atacante.
+        if (savedToken.getValidatedAt() != null) {
+            throw new RuntimeException("Invalid token");
+        }
+
         if (LocalDateTime.now().isAfter(savedToken.getExpiresAt())) {
             sendValidationEmail(savedToken.getUser());
             throw new RuntimeException("Activation token has expired. A new token has been send to the same email address");


### PR DESCRIPTION
Bug: AuthenticationService.activateAccount no verificaba si el token ya habia sido usado. Un token validatedAt != null podia reutilizarse sin limite, permitiendo replay attacks.

Cambios:

1. Chequeo de validatedAt != null despues del findByToken. Si el token ya fue usado, se rechaza con "Invalid token" (mismo mensaje que "no encontrado" para no filtrar info al atacante).

2. Anadida anotacion @Transactional al metodo. Garantiza que user.enabled = true y token.validatedAt = now se persisten atomicamente. Si algo falla despues del setEnabled, el token no queda marcado como validado y no queda estado inconsistente.

Impacto funcional:
- 1er uso legitimo del token: sin cambios (200 OK).
- Reintentos con el mismo token: ahora bloqueados (correcto).
- Cuenta ya activada: el usuario puede seguir haciendo login normal, el rechazo del token repetido no afecta el estado del usuario.
- Endpoint publico /auth/activate-account sigue con el mismo path y respuestas.

Ver "activateAccount" en RN-003 de docs/05-reglas-de-negocio.md y C-4 en docs/12-seguridad-y-auth.md.