### PR TITLE
feat(auth): BE-12/13/14/15 refresh tokens con rotacion y deteccion de…

### DIFF
--- a/database/migrations/067_refresh_token.sql
+++ b/database/migrations/067_refresh_token.sql
@@ -1,0 +1,51 @@
+-- Migration 067: Refresh token store con rotacion + deteccion de reuso
+-- Date: 2026-07-08
+-- Description:
+--   Almacena los refresh tokens emitidos por el sistema de auth. Necesario para:
+--   1) Rotacion: cada uso de un refresh token lo revoca y emite uno nuevo (menor
+--      exposicion si se filtra).
+--   2) Deteccion de reuso: si un refresh token ya revocado se intenta usar de
+--      nuevo, se revoca toda su familia (sesion completa).
+--   3) Logout server-side: al cerrar sesion se revoca la familia entera.
+--
+--   El "family_id" agrupa todos los refresh tokens de una misma sesion (encadenados
+--   por previous_jti). Al login se genera un family_id nuevo; al rotar se hereda.
+
+CREATE TABLE IF NOT EXISTS public.refresh_token (
+    id BIGSERIAL PRIMARY KEY,
+    user_id INT4 NOT NULL REFERENCES public._user(id) ON DELETE CASCADE,
+    jti VARCHAR(64) NOT NULL UNIQUE,
+    family_id VARCHAR(64) NOT NULL,
+    previous_jti VARCHAR(64),
+    issued_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ NOT NULL,
+    revoked_at TIMESTAMPTZ,
+    revoked_reason VARCHAR(50),
+    user_agent VARCHAR(500),
+    ip_address VARCHAR(64)
+);
+
+CREATE INDEX IF NOT EXISTS idx_refresh_token_jti
+    ON public.refresh_token (jti);
+
+CREATE INDEX IF NOT EXISTS idx_refresh_token_user_id
+    ON public.refresh_token (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_refresh_token_family_id
+    ON public.refresh_token (family_id);
+
+CREATE INDEX IF NOT EXISTS idx_refresh_token_previous_jti
+    ON public.refresh_token (previous_jti);
+
+COMMENT ON TABLE public.refresh_token IS
+    'Refresh tokens emitidos por el sistema de auth. Rotacion + deteccion de reuso + logout server-side.';
+COMMENT ON COLUMN public.refresh_token.jti IS
+    'JWT ID unico del refresh token. Se busca aca al recibir el JWT crudo.';
+COMMENT ON COLUMN public.refresh_token.family_id IS
+    'Agrupa refresh tokens de una misma sesion. Al login = UUID nuevo. Al rotar = heredado.';
+COMMENT ON COLUMN public.refresh_token.previous_jti IS
+    'JTI del refresh anterior en la cadena de rotacion (NULL para el primero). Usado para detectar reuso.';
+COMMENT ON COLUMN public.refresh_token.revoked_at IS
+    'NULL = activo. Set al hacer logout, rotar (revocacion soft del anterior) o detectar reuso.';
+COMMENT ON COLUMN public.refresh_token.revoked_reason IS
+    'Motivo de revocacion: logout, rotated, reuse_detected, family_revoked.';

--- a/src/main/java/com/tourya/api/config/auth/AuthenticationController.java
+++ b/src/main/java/com/tourya/api/config/auth/AuthenticationController.java
@@ -1,6 +1,7 @@
 package com.tourya.api.config.auth;
 
 import com.tourya.api.config.auth.request.AuthenticationRequest;
+import com.tourya.api.config.auth.request.RefreshTokenRequest;
 import com.tourya.api.config.auth.request.SocialAuthRequest;
 import com.tourya.api.config.auth.request.RegistrationRequest;
 import com.tourya.api.config.auth.response.AuthenticationResponse;
@@ -59,6 +60,23 @@ public class AuthenticationController {
             @RequestBody @Valid SocialAuthRequest request
     ){
         return ResponseEntity.ok(service.authenticateWithSocial(request));
+    }
+
+    @PostMapping("/refresh")
+    @Operation(summary = "Rotar tokens", description = "Recibe un refresh token valido, revoca ese (rotated) y emite un nuevo par access + refresh (mismo family_id). Si detecta reuso, revoca toda la familia y devuelve 401.")
+    public ResponseEntity<AuthenticationResponse> refresh(
+            @RequestBody @Valid RefreshTokenRequest request
+    ){
+        return ResponseEntity.ok(service.refreshTokens(request.getRefreshToken()));
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "Cerrar sesion", description = "Revoca toda la familia del refresh token proporcionado. Idempotente: si el token es invalido, tambien retorna 204.")
+    public ResponseEntity<Void> logout(
+            @RequestBody @Valid RefreshTokenRequest request
+    ){
+        service.logout(request.getRefreshToken());
+        return ResponseEntity.noContent().build();
     }
 
     @Hidden

--- a/src/main/java/com/tourya/api/config/auth/AuthenticationService.java
+++ b/src/main/java/com/tourya/api/config/auth/AuthenticationService.java
@@ -42,6 +42,7 @@ public class AuthenticationService {
     private final RoleRepository roleRepository;
     private final EmailService emailService;
     private final TokenRepository tokenRepository;
+    private final RefreshTokenService refreshTokenService;
     @Value("${application.mailing.frontend.activation-url}")
     private String activationUrl;
 
@@ -116,19 +117,43 @@ public class AuthenticationService {
                 )
         );
 
-        var claims = new HashMap<String, Object>();
-        var user = ((User) auth.getPrincipal());
-        claims.put("fullName", user.fullName());
+        User user = (User) auth.getPrincipal();
+        RefreshTokenService.IssuedTokens tokens = refreshTokenService.issueForUser(user);
+        return buildAuthResponse(user, tokens, user.isMustChangePassword());
+    }
 
