### PR TITLE
feat(payments): BE-17 job de reconciliacion de webhooks Wompi

### DIFF
--- a/src/main/java/com/tourya/api/jobs/WompiReconciliationJob.java
+++ b/src/main/java/com/tourya/api/jobs/WompiReconciliationJob.java
@@ -1,0 +1,79 @@
+package com.tourya.api.jobs;
+
+import com.tourya.api.models.Payment;
+import com.tourya.api.models.WompiWebhookEvent;
+import com.tourya.api.repository.PaymentRepository;
+import com.tourya.api.repository.WompiWebhookEventRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Reconcilia eventos webhook Wompi (APPROVED con firma valida) contra Payments
+ * existentes.
+ * <ul>
+ *   <li>Si Tourya ya tiene el Payment para ese transactionId (flujo normal turista):
+ *       linkea el evento con el Payment (linked_payment_id) y lo marca procesado.
+ *   <li>Si NO existe Payment (pago huerfano: Wompi aprobo pero el cliente nunca llamo
+ *       POST /payment): loguea WARN y marca procesado para no retocarlo. Queda visible
+ *       en la tabla wompi_webhook_event con linked_payment_id NULL para operacion manual.
+ * </ul>
+ * <p>Este job NO confirma reservas automaticamente porque el matching de un pago
+ * huerfano con las reservas TEMPORAL correctas requiere conocer la reference que el
+ * cliente uso al iniciar el checkout (no persistida hoy). Se atacara en un PR posterior
+ * junto con el cambio de modelo que agregue wompi_reference a shopping_cart.</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WompiReconciliationJob {
+
+    private static final String STATUS_APPROVED = "APPROVED";
+
+    private final WompiWebhookEventRepository eventRepository;
+    private final PaymentRepository paymentRepository;
+
+    @Scheduled(fixedDelayString = "${tourya.wompiReconciliation.fixedDelayMs:300000}")
+    @Transactional
+    public void reconcile() {
+        List<WompiWebhookEvent> pending = eventRepository
+                .findTop100BySignatureValidTrueAndProcessedAtIsNullAndTransactionStatusOrderByReceivedAtAsc(STATUS_APPROVED);
+
+        if (pending.isEmpty()) {
+            return;
+        }
+
+        int matched = 0;
+        int orphan = 0;
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+
+        for (WompiWebhookEvent event : pending) {
+            Optional<Payment> paymentOpt = paymentRepository.findByTransactionId(event.getTransactionId());
+            if (paymentOpt.isPresent()) {
+                event.setLinkedPaymentId(paymentOpt.get().getPaymentId());
+                event.setProcessedAt(now);
+                matched++;
+            } else {
+                log.warn("Wompi orphan payment detected: event_id={}, tx_id={}, reference={}, amount_cents={}, currency={}",
+                        event.getId(),
+                        event.getTransactionId(),
+                        event.getTransactionReference(),
+                        event.getAmountInCents(),
+                        event.getCurrency());
+                event.setProcessedAt(now);
+                orphan++;
+            }
+        }
+        eventRepository.saveAll(pending);
+
+        log.info("WompiReconciliationJob completed: matched={}, orphan={} (total processed: {})",
+                matched, orphan, pending.size());
+    }
+}

--- a/src/main/java/com/tourya/api/repository/WompiWebhookEventRepository.java
+++ b/src/main/java/com/tourya/api/repository/WompiWebhookEventRepository.java
@@ -12,4 +12,12 @@ public interface WompiWebhookEventRepository extends JpaRepository<WompiWebhookE
     List<WompiWebhookEvent> findByProcessedAtIsNull();
 
     List<WompiWebhookEvent> findByTransactionId(String transactionId);
+
+    /**
+     * Eventos pendientes de reconciliacion: firma valida, no procesados aun,
+     * y con un status especifico (tipicamente APPROVED). Limitado y ordenado
+     * por received_at ASC para procesar los mas viejos primero.
+     */
+    List<WompiWebhookEvent> findTop100BySignatureValidTrueAndProcessedAtIsNullAndTransactionStatusOrderByReceivedAtAsc(
+            String transactionStatus);
 }


### PR DESCRIPTION
Cron job que corre cada 5 minutos por defecto (configurable via property tourya.wompiReconciliation.fixedDelayMs) y procesa eventos webhook Wompi pendientes con firma valida y status APPROVED.

Comportamiento:

1. Si el Payment existe (Tourya ya lo tenia, flujo cliente normal):
   - event.linked_payment_id = payment.paymentId
   - event.processed_at = now() Es solo trazabilidad; el pago ya estaba confirmado por el flujo turista.

2. Si NO existe Payment (pago huerfano):
   - Loguea WARN con tx_id, reference, amount para investigacion operativa.
   - event.processed_at = now() para no volver a loguear el mismo evento.
   - event.linked_payment_id queda NULL - queda visible en la tabla para reconciliacion manual.

Este PR NO confirma reservas TEMPORAL automaticamente al detectar un pago huerfano. La razon: para mapear un pago Wompi a reservas TEMPORAL correctas necesitamos conocer la "reference" que el cliente uso al iniciar el checkout, y esa reference NO se persiste hoy en shopping_cart ni en reservation. Ver BE-20 futuro que agregara wompi_reference a shopping_cart + logica de matching automatico.

Cambios:

- WompiWebhookEventRepository: nuevo metodo findTop100BySignatureValidTrueAndProcessedAtIsNullAndTransactionStatusOrderByReceivedAtAsc Limita a 100 eventos por corrida para evitar transacciones muy grandes; ordena por received_at ASC para procesar los mas viejos primero.

- WompiReconciliationJob: @Component con @Scheduled + @Transactional. Usa el mismo patron fixedDelayString con property configurable que los otros jobs del proyecto (TemporalReservationExpiryJob, etc.).

Filtros de query:
- signature_valid = true (los invalidos son intentos de fraude / error; solo log)
- processed_at IS NULL (evita reprocesar)
- transaction_status = 'APPROVED' (otros estados no requieren accion en este PR)

Riesgo para dev:
- Cambio 100% aditivo. Nuevo componente + un metodo mas en el repository.
- @EnableScheduling ya esta activo en la aplicacion (otros jobs lo usan).
- Si no hay eventos pendientes, el job no toca nada y retorna en microsegundos.
- Cero eventos APPROVED en dev todavia (solo el evento de test que borre con signature_valid=false, que este job NO procesa).

Siguientes pasos:
- Configurar la URL del webhook en dashboard Wompi (Franklin + Luis) para empezar a recibir eventos reales.
- BE-20 futuro: agregar wompi_reference + logica automatica de confirmacion de reservas huerfanas.