### PR TITLE
feat(security): migrar autenticacion GitHub Actions a Workload Identi…

### DIFF
--- a/.github/workflows/gcp_deploy_develop.yml
+++ b/.github/workflows/gcp_deploy_develop.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: '${{ secrets.GCP_SA_KEY_DEV }}'
+          workload_identity_provider: 'projects/640622322458/locations/global/workloadIdentityPools/github-actions-pool/providers/github-oidc'
+          service_account: 'tourya-dev-cloud-run@tourya-project-dev.iam.gserviceaccount.com'
 
       - name: Configure Docker
         run: gcloud auth configure-docker us-east1-docker.pkg.dev --quiet


### PR DESCRIPTION
…ty Federation (SEC-07)

Reemplaza el uso de un service account key JSON (secreto GCP_SA_KEY_DEV en GitHub Secrets) por Workload Identity Federation (WIF).

Antes:
- GitHub Actions se autenticaba en GCP con un SA key JSON de larga duracion almacenado en GitHub Secrets.
- El mismo key JSON estaba ademas commiteado en el repo como docs/tourya-dev-sa-key.json (vulnerabilidad H-1).

Ahora:
- GitHub Actions se autentica via OIDC (workload_identity_provider).
- Tokens de corta duracion emitidos por deploy, no keys de larga duracion.
- Traza auditable (repository, ref, sub) por cada autenticacion.

Setup en GCP tourya-project-dev (ya aplicado):
- APIs habilitadas: iamcredentials.googleapis.com, sts.googleapis.com
- Workload Identity Pool: github-actions-pool (global)
- OIDC Provider: github-oidc
  - Issuer: https://token.actions.githubusercontent.com
  - Attribute condition: assertion.repository_owner=='Touryapp'
- Binding: SA tourya-dev-cloud-run recibe rol roles/iam.workloadIdentityUser desde: principalSet://.../attribute.repository/Touryapp/tourya-api (restringido a este repo, no toda la organizacion)

El workflow ya tiene permissions.id-token: write (requerido por WIF).

Siguientes pasos (post-merge):
1. Verificar que el proximo deploy funciona con OIDC.
2. Revocar los 4 keys viejos del SA en IAM.
3. Eliminar docs/tourya-dev-sa-key.json del repo (PR separado).
4. Franklin puede borrar el GitHub Secret GCP_SA_KEY_DEV (ya no se usa).

Ver H-1 en docs/12-seguridad-y-auth.md.