-        var jwtToken = jwtService.generateToken(claims, (User) auth.getPrincipal());
-        MetaResponse metaResponse = new MetaResponse();
+    /**
+     * Rota el par (access + refresh) usando un refresh token existente.
+     * Requiere que el refresh no este revocado ni expirado. Si detecta reuso,
+     * revoca la familia completa antes de lanzar la excepcion.
+     */
+    public AuthenticationResponse refreshTokens(String rawRefreshToken) {
+        RefreshTokenService.IssuedTokens tokens = refreshTokenService.rotate(rawRefreshToken);
+        return buildAuthResponse(tokens.user(), tokens, tokens.user().isMustChangePassword());
+    }
+
+    /**
+     * Cierra sesion: revoca la familia entera del refresh token. Idempotente.
+     */
+    public void logout(String rawRefreshToken) {
+        refreshTokenService.logout(rawRefreshToken);
+    }
+
+    /**
+     * Construye la respuesta de auth manteniendo compatibilidad hacia atras:
+     * `token` sigue siendo el access token (clientes viejos lo leen), y se agregan
+     * `accessToken` y `refreshToken` para los clientes nuevos.
+     */
+    private AuthenticationResponse buildAuthResponse(User user, RefreshTokenService.IssuedTokens tokens, Boolean mustChangePassword) {
         return AuthenticationResponse.builder()
-                .meta(metaResponse)
+                .meta(new MetaResponse())
                 .fullName(user.fullName())
                 .email(user.getEmail())
                 .roleList(user.getRoles())
-                .token(jwtToken)
-                .mustChangePassword(user.isMustChangePassword())
+                .token(tokens.accessToken())
+                .accessToken(tokens.accessToken())
+                .refreshToken(tokens.refreshToken())
+                .mustChangePassword(mustChangePassword)
                 .build();
     }
 
