### PR TITLE
feat(pricing): BE-01/02 reactivar tour.porcentaje_tourya como default…

### DIFF
--- a/database/migrations/071_tour_porcentaje_tourya_default_15.sql
+++ b/database/migrations/071_tour_porcentaje_tourya_default_15.sql
@@ -1,0 +1,30 @@
+-- Migration 071: Reactivar tour.porcentaje_tourya como default del tour
+-- Date: 2026-07-09
+-- Description:
+--   El campo tour.porcentaje_tourya se agrego en la migracion 043 y despues
+--   se marco como "DEPRECATED" en la 050 al mover la logica al slot. Sin embargo
+--   Luis (RN-015) confirmo que el campo debe existir como el default por tour
+--   que se hereda al crear cada slot. Esta migracion:
+--     1) Hace backfill: pone 0.15 (15%) en todos los tours que hoy tienen 0 o NULL.
+--     2) Cambia el DEFAULT de la columna a 0.15 para nuevos tours.
+--     3) Actualiza el COMMENT quitando "DEPRECATED" y explicando el nuevo rol.
+--
+--   Impacto:
+--   - El campo tour.porcentaje_tourya NO se lee en el codigo hoy, entonces el
+--     backfill no cambia comportamiento observable inmediato.
+--   - En el PR de codigo asociado, TourScheduleConfigGeneralService al crear un
+--     nuevo slot hereda este valor en vez de setear ZERO. Los slots ya existentes
+--     con slot_porcentaje_tourya especifico NO se tocan.
+--   - sp_get_tour_schedule_json y demas SPs ya usan slot_porcentaje_tourya (no
+--     tour.porcentaje_tourya), asi que no hay cambio en calculo de precios de
+--     tours existentes.
+
+UPDATE public.tour
+SET porcentaje_tourya = 0.15
+WHERE porcentaje_tourya IS NULL OR porcentaje_tourya = 0;
+
+ALTER TABLE public.tour
+    ALTER COLUMN porcentaje_tourya SET DEFAULT 0.15;
+
+COMMENT ON COLUMN public.tour.porcentaje_tourya IS
+    'Porcentaje Tourya default del tour (fraccion decimal, ej. 0.15 = 15%). Solo editable por backoffice Tourya. Se hereda al crear un nuevo tour_schedule_config_slot como valor inicial de slot_porcentaje_tourya. El slot puede tener override por dia via tour_schedule_slot_override.';

