### PR TITLE
feat(security): workflow inyecta secretos desde GCP Secret Manager

### DIFF
--- a/.github/workflows/gcp_deploy_develop.yml
+++ b/.github/workflows/gcp_deploy_develop.yml
@@ -59,7 +59,11 @@ jobs:
             DB_HOST=${{ secrets.DB_HOST }}
             DB_PORT=${{ secrets.DB_PORT }}
             DB_USER=${{ secrets.DB_USER }}
-            DB_PASSWORD=${{ secrets.DB_PASSWORD }}
             STORAGE_PROVIDER=GCP
             GCS_BUCKET=tourya-dev-storage
             GCP_PROJECT_ID=tourya-project-dev
+          secrets: |
+            JWT_SECRET=tourya-jwt-key:latest
+            WOMPI_INTEGRITY_SECRET=tourya-wompi-integrity-secret:latest
+            DB_PASSWORD=tourya-db-password:latest
+            MAIL_PASSWORD=tourya-smtp-password:latest


### PR DESCRIPTION
Reemplaza el manejo de secretos runtime en Cloud Run: en vez de inyectar valores desde GitHub Secrets (visibles como env vars en texto plano), ahora Cloud Run los lee desde Secret Manager.

Cambios en gcp_deploy_develop.yml:

1. DB_PASSWORD removido del bloque env_vars. Antes: DB_PASSWORD=\${{ secrets.DB_PASSWORD }} Ahora: viene de Secret Manager como parte del bloque 'secrets'.

2. Nuevo bloque 'secrets' con 4 entradas:
   - JWT_SECRET=tourya-jwt-key:latest
   - WOMPI_INTEGRITY_SECRET=tourya-wompi-integrity-secret:latest
   - DB_PASSWORD=tourya-db-password:latest
   - MAIL_PASSWORD=tourya-smtp-password:latest

Efectos al mergear:

- JWT_SECRET pasa de valor hardcoded en application.properties al valor NUEVO rotado del Secret Manager. Todos los JWTs emitidos antes del deploy quedaran invalidos. En dev con 0 users reales, cero impacto observable.

- WOMPI_INTEGRITY_SECRET, DB_PASSWORD, MAIL_PASSWORD mantienen los MISMOS valores (los movi tal cual al Secret Manager). Cero cambio funcional.

- application.properties tiene fallbacks (PR anterior 0.3b), asi que si Cloud Run no puede leer algun secreto, la app arranca con el hardcoded como puente. Cero downtime.

Prerequisitos ya hechos (bloque 0.3a):
- Secret Manager API habilitada en tourya-project-dev.
- 4 secretos creados con los valores actuales (JWT rotado).
- SA tourya-dev-cloud-run tiene rol secretmanager.secretAccessor.

Verificacion post-merge:
1. gh run watch: workflow debe completar sin errores.
2. Smoke tests: endpoints publicos siguen respondiendo 200.
3. Rollback rapido si falla: gcloud run services update-traffic --to-revisions=REV_ANTERIOR=100.

Ver C-1 y C-2 en docs/12-seguridad-y-auth.md.