### PR TITLE
fix(security): eliminar log de password temporal en social auth (SEC-08)

### DIFF
--- a/src/main/java/com/tourya/api/config/auth/AuthenticationService.java
+++ b/src/main/java/com/tourya/api/config/auth/AuthenticationService.java
@@ -169,7 +169,6 @@ public class AuthenticationService {
             var userRole = roleRepository.findByName("USER")
                     .orElseThrow(() -> new IllegalStateException("ROLE USER was not initiated"));
             String tempPassword = generateTemporaryPassword();
-            System.out.println("tempPassword : " +tempPassword);
             User newUser = User.builder()
                     .firstname(request.getFirstname())
                     .lastname(request.getLastname())


### PR DESCRIPTION
En authenticateWithSocial, cuando se crea un usuario nuevo por login social (Google/Facebook), se generaba un password temporal random y se imprimia a stdout via System.out.println. El stdout de Cloud Run va a Cloud Logging, exponiendo ese password a cualquier persona con permisos de lectura de logs.

Aunque el usuario nunca usa ese password (login social usa el token externo), esta guardado como hash BCrypt en la BD. Un atacante con acceso a los logs podria hacer login como el usuario via POST /auth/authenticate con email + password.

Cambio quirurgico: eliminada la linea del println. Cero impacto funcional en el flujo de authenticateWithSocial.

Nota: los logs historicos que ya contienen passwords temporales deben limpiarse manualmente desde Cloud Logging (accion aparte, fuera del scope de este PR).

Otros System.out/err.println en el codigo son tech debt de logging (no exponen secretos): TourScheduleController:147, ShoppingCartService:573, TourGalleryService:143. Se anotan para el backlog general, no se tocan aqui.

Ver H-2 en docs/12-seguridad-y-auth.md.