--- a/src/main/java/com/tourya/api/services/TourScheduleConfigGeneralService.java
+++ b/src/main/java/com/tourya/api/services/TourScheduleConfigGeneralService.java
@@ -139,12 +139,19 @@ public class TourScheduleConfigGeneralService {
             slot.setAvailability(cap0);
             tourScheduleSlotAvailabilityService.applyMinCapacityAndCheckAvailability(slot, tourForConfig);
 
-            slot.setSlotPorcentajeTourya(BigDecimal.ZERO);
+            // BE-02 (RN-015): heredar el porcentaje default del tour para nuevos slots.
+            // Antes se seteaba en ZERO y el ADMIN tenia que llamar despues a
+            // PUT /tour-schedules/tours/{tourId}/percentage. Ahora nace ya con el valor
+            // del tour; el ADMIN puede sobrescribirlo por rango de fechas via override.
+            BigDecimal tourDefaultPct = tourForConfig != null && tourForConfig.getPorcentajeTourya() != null
+                    ? tourForConfig.getPorcentajeTourya()
+                    : BigDecimal.ZERO;
+            slot.setSlotPorcentajeTourya(tourDefaultPct);
 
             if (slotDto.getPrices() != null) {
                 Set<TourScheduleConfigPrice> prices = new HashSet<>();
                 for (TourScheduleConfigPriceDto priceDto : slotDto.getPrices()) {
-                    TourScheduleConfigPrice price = buildPriceEntity(slot, priceDto, BigDecimal.ZERO, roleList);
+                    TourScheduleConfigPrice price = buildPriceEntity(slot, priceDto, tourDefaultPct, roleList);
                     prices.add(price);
                 }
                 slot.setPrices(prices);
@@ -286,11 +293,17 @@ public class TourScheduleConfigGeneralService {
             currentSlot.setAvailability(capVal != null ? Math.max(0, capVal - booked) : 0);
             tourScheduleSlotAvailabilityService.applyMinCapacityAndCheckAvailability(currentSlot, tourForConfig);
 
+            // BE-02 (RN-015): para slots nuevos, heredar el porcentaje default del tour.
+            // Slots existentes conservan su slot_porcentaje_tourya actual (posiblemente
+            // override manual del ADMIN).
+            BigDecimal tourDefaultPct = tourForConfig != null && tourForConfig.getPorcentajeTourya() != null
+                    ? tourForConfig.getPorcentajeTourya()
+                    : BigDecimal.ZERO;
             BigDecimal slotPct = isNewSlot
-                    ? BigDecimal.ZERO
+                    ? tourDefaultPct
                     : TouryaPriceCalculator.normalizePercentage(currentSlot.getSlotPorcentajeTourya());
             if (isNewSlot) {
-                currentSlot.setSlotPorcentajeTourya(BigDecimal.ZERO);
+                currentSlot.setSlotPorcentajeTourya(tourDefaultPct);
             }
 
             updateSlotPrices(currentSlot, new HashSet<>(slotDto.getPrices()), slotPct, roleList);


### PR DESCRIPTION
… heredable

RN-015: el porcentaje Tourya por tour se convierte en el valor default que heredan los slots al crearse. Antes cada slot nuevo nacia con 0 y el ADMIN tenia que llamar despues a PUT /tour-schedules/tours/{tourId}/percentage para setear el valor real. Ahora nace con el porcentaje del tour desde el primer slot; el ADMIN puede seguir sobrescribiendo por rango de fechas via tour_schedule_slot_override.

Reactivacion del campo:

El campo tour.porcentaje_tourya existe desde la migracion 043 pero se marco como "DEPRECATED" en la 050 al mover la logica al slot. Luis (2026-07-07, doc 00-README) confirmo el rol de default por tour. El codigo no lo leia en ninguna parte; solo se seteaba via el endpoint UpdatePorcentajeTouryaRequest. Esta implementacion lo activa donde importa: creacion de slots.

Cambios:

1. Migracion 071:
   - Backfill: UPDATE tour SET porcentaje_tourya = 0.15 WHERE porcentaje_tourya IS NULL OR = 0. En dev afecta 38 tours (todos los existentes tenian 0/NULL). El backfill no cambia comportamiento observable porque el campo no se lee todavia en calculos.
   - ALTER: DEFAULT = 0.15 para nuevos tours.
   - COMMENT actualizado: quita "DEPRECATED" y explica el nuevo rol.

2. TourScheduleConfigGeneralService en 2 puntos:

   a. buildSlots(): al crear TourScheduleConfigSlot nuevo, usar tourForConfig.getPorcentajeTourya() en vez de BigDecimal.ZERO. Tambien se propaga al buildPriceEntity para el calculo de precios.

   b. manageSlotsUpdate() para slots nuevos (isNewSlot=true): mismo cambio. Slots existentes conservan su slot_porcentaje_tourya actual (posibles overrides manuales del ADMIN).

   Fallback en ambos puntos: si tour == null o porcentaje == null, usa BigDecimal.ZERO como hoy. Zero risk.

3. NO se hizo rename porcentaje_tourya -> percentage_tourya. Aunque el backlog usa nombre en ingles, renombrarlo tocaria: entity + SP + endpoint publico + DTO UpdatePorcentajeTouryaRequest + 6 SPs que referencian slot_porcentaje_tourya. Alto riesgo por un mero rename. Franklin confirmo mantener nombre en espanol.

Impacto en dev:

- 38 tours ya existentes: backfilleados a 0.15 en migracion. No cambia visualizacion porque los slots ya existen con su slot_porcentaje_tourya (0 en la mayoria).
- Tours nuevos post-deploy: nacen con 0.15 por default.
- Slots nuevos post-deploy: nacen con el porcentaje del tour (0.15 por default, o lo que Luis haya ajustado por tour). Antes nacian con 0.

Migracion 071 YA ejecutada en tourya-dev-db (verificado: 38 tours actualizados, DEFAULT column = 0.15).

Fuera de scope:

- Rename porcentaje_tourya -> percentage_tourya (alto costo/bajo valor).
- Slots ya existentes con slot_porcentaje_tourya = 0: no se tocan. Si el ADMIN quiere aplicar el default a slots viejos, puede usar PUT /tour-schedules/tours/{tourId}/percentage manualmente.