### PR TITLE
feat(config): BE-06/07/08/09 configs a app_config con endpoint admin

### DIFF
--- a/database/migrations/068_app_config_seeds_bootstrap.sql
+++ b/database/migrations/068_app_config_seeds_bootstrap.sql
@@ -1,0 +1,28 @@
+-- Migration 068: Seeds default en app_config para BE-06/07/08
+-- Date: 2026-07-09
+-- Description:
+--   Inserta 3 configuraciones default que hasta ahora estaban hardcoded en el codigo:
+--     - HOLD_MINUTES: minutos de duracion del hold temporal del carrito (ReservationService)
+--     - PAYOUT_BUFFER_DAYS: dias entre fecha de la reserva y payout al proveedor
+--     - CREDIT_EXPIRATION_MONTHS: meses de vigencia de un credito emitido (default: 6)
+--
+--   La tabla app_config YA EXISTE en la BD (creada fuera del sistema de migraciones);
+--   este script solo agrega filas idempotentemente con ON CONFLICT DO NOTHING.
+--   Los servicios refactorizados leen estos valores via AppConfigService.getInt(key, fallback),
+--   asi que si por alguna razon estas filas no estan, la app usa el fallback hardcoded.
+
+INSERT INTO public.app_config (config_key, config_value, description, created_date, created_by)
+VALUES
+    ('HOLD_MINUTES',
+     '{"value": 15}'::jsonb,
+     'Minutos que dura el hold temporal de una reserva antes de expirar. Usado por ReservationService al crear reservas TEMPORAL.',
+     now(), 1),
+    ('PAYOUT_BUFFER_DAYS',
+     '{"value": 2}'::jsonb,
+     'Dias entre la fecha de la reserva y la fecha en que el proveedor puede recibir el payout. Usado al confirmar el pago para setear reservation.payout_available_date.',
+     now(), 1),
+    ('CREDIT_EXPIRATION_MONTHS',
+     '{"value": 6}'::jsonb,
+     'Meses de vigencia de un credito emitido tras cancelacion de reserva. Usado al crear el Credit para setear expirationDate.',
+     now(), 1)
+ON CONFLICT (config_key) DO NOTHING;

--- a/src/main/java/com/tourya/api/constans/enums/ConfigKeyEnum.java
+++ b/src/main/java/com/tourya/api/constans/enums/ConfigKeyEnum.java
@@ -7,7 +7,10 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public enum ConfigKeyEnum {
-    CANCELLATION_POLICY("CANCELLATION_POLICY");
+    CANCELLATION_POLICY("CANCELLATION_POLICY"),
+    HOLD_MINUTES("HOLD_MINUTES"),
+    PAYOUT_BUFFER_DAYS("PAYOUT_BUFFER_DAYS"),
+    CREDIT_EXPIRATION_MONTHS("CREDIT_EXPIRATION_MONTHS");
 
     private String value;
 

--- a/src/main/java/com/tourya/api/controller/AppConfigController.java
+++ b/src/main/java/com/tourya/api/controller/AppConfigController.java
@@ -1,6 +1,8 @@
 package com.tourya.api.controller;
 
 import com.tourya.api.constans.enums.ConfigKeyEnum;
+import com.tourya.api.models.AppConfig;
+import com.tourya.api.models.request.AppConfigUpsertRequest;
 import com.tourya.api.services.AppConfigService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -8,9 +10,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -45,19 +49,48 @@ public class AppConfigController {
             @ApiResponse(responseCode = "404", description = "Configuración no encontrada")
     })
     public ResponseEntity<Map<String, Object>> getConfig(
-            @Parameter(description = "Clave de la configuración (ej: CANCELLATION_POLICY)") 
+            @Parameter(description = "Clave de la configuración (ej: CANCELLATION_POLICY)")
             @PathVariable String configKey) {
         log.info("Getting config for key: {}", configKey);
-        
+
         ConfigKeyEnum keyEnum;
         try {
             keyEnum = ConfigKeyEnum.of(configKey);
         } catch (Exception e) {
             return ResponseEntity.notFound().build();
         }
-        
+
         Map<String, Object> configValue = appConfigService.getConfigValue(keyEnum);
         return ResponseEntity.ok(configValue);
+    }
+
+    /**
+     * Upsert de una configuracion por clave. Solo ADMIN.
+     * Body: { "value": {...}, "description": "..." } — description es opcional.
+     */
+    @PutMapping("/{configKey}")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Crear o actualizar configuracion",
+            description = "Solo ADMIN. Upsert por clave. El cuerpo debe incluir 'value' (Map<String,Object>).")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Configuracion guardada"),
+            @ApiResponse(responseCode = "400", description = "Clave desconocida o body invalido"),
+            @ApiResponse(responseCode = "403", description = "No autorizado (rol ADMIN requerido)")
+    })
+    public ResponseEntity<AppConfig> upsertConfig(
+            @Parameter(description = "Clave de la configuracion (ej: HOLD_MINUTES)")
+            @PathVariable String configKey,
+            @Valid @RequestBody AppConfigUpsertRequest request) {
+        log.info("Upserting config for key: {}", configKey);
+
+        ConfigKeyEnum keyEnum;
+        try {
+            keyEnum = ConfigKeyEnum.of(configKey);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
+        AppConfig saved = appConfigService.upsertConfig(keyEnum, request.getValue(), request.getDescription());
+        return ResponseEntity.ok(saved);
     }
 }
 