@@ -181,49 +206,19 @@ public class AuthenticationService {
                     .build();
             userRepository.save(newUser);
 
-            var claims = new HashMap<String, Object>();
-            claims.put("fullName", newUser.fullName());
-
-            var jwtToken = jwtService.generateToken(claims, newUser);
-            MetaResponse metaResponse = new MetaResponse();
-            return AuthenticationResponse.builder()
-                    .meta(metaResponse)
-                    .fullName(newUser.fullName())
-                    .email(newUser.getEmail())
-                    .roleList(newUser.getRoles())
-                    .token(jwtToken)
-                    .build();
+            RefreshTokenService.IssuedTokens tokens = refreshTokenService.issueForUser(newUser);
+            return buildAuthResponse(newUser, tokens, newUser.isMustChangePassword());
         } else if (!user.isEnabled()) {
             user.setEnabled(true);
             userRepository.save(user);
 
-            var claims = new HashMap<String, Object>();
-            claims.put("fullName", user.fullName());
-
-            var jwtToken = jwtService.generateToken(claims, user);
-            MetaResponse metaResponse = new MetaResponse();
-            return AuthenticationResponse.builder()
-                    .meta(metaResponse)
-                    .fullName(user.fullName())
-                    .email(user.getEmail())
-                    .roleList(user.getRoles())
-                    .token(jwtToken)
-                    .build();
+            RefreshTokenService.IssuedTokens tokens = refreshTokenService.issueForUser(user);
+            return buildAuthResponse(user, tokens, user.isMustChangePassword());
         }
 
         // El usuario ya existe y está habilitado
