### PR TITLE
fix(security): eliminar PII del pagador en respuesta publica de booki…

### DIFF
--- a/src/main/java/com/tourya/api/models/responses/BookingDetailsResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/BookingDetailsResponse.java
@@ -21,10 +21,6 @@ public class BookingDetailsResponse {
     private String bookingId;
     private Long paymentId;
     private String transactionId;
-    private String payer;
-    private String payerDocumentType;
-    private String payerDocumentNumber;
-    private String email;
     private LocalDateTime reservationDate;
     private String status;
     private Integer tourId;
@@ -38,7 +34,6 @@ public class BookingDetailsResponse {
     private LocalDateTime checkInDate;
     private LocalDateTime returnDate;
     private String destination;
-    private String customerPhone;
     private List<String> extraServices;
     private List<String> activities;
 }

--- a/src/main/java/com/tourya/api/services/ReservationService.java
+++ b/src/main/java/com/tourya/api/services/ReservationService.java
@@ -647,16 +647,15 @@ public class ReservationService {
             providerTotalAmount = reservationPriceBreakdownMapper.sumProviderTotal(priceBreakdown);
         }
 
+        // SEC-05: endpoint publico /public/bookings/{id} NO expone PII del pagador
+        // (nombre, email, telefono, tipo/numero de documento). Esos datos requieren JWT
+        // y viven en endpoints autenticados (/reservations/*).
         return com.tourya.api.models.responses.BookingDetailsResponse.builder()
                 .id(reservation.getReservationId().intValue())
                 .reservationId(reservation.getReservationId())
                 .bookingId(com.tourya.api._utils.ReservationDisplayId.format(reservation.getReservationId()))
                 .paymentId(reservation.getPaymentId())
                 .transactionId(payment != null ? payment.getTransactionId() : null)
-                .payer(payment != null ? payment.getPayerName() : null)
-                .payerDocumentType(payment != null ? payment.getPayerDocumentType() : null)
-                .payerDocumentNumber(payment != null ? payment.getPayerDocumentNumber() : null)
-                .email(payment != null ? payment.getPayerEmail() : null)
                 .reservationDate(reservation.getReservationDate())
                 .status(reservation.getDeliveryStatus() != null ? reservation.getDeliveryStatus().name() : null)
                 .tourId(tourId)
@@ -670,7 +669,6 @@ public class ReservationService {
                 .checkInDate(checkInDate)
                 .returnDate(returnDate)
                 .destination(destination)
-                .customerPhone(payment != null ? payment.getPayerPhone() : null)
                 .extraServices(extraServices.isEmpty() ? null : extraServices)
                 .activities(activities.isEmpty() ? null : activities)
                 .build();


### PR DESCRIPTION
…ngs (SEC-05)

El endpoint publico GET /public/bookings/{bookingId} devolvia datos personales del pagador (nombre, email, telefono, tipo y numero de documento) sin requerir autenticacion. Un atacante podia enumerar bookingIds y extraer PII masivamente.

Cambios:

1. BookingDetailsResponse: eliminados los campos payer, email, customerPhone, payerDocumentType y payerDocumentNumber. Los demas campos (identificadores, fechas, estado, info del tour, precios, contadores travellers, extras, actividades) se mantienen porque no son PII.

2. ReservationService.buildBookingDetailsResponse: removidos los 5 setters correspondientes del builder. Comentario explicativo agregado con la referencia SEC-05.

Verificacion de consumidores previa al cambio:
- Backend: BookingDetailsResponse solo se usa en PublicController
  + ReservationService (grep confirmado). Sin ripple.
- Frontend web: reservation.service.ts apunta a mock de Postman, no al endpoint real. Sin impacto en produccion.
- Mobile MAUI: sin referencias a /public/bookings.

Datos sensibles solo accesibles ahora en endpoints autenticados (/reservations/*, /public/save/review, etc.) que ya requieren JWT.

Ver C-5 en docs/12-seguridad-y-auth.md.