### PR TITLE
feat(payments): BE-16 recibir + verificar + persistir webhooks Wompi

### DIFF
--- a/database/migrations/066_wompi_webhook_event.sql
+++ b/database/migrations/066_wompi_webhook_event.sql
@@ -1,0 +1,43 @@
+-- Migration 066: Wompi webhook event log
+-- Date: 2026-07-08
+-- Description:
+--   Tabla para registrar todos los eventos webhook recibidos de Wompi.
+--   Uso: (a) auditoria de eventos recibidos, (b) reconciliacion posterior de pagos huerfanos.
+--   Endpoint que persiste aqui: POST /public/wompi/webhook
+
+CREATE TABLE IF NOT EXISTS public.wompi_webhook_event (
+    id BIGSERIAL PRIMARY KEY,
+    wompi_event_type VARCHAR(50) NOT NULL,
+    transaction_id VARCHAR(120) NOT NULL,
+    transaction_reference VARCHAR(255),
+    transaction_status VARCHAR(30) NOT NULL,
+    amount_in_cents BIGINT,
+    currency VARCHAR(10),
+    wompi_sent_at TIMESTAMPTZ,
+    wompi_timestamp BIGINT,
+    raw_payload JSONB NOT NULL,
+    signature_valid BOOLEAN NOT NULL DEFAULT FALSE,
+    signature_checksum VARCHAR(128),
+    received_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    processed_at TIMESTAMPTZ,
+    linked_payment_id BIGINT REFERENCES public.payment(payment_id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_wompi_event_transaction_id
+    ON public.wompi_webhook_event (transaction_id);
+
+CREATE INDEX IF NOT EXISTS idx_wompi_event_unprocessed
+    ON public.wompi_webhook_event (received_at)
+    WHERE processed_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_wompi_event_received_at
+    ON public.wompi_webhook_event (received_at);
+
+COMMENT ON TABLE public.wompi_webhook_event IS
+    'Log de eventos webhook recibidos de Wompi. Usado para reconciliacion + auditoria.';
+COMMENT ON COLUMN public.wompi_webhook_event.signature_valid IS
+    'TRUE si el checksum SHA-256 de Wompi verifico correctamente contra el events secret.';
+COMMENT ON COLUMN public.wompi_webhook_event.processed_at IS
+    'Marca temporal de cuando el job de reconciliacion proceso este evento (NULL = pendiente).';
+COMMENT ON COLUMN public.wompi_webhook_event.linked_payment_id IS
+    'Payment de Tourya al que se pudo asociar este evento tras reconciliacion.';

--- a/src/main/java/com/tourya/api/controller/WompiWebhookController.java
+++ b/src/main/java/com/tourya/api/controller/WompiWebhookController.java
@@ -1,0 +1,37 @@
+package com.tourya.api.controller;
+
+import com.tourya.api.services.WompiWebhookService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Recibe eventos webhook enviados por Wompi (server-to-server).
+ * Endpoint publico (sin auth JWT). La autenticacion se hace verificando el
+ * checksum SHA-256 firmado con el events secret de Wompi.
+ * Siempre responde 200 OK si el JSON es valido (independiente de la firma)
+ * para evitar reintentos inutiles de Wompi. La validez de la firma se
+ * guarda en la BD para forensia y reconciliacion.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/public/wompi")
+@RequiredArgsConstructor
+@Tag(name = "Wompi Webhook", description = "Recibe eventos server-to-server de Wompi")
+public class WompiWebhookController {
+
+    private final WompiWebhookService webhookService;
+
+    @PostMapping("/webhook")
+    public ResponseEntity<Void> receiveWebhook(@RequestBody String rawPayload) {
+        log.info("Wompi webhook received. payload_length={}",
+                rawPayload != null ? rawPayload.length() : 0);
+        webhookService.processIncoming(rawPayload);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/tourya/api/models/WompiWebhookEvent.java
+++ b/src/main/java/com/tourya/api/models/WompiWebhookEvent.java
@@ -1,0 +1,74 @@
+package com.tourya.api.models;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Registro de un evento webhook recibido desde Wompi.
+ * No extiende BaseEntity porque received_at + processed_at cubren la trazabilidad temporal
+ * y no hay auditoria de usuario (los webhooks son server-to-server, no hay usuario Tourya asociado).
+ */
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "wompi_webhook_event")
+public class WompiWebhookEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "wompi_event_type", nullable = false, length = 50)
+    private String wompiEventType;
+
+    @Column(name = "transaction_id", nullable = false, length = 120)
+    private String transactionId;
+
+    @Column(name = "transaction_reference", length = 255)
+    private String transactionReference;
+
+    @Column(name = "transaction_status", nullable = false, length = 30)
+    private String transactionStatus;
+
+    @Column(name = "amount_in_cents")
+    private Long amountInCents;
+
+    @Column(name = "currency", length = 10)
+    private String currency;
+
+    @Column(name = "wompi_sent_at")
+    private OffsetDateTime wompiSentAt;
+
+    @Column(name = "wompi_timestamp")
+    private Long wompiTimestamp;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "raw_payload", nullable = false, columnDefinition = "jsonb")
+    private String rawPayload;
+
+    @Column(name = "signature_valid", nullable = false)
+    private Boolean signatureValid;
+
+    @Column(name = "signature_checksum", length = 128)
+    private String signatureChecksum;
+
+    @Column(name = "received_at", nullable = false)
+    private OffsetDateTime receivedAt;
+
+    @Column(name = "processed_at")
+    private OffsetDateTime processedAt;
+
+    @Column(name = "linked_payment_id")
+    private Long linkedPaymentId;
+}