--- a/src/main/java/com/tourya/api/models/request/AppConfigUpsertRequest.java
+++ b/src/main/java/com/tourya/api/models/request/AppConfigUpsertRequest.java
@@ -1,0 +1,17 @@
+package com.tourya.api.models.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+public class AppConfigUpsertRequest {
+
+    @NotNull(message = "value is mandatory")
+    private Map<String, Object> value;
+
+    private String description;
+}

--- a/src/main/java/com/tourya/api/services/AppConfigService.java
+++ b/src/main/java/com/tourya/api/services/AppConfigService.java
@@ -9,7 +9,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Servicio para gestionar configuraciones del sistema.
@@ -44,17 +46,67 @@ public class AppConfigService {
 
     /**
      * Obtiene la configuración completa por su clave
-     * 
+     *
      * @param configKey Clave de la configuración
      * @return Entidad AppConfig
      */
     @Transactional(readOnly = true)
     public AppConfig getConfig(ConfigKeyEnum configKey) {
         log.info("Getting config for key: {}", configKey.getValue());
-        
+
         return appConfigRepository.findByConfigKey(configKey.getValue())
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Config not found with key: " + configKey.getValue()));
+    }
+
+    /**
+     * Lee un valor entero de app_config con fallback silencioso al valor default.
+     * Usa el JSON pattern `{"value": N}`. Si la key no existe o el JSON no tiene "value"
+     * o no es numerico, retorna el fallback (comportamiento equivalente al hardcoded).
+     * NO lanza excepcion: uso desde servicios criticos que no deben fallar por config.
+     */
+    @Transactional(readOnly = true)
+    public int getInt(ConfigKeyEnum configKey, int fallback) {
+        Optional<AppConfig> found = appConfigRepository.findByConfigKey(configKey.getValue());
+        if (found.isEmpty()) {
+            return fallback;
+        }
+        Map<String, Object> raw = found.get().getConfigValue();
+        if (raw == null) {
+            return fallback;
+        }
+        Object v = raw.get("value");
+        if (v instanceof Number number) {
+            return number.intValue();
+        }
+        if (v instanceof String s) {
+            try {
+                return Integer.parseInt(s.trim());
+            } catch (NumberFormatException e) {
+                log.warn("app_config key={} tiene value no numerico ({}), usando fallback={}", configKey.getValue(), s, fallback);
+                return fallback;
+            }
+        }
+        log.warn("app_config key={} tiene formato inesperado, usando fallback={}", configKey.getValue(), fallback);
+        return fallback;
+    }
+
+    /**
+     * Upsert de configuracion por clave. Si existe, actualiza value y description; si no, crea.
+     * La auditoria (created_by / last_modified_by) se maneja automaticamente via JPA Auditing.
+     */
+    @Transactional
+    public AppConfig upsertConfig(ConfigKeyEnum configKey, Map<String, Object> value, String description) {
+        AppConfig entity = appConfigRepository.findByConfigKey(configKey.getValue())
+                .orElseGet(() -> AppConfig.builder()
+                        .configKey(configKey.getValue())
+                        .configValue(new HashMap<>())
+                        .build());
+        entity.setConfigValue(value);
+        if (description != null && !description.isBlank()) {
+            entity.setDescription(description);
+        }
+        return appConfigRepository.save(entity);
     }
 }
 

