### PR TITLE
feat(reservations): BE-05 agregar razones LEGAL_OBLIGATIONS y CHANGE_…

### DIFF
--- a/src/main/java/com/tourya/api/constans/enums/CancellationReasonEnum.java
+++ b/src/main/java/com/tourya/api/constans/enums/CancellationReasonEnum.java
@@ -25,7 +25,17 @@ public enum CancellationReasonEnum {
     /**
      * Cancelación por lluvia (DIMAR). Solo vía {@code PUT /reservations/{id}/cancel/rain}.
      */
-    RAIN
+    RAIN,
+
+    /**
+     * Obligaciones legales del turista (BE-05, aprobado Luis 2026-07-07, RN-030).
+     */
+    LEGAL_OBLIGATIONS,
+
+    /**
+     * Cambio de planes del turista (BE-05, aprobado Luis 2026-07-07, RN-030).
+     */
+    CHANGE_OF_PLANS
 }
 
 


### PR DESCRIPTION
…OF_PLANS

Agrega 2 valores al final de CancellationReasonEnum segun RN-030 (aprobado por Luis 2026-07-07):
  - LEGAL_OBLIGATIONS: obligaciones legales del turista.
  - CHANGE_OF_PLANS: cambio de planes del turista.

Sin migracion SQL:

La columna reservation.cancellation_reason es VARCHAR(20) y persiste los strings del enum tal cual (verificado en dev). Ambos valores nuevos caben (17 y 15 caracteres). Los valores existentes en dev (CANNOT_ATTEND=40, RAIN=3) se mantienen sin cambios.

Sin cambios en:

- Reservation entity y CancelReservationRequest DTO: ya usan el enum, las nuevas razones se aceptan automaticamente al deserializar strings del cliente.
- SPs sp_get_provider_reservations y variantes: ya declaran cancellation_reason como character varying, no requieren modificacion.

Frontend/Mobile (FE-06 pendiente): agregar las 2 opciones al dropdown de razones de cancelacion en el cliente. Sin ese cambio el turista no podra elegir estas nuevas razones desde la UI, pero el endpoint las acepta si se envian directamente.

Riesgo: 🟢 CERO. Aditivo puro al final del enum. Ningun valor existente se ve afectado.