--- a/src/main/java/com/tourya/api/repository/WompiWebhookEventRepository.java
+++ b/src/main/java/com/tourya/api/repository/WompiWebhookEventRepository.java
@@ -1,0 +1,15 @@
+package com.tourya.api.repository;
+
+import com.tourya.api.models.WompiWebhookEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface WompiWebhookEventRepository extends JpaRepository<WompiWebhookEvent, Long> {
+
+    List<WompiWebhookEvent> findByProcessedAtIsNull();
+
+    List<WompiWebhookEvent> findByTransactionId(String transactionId);
+}

--- a/src/main/java/com/tourya/api/services/WompiWebhookService.java
+++ b/src/main/java/com/tourya/api/services/WompiWebhookService.java
@@ -1,0 +1,168 @@
+package com.tourya.api.services;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tourya.api.models.WompiWebhookEvent;
+import com.tourya.api.repository.WompiWebhookEventRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+/**
+ * Procesa eventos webhook recibidos desde Wompi.
+ * Responsabilidades:
+ *   1) Verificar la firma HMAC (checksum SHA-256 con events secret).
+ *   2) Persistir el evento en wompi_webhook_event para reconciliacion posterior.
+ * NO confirma reservas automaticamente: eso lo hace el job de reconciliacion (BE-17)
+ * despues de matchear el transaction_id contra Payments existentes.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WompiWebhookService {
+
+    private final WompiWebhookEventRepository repository;
+    private final ObjectMapper objectMapper;
+
+    @Value("${payment.wompi.events.secret}")
+    private String eventsSecret;
+
+    @Transactional
+    public ProcessResult processIncoming(String rawPayload) {
+        if (rawPayload == null || rawPayload.isBlank()) {
+            log.warn("Wompi webhook: empty payload");
+            return ProcessResult.invalid("empty_payload");
+        }
+
+        JsonNode root;
+        try {
+            root = objectMapper.readTree(rawPayload);
+        } catch (Exception e) {
+            log.warn("Wompi webhook: invalid JSON payload", e);
+            return ProcessResult.invalid("invalid_json");
+        }
+
+        JsonNode signatureNode = root.path("signature");
+        JsonNode propsNode = signatureNode.path("properties");
+        String checksum = signatureNode.path("checksum").asText(null);
+        long timestamp = root.path("timestamp").asLong(0);
+
+        if (checksum == null || !propsNode.isArray() || propsNode.isEmpty()) {
+            log.warn("Wompi webhook missing signature.checksum or properties[]");
+            persistEvent(root, rawPayload, false, checksum);
+            return ProcessResult.invalid("missing_signature");
+        }
+
+        // Wompi arma el string a firmar concatenando los valores de las properties (en orden)
+        // + timestamp + events_secret. Las properties son dot-paths bajo "data" del payload.
+        // Algunas versiones envian "transaction.id", otras "data.transaction.id" -> normalizamos.
+        StringBuilder toSign = new StringBuilder();
+        JsonNode dataNode = root.path("data");
+        for (JsonNode prop : propsNode) {
+            String path = prop.asText();
+            if (path.startsWith("data.")) {
+                path = path.substring("data.".length());
+            }
+            String value = readByDotPath(dataNode, path);
+            toSign.append(value != null ? value : "");
+        }
+        toSign.append(timestamp);
+        toSign.append(eventsSecret);
+
+        String computed = sha256Hex(toSign.toString());
+        boolean valid = computed.equalsIgnoreCase(checksum);
+
+        WompiWebhookEvent saved = persistEvent(root, rawPayload, valid, checksum);
+
+        if (!valid) {
+            log.warn("Wompi webhook SIGNATURE INVALID. tx_id={}, computed_len={}, received_len={}",
+                    root.path("data").path("transaction").path("id").asText("unknown"),
+                    computed.length(), checksum.length());
+            return ProcessResult.invalid("checksum_mismatch");
+        }
+
+        log.info("Wompi webhook valid. event_id={}, tx_id={}, status={}",
+                saved.getId(),
+                saved.getTransactionId(),
+                saved.getTransactionStatus());
+        return ProcessResult.valid(saved.getId());
+    }
+
+    private WompiWebhookEvent persistEvent(JsonNode root, String rawPayload, boolean signatureValid, String checksum) {
+        JsonNode tx = root.path("data").path("transaction");
+        OffsetDateTime sentAt = null;
+        String sentAtStr = root.path("sent_at").asText(null);
+        if (sentAtStr != null) {
+            try {
+                sentAt = OffsetDateTime.parse(sentAtStr);
+            } catch (Exception e) {
+                log.debug("Wompi webhook: could not parse sent_at={}", sentAtStr);
+            }
+        }
+
+        WompiWebhookEvent event = WompiWebhookEvent.builder()
+                .wompiEventType(root.path("event").asText("unknown"))
+                .transactionId(tx.path("id").asText("unknown"))
+                .transactionReference(tx.path("reference").asText(null))
+                .transactionStatus(tx.path("status").asText("UNKNOWN"))
+                .amountInCents(tx.has("amount_in_cents") ? tx.get("amount_in_cents").asLong() : null)
+                .currency(tx.path("currency").asText(null))
+                .wompiSentAt(sentAt)
+                .wompiTimestamp(root.has("timestamp") ? root.get("timestamp").asLong() : null)
+                .rawPayload(rawPayload)
+                .signatureValid(signatureValid)
+                .signatureChecksum(checksum)
+                .receivedAt(OffsetDateTime.now(ZoneOffset.UTC))
+                .build();
+        return repository.save(event);
+    }
+
+    /**
+     * Lee un valor por dot-path. "transaction.id" -> root.get("transaction").get("id").
+     * Devuelve null si algun segmento no existe.
+     */
+    private String readByDotPath(JsonNode root, String dotPath) {
+        JsonNode current = root;
+        for (String segment : dotPath.split("\\.")) {
+            current = current.path(segment);
+            if (current.isMissingNode() || current.isNull()) {
+                return null;
+            }
+        }
+        if (current.isNumber()) return current.asText();
+        if (current.isTextual()) return current.asText();
+        if (current.isBoolean()) return String.valueOf(current.asBoolean());
+        return current.toString();
+    }
+
+    private String sha256Hex(String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString();
+        } catch (Exception e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    public record ProcessResult(boolean signatureValid, Long eventId, String errorCode) {
+        public static ProcessResult valid(Long eventId) {
+            return new ProcessResult(true, eventId, null);
+        }
+
+        public static ProcessResult invalid(String code) {
+            return new ProcessResult(false, null, code);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,6 +12,7 @@ spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 payment.wompi.integrity.secret=${WOMPI_INTEGRITY_SECRET}
+payment.wompi.events.secret=${WOMPI_EVENTS_SECRET}
 
 
 # Actuator: exponer solo endpoints publicos necesarios (health, info)


### PR DESCRIPTION
Nuevo endpoint POST /public/wompi/webhook que recibe eventos server-to-server de Wompi cuando cambia el estado de una transaccion. Objetivo: detectar pagos huerfanos (turista completa pago en Wompi pero el frontend no llama a POST /payment) para reconciliacion posterior.

Arquitectura:

1. Migracion 066: nueva tabla wompi_webhook_event que registra TODOS los eventos recibidos (validos o invalidos, para forensia). Incluye:
   - transaction_id, transaction_reference, transaction_status
   - amount_in_cents, currency
   - raw_payload (JSONB) - copia completa para auditoria/debug
   - signature_valid - resultado de la verificacion HMAC
   - processed_at, linked_payment_id - para reconciliacion (BE-17)

2. Entidad WompiWebhookEvent - no extiende BaseEntity porque es una tabla de log, no de dominio; received_at + processed_at cubren la trazabilidad.

3. WompiWebhookService - verifica firma SHA-256:
   - Concatena valores de las properties del signature (dot-paths bajo "data")
   - Agrega timestamp + events_secret
   - Compara con signature.checksum
   - Robusto ante paths con o sin prefijo "data." (varia por version de Wompi)

4. WompiWebhookController - endpoint publico bajo /public/**. Siempre devuelve 200 OK si el JSON parsea (evita reintentos innecesarios de Wompi). La validez de la firma queda persistida en la BD.

5. application.properties: nueva property payment.wompi.events.secret sin fallback (fail-fast si no esta configurada).

Prerequisitos para deploy en dev (no incluidos en este PR):

- Obtener "events secret" del dashboard Wompi test (Luis).
- Crear secret tourya-wompi-events-secret en Secret Manager.
- IAM binding para el SA de Cloud Run.
- Agregar WOMPI_EVENTS_SECRET al bloque secrets del workflow gcp_deploy_develop.yml.
- Configurar URL del webhook en el dashboard de Wompi apuntando a: https://tourya-dev-api-640622322458.us-east1.run.app/api/v1/public/wompi/webhook

Riesgo para dev:
- Cambio 100% aditivo. Endpoint nuevo, tabla nueva, ninguna modificacion a codigo existente. Nadie usa este endpoint hasta que Wompi lo llame.
- La app fallara al arrancar si WOMPI_EVENTS_SECRET no esta en env vars - intencional (fail-fast). Por eso este PR NO se debe mergear hasta que el secreto este creado y el workflow actualizado.

Siguientes pasos:
- BE-17: WompiReconciliationJob que procesa eventos no procesados y matchea contra Payments existentes (PR separado).