### PR TITLE
fix(security): properties leen JWT y Wompi secrets de env var (SEC-01…

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,7 +11,7 @@ spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-payment.wompi.integrity.secret=test_integrity_PnLqXgX3tMbgvUqpXOKnZvfikb3oSV8y
+payment.wompi.integrity.secret=${WOMPI_INTEGRITY_SECRET:test_integrity_PnLqXgX3tMbgvUqpXOKnZvfikb3oSV8y}
 
 
 # Actuator: exponer solo endpoints publicos necesarios (health, info)
@@ -75,7 +75,7 @@ gcp.storage.bucket=${GCS_BUCKET:}
 
 
 #Security
-application.security.jwt.secret-key=404E635266556A586E3272357538782F413F4428472B4B6250645367566B5970
+application.security.jwt.secret-key=${JWT_SECRET:404E635266556A586E3272357538782F413F4428472B4B6250645367566B5970}
 # a day
 application.security.jwt.expiration=86400000
 application.mailing.frontend.activation-url=${ACTIVATION_URL:http://44.203.38.85:8088/api/v1/auth/activar-cuenta-web?token=}


### PR DESCRIPTION
…/02 fase 1)

Refactor de application.properties para que los 2 secretos hardcoded lean desde env var, manteniendo el valor actual como fallback.

Cambios:

- Linea 14: payment.wompi.integrity.secret
  Antes: valor hardcoded (visible en repo publico Touryapp)
  Ahora: \${WOMPI_INTEGRITY_SECRET:<valor-actual>}

- Linea 78: application.security.jwt.secret-key
  Antes: valor hardcoded (visible en repo publico Touryapp)
  Ahora: \${JWT_SECRET:<valor-actual>}

Backwards-compatibilidad:
Este PR es 100% no-breaking. Los fallbacks son los MISMOS valores hardcoded actuales, por lo tanto:
- Si Cloud Run NO inyecta las env vars, la app arranca IGUAL que hoy.
- Si Cloud Run SI inyecta las env vars (bloque 0.3c), la app usa los valores del Secret Manager.

Este PR NO cambia el comportamiento observable de la app. Solo prepara el terreno para el siguiente PR (workflow inyecta secretos desde Secret Manager).

Secretos preparados en GCP Secret Manager de tourya-project-dev:
- tourya-jwt-key (valor NUEVO random, rota el actual)
- tourya-wompi-integrity-secret (mismo valor, migrado)

El fallback se removera en un PR posterior (0.3d) despues de verificar que Cloud Run inyecta correctamente desde Secret Manager.

Ver C-1 y C-2 en docs/12-seguridad-y-auth.md.