### PR TITLE
refactor(security): quitar fallbacks hardcoded de application.propert…

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,7 +11,7 @@ spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-payment.wompi.integrity.secret=${WOMPI_INTEGRITY_SECRET:test_integrity_PnLqXgX3tMbgvUqpXOKnZvfikb3oSV8y}
+payment.wompi.integrity.secret=${WOMPI_INTEGRITY_SECRET}
 
 
 # Actuator: exponer solo endpoints publicos necesarios (health, info)
@@ -75,7 +75,7 @@ gcp.storage.bucket=${GCS_BUCKET:}
 
 
 #Security
-application.security.jwt.secret-key=${JWT_SECRET:404E635266556A586E3272357538782F413F4428472B4B6250645367566B5970}
+application.security.jwt.secret-key=${JWT_SECRET}
 # a day
 application.security.jwt.expiration=86400000
 application.mailing.frontend.activation-url=${ACTIVATION_URL:http://44.203.38.85:8088/api/v1/auth/activar-cuenta-web?token=}


### PR DESCRIPTION
…ies (fail-fast)

Antes: los secretos JWT y Wompi tenian fallback al valor hardcoded (los valores originales que estaban antes de Fase 0). La app arrancaba con el hardcoded si Cloud Run no inyectaba la env var, lo que enmascaraba problemas de configuracion.

Ahora: sin fallback.
- payment.wompi.integrity.secret=\${WOMPI_INTEGRITY_SECRET}
- application.security.jwt.secret-key=\${JWT_SECRET}

Efecto: si Cloud Run pierde acceso al Secret Manager o el secret no esta configurado, Spring falla al arrancar con un error claro sobre placeholder no resuelto. Fail-fast en vez de silently usar valores viejos.

Prerequisitos (ya cumplidos en bloque 0.3):
- Secret Manager habilitado en tourya-project-dev
- Secretos tourya-jwt-key y tourya-wompi-integrity-secret creados
- SA tourya-dev-cloud-run con permiso secretmanager.secretAccessor
- Workflow con --set-secrets JWT_SECRET y WOMPI_INTEGRITY_SECRET

Si el deploy falla por algun motivo, la app sigue en la revision anterior (rollback instantaneo).

Nota fuera del scope: application.mailing.frontend.activation-url sigue con fallback a AWS legacy (linea 81). Es un tema aparte (URL de fallback, no secret) — se atendera en otro PR.