-        var claims = new HashMap<String, Object>();
-        claims.put("fullName", user.fullName());
-
-        var jwtToken = jwtService.generateToken(claims, user);
-        MetaResponse metaResponse = new MetaResponse();
-        return AuthenticationResponse.builder()
-                .meta(metaResponse)
-                .fullName(user.fullName())
-                .email(user.getEmail())
-                .roleList(user.getRoles())
-                .token(jwtToken)
-                .build();
+        RefreshTokenService.IssuedTokens tokens = refreshTokenService.issueForUser(user);
+        return buildAuthResponse(user, tokens, user.isMustChangePassword());
     }
     private String generateTemporaryPassword() {
         // Generar una contraseña temporal segura

--- a/src/main/java/com/tourya/api/config/auth/RefreshTokenService.java
+++ b/src/main/java/com/tourya/api/config/auth/RefreshTokenService.java
@@ -1,0 +1,174 @@
+package com.tourya.api.config.auth;
+
+import com.tourya.api.config.security.JwtService;
+import com.tourya.api.models.RefreshToken;
+import com.tourya.api.models.User;
+import com.tourya.api.repository.RefreshTokenRepository;
+import com.tourya.api.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Gestiona el ciclo de vida de los refresh tokens.
+ * <ul>
+ *   <li><b>issueForUser</b>: emite el primer refresh token de una sesion nueva (family_id nuevo).</li>
+ *   <li><b>rotate</b>: valida un refresh token existente, detecta reuso, revoca el actual
+ *       y emite un nuevo par access + refresh (misma familia).</li>
+ *   <li><b>logout</b>: revoca la familia entera de un refresh token dado.</li>
+ * </ul>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private static final String REASON_ROTATED = "rotated";
+    private static final String REASON_LOGOUT = "logout";
+    private static final String REASON_REUSE = "reuse_detected";
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+    private final JwtService jwtService;
+
+    /**
+     * Emite el primer refresh token de una nueva sesion.
+     * Se llama al login exitoso (password o social).
+     */
+    @Transactional
+    public IssuedTokens issueForUser(User user) {
+        String familyId = UUID.randomUUID().toString();
+        String jti = UUID.randomUUID().toString();
+        return persistAndBuild(user, jti, familyId, null);
+    }
+
+    /**
+     * Rota un refresh token existente.
+     * Al validar detecta 3 casos de fraude:
+     * <ol>
+     *   <li>Firma invalida o expirado (JWT).</li>
+     *   <li>Token no existe en BD (nunca emitido).</li>
+     *   <li>Token ya revocado (reuso -> revoca toda la familia).</li>
+     * </ol>
+     * Si todo OK: revoca el actual con reason=rotated, emite uno nuevo con el mismo family_id
+     * y previous_jti = jti anterior. Retorna el nuevo par access + refresh.
+     */
+    @Transactional
+    public IssuedTokens rotate(String rawRefreshToken) {
+        Claims claims;
+        try {
+            claims = jwtService.extractAllClaimsPublic(rawRefreshToken);
+        } catch (Exception e) {
+            log.warn("Refresh token rechazado: JWT invalido o expirado. reason={}", e.getClass().getSimpleName());
+            throw new RefreshTokenException("Invalid refresh token");
+        }
+
+        if (jwtService.isExpired(rawRefreshToken)) {
+            throw new RefreshTokenException("Refresh token expired");
+        }
+        if (!"refresh".equals(claims.get("type"))) {
+            throw new RefreshTokenException("Not a refresh token");
+        }
+
+        String jti = claims.get("jti", String.class);
+        if (jti == null) {
+            throw new RefreshTokenException("Refresh token missing jti");
+        }
+
+        Optional<RefreshToken> found = refreshTokenRepository.findByJti(jti);
+        if (found.isEmpty()) {
+            log.warn("Refresh token rechazado: jti={} no existe en BD (posible falsificacion)", jti);
+            throw new RefreshTokenException("Unknown refresh token");
+        }
+        RefreshToken current = found.get();
+
+        if (current.getRevokedAt() != null) {
+            log.warn("Reuso de refresh token detectado. jti={} family_id={} revoked_at={}. Revocando familia completa.",
+                    current.getJti(), current.getFamilyId(), current.getRevokedAt());
+            OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+            refreshTokenRepository.revokeFamily(current.getFamilyId(), now, REASON_REUSE);
+            throw new RefreshTokenException("Refresh token reuse detected");
+        }
+
+        User user = userRepository.findById(current.getUserId())
+                .orElseThrow(() -> new UsernameNotFoundException("User not found for refresh token"));
+
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        current.setRevokedAt(now);
+        current.setRevokedReason(REASON_ROTATED);
+        refreshTokenRepository.save(current);
+
+        String newJti = UUID.randomUUID().toString();
+        return persistAndBuild(user, newJti, current.getFamilyId(), current.getJti());
+    }
+
+    /**
+     * Cierra sesion: revoca la familia entera del refresh token.
+     * Si el token no existe o ya esta revocado, no hace nada (idempotente).
+     */
+    @Transactional
+    public void logout(String rawRefreshToken) {
+        Claims claims;
+        try {
+            claims = jwtService.extractAllClaimsPublic(rawRefreshToken);
+        } catch (Exception e) {
+            log.debug("Logout: refresh token invalido o expirado. Se ignora silenciosamente.");
+            return;
+        }
+        String jti = claims.get("jti", String.class);
+        if (jti == null) return;
+
+        Optional<RefreshToken> found = refreshTokenRepository.findByJti(jti);
+        if (found.isEmpty()) return;
+
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        int revoked = refreshTokenRepository.revokeFamily(found.get().getFamilyId(), now, REASON_LOGOUT);
+        log.info("Logout: revocada familia {} (tokens revocados: {})", found.get().getFamilyId(), revoked);
+    }
+
+    private IssuedTokens persistAndBuild(User user, String jti, String familyId, String previousJti) {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        OffsetDateTime expiresAt = Instant.ofEpochMilli(System.currentTimeMillis() + jwtService.getRefreshExpirationMs())
+                .atOffset(ZoneOffset.UTC);
+
+        RefreshToken entity = RefreshToken.builder()
+                .userId(user.getId())
+                .jti(jti)
+                .familyId(familyId)
+                .previousJti(previousJti)
+                .issuedAt(now)
+                .expiresAt(expiresAt)
+                .build();
+        refreshTokenRepository.save(entity);
+
+        Map<String, Object> accessClaims = new HashMap<>();
+        accessClaims.put("fullName", user.fullName());
+        String accessToken = jwtService.generateToken(accessClaims, user);
+        String refreshToken = jwtService.generateRefreshToken(user.getEmail(), jti, familyId, previousJti);
+
+        return new IssuedTokens(user, accessToken, refreshToken);
+    }
+
+    public record IssuedTokens(User user, String accessToken, String refreshToken) {}
+
+    /**
+     * Excepcion domain-level para errores de refresh token. Se mapea a 401 en el handler
+     * de auth (o Spring devuelve 500 por default hasta que se agregue en GlobalExceptionHandler).
+     */
+    public static class RefreshTokenException extends RuntimeException {
+        public RefreshTokenException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/main/java/com/tourya/api/config/auth/request/RefreshTokenRequest.java
+++ b/src/main/java/com/tourya/api/config/auth/request/RefreshTokenRequest.java
@@ -1,0 +1,13 @@
+package com.tourya.api.config.auth.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RefreshTokenRequest {
+
+    @NotBlank(message = "refreshToken is mandatory")
+    private String refreshToken;
+}

--- a/src/main/java/com/tourya/api/config/auth/response/AuthenticationResponse.java
+++ b/src/main/java/com/tourya/api/config/auth/response/AuthenticationResponse.java
@@ -18,7 +18,16 @@ public class AuthenticationResponse {
     private String fullName;
     private String email;
     private List<Role> roleList;
+
+    @Schema(description = "Access token JWT. Alias legacy: mismo valor que accessToken. Los nuevos clientes deben leer accessToken.")
     private String token;
+
+    @Schema(description = "Access token JWT (usar este; token es alias legacy).")
+    private String accessToken;
+
+    @Schema(description = "Refresh token JWT. Usar POST /auth/refresh para rotar antes de que expire el access token.")
+    private String refreshToken;
+
     @Schema(description = "Si es true, el cliente debe llamar PATCH /users para cambiar contraseña antes de continuar.")
     private Boolean mustChangePassword;
 }

--- a/src/main/java/com/tourya/api/config/security/JwtService.java
+++ b/src/main/java/com/tourya/api/config/security/JwtService.java
@@ -26,6 +26,46 @@ public class JwtService {
     private String secretKey;
     @Value("${application.security.jwt.expiration}")
     private long jwtExpiration;
+    @Value("${application.security.jwt.refresh-expiration:2592000000}")
+    private long refreshExpiration;
+
+    public long getRefreshExpirationMs() {
+        return refreshExpiration;
+    }
+
+    /**
+     * Emite un refresh token JWT firmado con la misma clave. Contiene el jti (identificador
+     * unico), la familia (para revocar la sesion completa) y el previousJti (para detectar
+     * reuso). El claim "type=refresh" evita que un access token se use como refresh.
+     */
+    public String generateRefreshToken(String subject, String jti, String familyId, String previousJti) {
+        java.util.Map<String, Object> claims = new java.util.HashMap<>();
+        claims.put("jti", jti);
+        claims.put("family", familyId);
+        claims.put("type", "refresh");
+        if (previousJti != null) {
+            claims.put("previous", previousJti);
+        }
+        return Jwts.builder()
+                .setClaims(claims)
+                .setSubject(subject)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + refreshExpiration))
+                .signWith(getSignInKey())
+                .compact();
+    }
+
+    /**
+     * Extrae claims arbitrarios (jti, family, type, etc.) de un JWT ya firmado.
+     * Lanza excepcion si la firma es invalida o el token esta mal formado.
+     */
+    public Claims extractAllClaimsPublic(String token) {
+        return extractAllClaims(token);
+    }
+
+    public boolean isExpired(String token) {
+        return isTokenExpired(token);
+    }
 
     public String extractUsername(String token) {
         return extractClaim(token, Claims::getSubject);

--- a/src/main/java/com/tourya/api/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/tourya/api/handler/GlobalExceptionHandler.java
@@ -106,6 +106,15 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(exceptionResponse, UNAUTHORIZED);
     }
 
+    @ExceptionHandler(com.tourya.api.config.auth.RefreshTokenService.RefreshTokenException.class)
+    public ResponseEntity<Object> handleRefreshTokenException(
+            com.tourya.api.config.auth.RefreshTokenService.RefreshTokenException exp) {
+        ExceptionResponse exceptionResponse = ExceptionResponse.builder()
+                .error(exp.getMessage())
+                .build();
+        return buildErrorResponse(exceptionResponse, UNAUTHORIZED);
+    }
+
     @ExceptionHandler(MessagingException.class)
     public ResponseEntity<Object> handleException(MessagingException exp) {
         ExceptionResponse exceptionResponse = ExceptionResponse.builder()

--- a/src/main/java/com/tourya/api/models/RefreshToken.java
+++ b/src/main/java/com/tourya/api/models/RefreshToken.java
@@ -1,0 +1,61 @@
+package com.tourya.api.models;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Refresh token emitido por el sistema de auth.
+ * Usado para rotar access tokens sin re-login. Cada rotacion revoca el token
+ * anterior; el reuso de un token revocado revoca toda su familia (sesion).
+ * No extiende BaseEntity: issued_at + revoked_at + user_id cubren la trazabilidad
+ * y no hay lastModifiedBy relevante (el usuario es el mismo que crea).
+ */
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "refresh_token")
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Integer userId;
+
+    @Column(name = "jti", nullable = false, unique = true, length = 64)
+    private String jti;
+
+    @Column(name = "family_id", nullable = false, length = 64)
+    private String familyId;
+
+    @Column(name = "previous_jti", length = 64)
+    private String previousJti;
+
+    @Column(name = "issued_at", nullable = false)
+    private OffsetDateTime issuedAt;
+
+    @Column(name = "expires_at", nullable = false)
+    private OffsetDateTime expiresAt;
+
+    @Column(name = "revoked_at")
+    private OffsetDateTime revokedAt;
+
+    @Column(name = "revoked_reason", length = 50)
+    private String revokedReason;
+
+    @Column(name = "user_agent", length = 500)
+    private String userAgent;
+
+    @Column(name = "ip_address", length = 64)
+    private String ipAddress;
+}