--- a/src/main/java/com/tourya/api/services/ReservationService.java
+++ b/src/main/java/com/tourya/api/services/ReservationService.java
@@ -70,9 +70,6 @@ import java.util.stream.Collectors;
 @Transactional
 public class ReservationService {
 
-    @Value("${tourya.reservations.holdMinutes:15}")
-    private int defaultHoldMinutes;
-
     private final ReservationRepository reservationRepository;
     private final PaymentRepository paymentRepository;
     private final ReservationMapper reservationMapper;
@@ -120,7 +117,9 @@ public class ReservationService {
                                                                                Authentication connectedUser) {
         User user = (User) connectedUser.getPrincipal();
         // Usar una referencia consistente (UTC) para evitar expiraciones inmediatas por desfase de zona horaria
-        LocalDateTime expiresAt = LocalDateTime.now(java.time.ZoneId.of("UTC")).plusMinutes(defaultHoldMinutes);
+        // Duracion del hold desde app_config (fallback 15 min si la key no esta seteada)
+        int holdMinutes = appConfigService.getInt(ConfigKeyEnum.HOLD_MINUTES, 15);
+        LocalDateTime expiresAt = LocalDateTime.now(java.time.ZoneId.of("UTC")).plusMinutes(holdMinutes);
 
         List<Long> requestedItemIds = new ArrayList<>();
         Map<Long, CreateTemporalReservationHoldRequest.ServiceResponsibleRequest> responsibleByItemId =
@@ -181,7 +180,7 @@ public class ReservationService {
                     .itemId(item.getId())
                     .qrUrl(null)
                     .reservationDate(reservationDateUtc)
-                    .payoutAvailableDate(reservationDateUtc.toLocalDate().plusDays(2))
+                    .payoutAvailableDate(reservationDateUtc.toLocalDate().plusDays(appConfigService.getInt(ConfigKeyEnum.PAYOUT_BUFFER_DAYS, 2)))
                     .payoutStatus(Reservation.PAYOUT_STATUS_PENDING)
                     .deliveryStatus(DeliveryStatusEnum.TEMPORAL)
                     .expiresAt(expiresAt)
@@ -1718,7 +1717,7 @@ public class ReservationService {
                 .amount(creditAmount)
                 .reservedAmount(BigDecimal.ZERO)
                 .creationDate(LocalDate.now())
-                .expirationDate(LocalDate.now().plusMonths(6))
+                .expirationDate(LocalDate.now().plusMonths(appConfigService.getInt(ConfigKeyEnum.CREDIT_EXPIRATION_MONTHS, 6)))
                 .status(CreditStatusEnum.CREATED)
                 .build();
         
@@ -1942,7 +1941,7 @@ public class ReservationService {
                     .amount(priceDifference)
                     .reservedAmount(BigDecimal.ZERO)
                     .creationDate(LocalDate.now())
-                    .expirationDate(LocalDate.now().plusMonths(6))
+                    .expirationDate(LocalDate.now().plusMonths(appConfigService.getInt(ConfigKeyEnum.CREDIT_EXPIRATION_MONTHS, 6)))
                     .status(CreditStatusEnum.CREATED)
                     .build();
             credit = creditRepository.save(credit);
@@ -2043,7 +2042,7 @@ public class ReservationService {
                 .amount(currentPrice)
                 .reservedAmount(BigDecimal.ZERO)
                 .creationDate(LocalDate.now())
-                .expirationDate(LocalDate.now().plusMonths(6))
+                .expirationDate(LocalDate.now().plusMonths(appConfigService.getInt(ConfigKeyEnum.CREDIT_EXPIRATION_MONTHS, 6)))
                 .status(CreditStatusEnum.CREATED)
                 .build();
         credit = creditRepository.save(credit);


### PR DESCRIPTION
Mueve 3 valores hardcoded del codigo a la tabla app_config (que ya existia solo con CANCELLATION_POLICY) para que ADMIN los ajuste desde backoffice sin re-deploy. Agrega PUT endpoint que faltaba para completar BE-09.

Cambios:

1. Migracion 068: seeds default en app_config (idempotente con ON CONFLICT):
   - HOLD_MINUTES = 15 (min del hold del carrito)
   - PAYOUT_BUFFER_DAYS = 2 (dias entre reserva y payout available)
   - CREDIT_EXPIRATION_MONTHS = 6 (meses de vigencia de credito) La tabla ya existia (no CREATE); solo INSERT.

2. ConfigKeyEnum: agregadas las 3 keys nuevas.

3. AppConfigService:
   - getInt(ConfigKeyEnum, int fallback): helper con fallback silencioso al valor default si la key no existe o el JSON no tiene "value" numerico. NO lanza excepcion: uso desde servicios criticos que no deben fallar por config incompleta.
   - upsertConfig(ConfigKeyEnum, Map<String,Object>, String description): upsert por clave. Auditoria via JPA Auditing automatica.

4. AppConfigController:
   - Nuevo PUT /config/{configKey} con @PreAuthorize("hasRole('ADMIN')"). Body: { value: {...}, description: "..." }. Retorna la entidad guardada.
   - DTO AppConfigUpsertRequest con @Valid.

5. ReservationService refactorizado (5 puntos):
   - Removido @Value("${tourya.reservations.holdMinutes:15}") + field.
   - createTemporalReservationHolds() lee HOLD_MINUTES via getInt(15).
   - Confirmacion de pago usa PAYOUT_BUFFER_DAYS via getInt(2) para setear reservation.payout_available_date.
   - Los 3 puntos donde se crea Credit ahora leen CREDIT_EXPIRATION_MONTHS via getInt(6). Correccion vs backlog: el codigo real usa 6 meses (no 1 ano como decia el backlog); mantengo 6 para no cambiar comportamiento.

Riesgo para dev: CERO.

- Aditivo puro: seeds nuevos, keys nuevas en enum, nuevo endpoint PUT.
- Todos los refactors llevan fallback al valor hardcoded original -> si por alguna razon las filas de app_config no estan, los servicios funcionan identico a antes.
- Migracion 068 YA ejecutada en tourya-dev-db (verificado).

Cambio de comportamiento observable:

Ninguno inmediato. Si algun dia ADMIN cambia un valor via PUT /config/xxx, las proximas reservas / creditos / payouts usaran el nuevo valor sin deploy.

Ejemplo de uso desde ADMIN:

  curl -X PUT https://.../api/v1/config/HOLD_MINUTES \
    -H "Authorization: Bearer <ADMIN_TOKEN>" \
    -H "Content-Type: application/json" \
    -d '{"value": {"value": 30}, "description": "Ampliado a 30 min por temporada alta"}'

Nota: el JSONB usa el patron {"value": N} para tipos escalares. Configs complejas como CANCELLATION_POLICY usan JSON estructurado directo (no requieren el wrapper).