### PR TITLE
fix(security): limpiar CORS - quitar URLs legacy, agregar dominios ac…

### DIFF
--- a/src/main/java/com/tourya/api/config/BeansConfig.java
+++ b/src/main/java/com/tourya/api/config/BeansConfig.java
@@ -46,11 +46,18 @@ public class BeansConfig {
         final CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
         //config.setAllowedOrigins(List.of("*")); //Despues cambiar a las urls de origen.
-        config.setAllowedOrigins(List.of("http://localhost:4200",
-                "http://localhost:8080", "http://44.203.38.85:8088", "http://44.203.38.85:8080",
-                "http://localhost:8100", "https://localhost/",
-                "https://tourya-dev-front-5j2nd2oflq-ue.a.run.app",
-                "https://tourya-dev-api-5j2nd2oflq-ue.a.run.app"));
+        config.setAllowedOrigins(List.of(
+                // Dev local
+                "http://localhost:4200",
+                "http://localhost:8080",
+                "http://localhost:8100",
+                // Cloud Run dev (URLs actuales)
+                "https://tourya-dev-front-640622322458.us-east1.run.app",
+                "https://tourya-dev-api-640622322458.us-east1.run.app",
+                // Dominio custom (produccion)
+                "https://tourya.co",
+                "https://www.tourya.co"
+        ));
         config.setAllowedHeaders(Arrays.asList(
                 HttpHeaders.ORIGIN,
                 HttpHeaders.CONTENT_TYPE,


### PR DESCRIPTION
…tuales (SEC-11)

La lista de allowedOrigins tenia URLs muertas y faltaban los orígenes actuales que si se usan en produccion.

Quitados (URLs muertas):
- http://44.203.38.85:8088 y http://44.203.38.85:8080 (AWS EC2 legacy)
- https://localhost/ (residual sin proposito)
- https://tourya-dev-front-5j2nd2oflq-ue.a.run.app (URL vieja Cloud Run)
- https://tourya-dev-api-5j2nd2oflq-ue.a.run.app (URL vieja Cloud Run)

Agregados (orígenes actuales):
- https://tourya-dev-front-640622322458.us-east1.run.app (front dev actual)
- https://tourya-dev-api-640622322458.us-east1.run.app (api dev actual)
- https://tourya.co (dominio custom produccion)
- https://www.tourya.co (dominio custom con www)

Mantenidos (dev local):
- http://localhost:4200 (Angular dev)
- http://localhost:8080 (dev local)
- http://localhost:8100 (Ionic/MAUI dev)

Otras propiedades del CorsFilter sin cambios:
- allowCredentials=true (necesario para login social con cookies).
- Headers: Origin, Content-Type, Accept, Authorization.
- Metodos: GET, POST, DELETE, PUT, PATCH.
- Patron aplicado: /**.

Hallazgos relacionados (van en PRs separados):
- ReservationQrService:130 tiene URL de QR hardcoded a AWS legacy (se aborda en feature/fase-0-qr-baseurl-cleanup).
- application.properties:81 tiene fallback de ACTIVATION_URL a AWS (se limpia en el PR de secretos, bloque 0.3).
- MAIL_PASSWORD en Cloud Run visible como env var en texto plano (se mueve a Secret Manager en bloque 0.3).

Ver H-7 en docs/12-seguridad-y-auth.md.