--- a/src/main/java/com/tourya/api/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/tourya/api/repository/RefreshTokenRepository.java
@@ -1,0 +1,25 @@
+package com.tourya.api.repository;
+
+import com.tourya.api.models.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByJti(String jti);
+
+    @Modifying
+    @Query("UPDATE RefreshToken rt " +
+           "SET rt.revokedAt = :revokedAt, rt.revokedReason = :reason " +
+           "WHERE rt.familyId = :familyId AND rt.revokedAt IS NULL")
+    int revokeFamily(@Param("familyId") String familyId,
+                     @Param("revokedAt") OffsetDateTime revokedAt,
+                     @Param("reason") String reason);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -77,8 +77,10 @@ gcp.storage.bucket=${GCS_BUCKET:}
 
 #Security
 application.security.jwt.secret-key=${JWT_SECRET}
-# a day
+# access token: 1 dia
 application.security.jwt.expiration=86400000
+# refresh token: 30 dias por default; sobreescribir via JWT_REFRESH_EXPIRATION (ms)
+application.security.jwt.refresh-expiration=${JWT_REFRESH_EXPIRATION:2592000000}
 application.mailing.frontend.activation-url=${ACTIVATION_URL:http://44.203.38.85:8088/api/v1/auth/activar-cuenta-web?token=}
 #application.mailing.frontend.activation-url=http://localhost:8088/api/v1/auth/activar-cuenta-web?token=
 


### PR DESCRIPTION
… reuso

Implementa el sistema completo de refresh tokens para evitar que los usuarios pierdan sesion cada 24h (duracion del access token). El diseno es 100% backwards-compatible con clientes existentes.

Cambios de modelo:

- Migracion 067: tabla refresh_token con jti, family_id, previous_jti, issued_at, expires_at, revoked_at, revoked_reason. Indices en jti (unique), user_id, family_id, previous_jti.

Piezas nuevas:

- RefreshToken (entity) + RefreshTokenRepository con revokeFamily(bulk update).
- RefreshTokenService: issueForUser (nueva sesion), rotate (con deteccion de reuso), logout (revoca familia completa). Excepcion custom RefreshTokenException que se mapea a HTTP 401 via GlobalExceptionHandler.
- RefreshTokenRequest: DTO para /auth/refresh y /auth/logout.
- JwtService: nuevos metodos generateRefreshToken(subject, jti, familyId, previousJti), extractAllClaimsPublic, isExpired, getRefreshExpirationMs. Property nueva application.security.jwt.refresh-expiration (default 30 dias).

Endpoints nuevos:

- POST /auth/refresh: recibe {refreshToken}, valida, revoca el actual (rotated), emite un nuevo par access+refresh (misma familia). Si el token ya estaba revocado, revoca toda la familia y devuelve 401 (posible ataque de reuso).
- POST /auth/logout: recibe {refreshToken}, revoca la familia entera. Idempotente: si el token es invalido/desconocido tambien devuelve 204.

Backwards compat en /auth/authenticate y /auth/social-auth:

AuthenticationResponse ahora incluye 3 tokens simultaneos:
- token: legacy alias (mismo valor que accessToken) - Angular/MAUI actuales siguen leyendolo, sin cambio.
- accessToken: mismo valor - clientes nuevos deben migrar a este campo.
- refreshToken: nuevo campo con el refresh token JWT.

Los clientes NO se rompen: siguen leyendo "token" como antes. Cuando quieran usar el refresh flow, migran a leer accessToken + refreshToken.

Seguridad:

- Cada refresh rota: emite nuevo refresh, revoca el anterior.
- Deteccion de reuso: si un refresh revocado se usa de nuevo, se revoca la familia entera (logout global de la sesion). Loguea WARN con jti y family.
- Logout server-side: revocando la familia se invalidan todos los refresh tokens de la sesion (incluso si otro dispositivo tiene una copia).
- El refresh token es un JWT firmado con la misma clave que el access token, pero con claim type=refresh para diferenciarlos.
- La BD es la fuente autoritativa del estado (revocado o no); el JWT sirve solo para autoprobar la firma antes de ir a BD.

Riesgo para dev:

- Cero. Cambio 100% aditivo: nuevos endpoints, nueva tabla, campos nuevos en la response sin quitar los viejos. Clientes actuales siguen usando "token" como siempre.
- Migracion 067 YA ejecutada en tourya-dev-db (tabla refresh_token existe con 6 indices). Verificado.

Property nueva sin fallback:

application.security.jwt.refresh-expiration=\${JWT_REFRESH_EXPIRATION:2592000000}

Tiene default 30 dias hardcoded en el placeholder. NO requiere secret nuevo en Secret Manager ni cambios de env vars en Cloud Run. Deploy 100% listo.

Siguientes pasos (futuros PRs):

- Frontend Angular (FE-01): interceptor que llama /auth/refresh cuando el access token expira, mantiene sesion viva.
- Mobile MAUI: mismo flujo con SecureStorage para persistir el refresh token.
- Considerar bajar duracion del access token a 1h una vez Angular/MAUI usen el refresh flow (menor exposicion si se filtra el access).