### PR TITLE
chore(smtp): elimina referencias a noreply@wass.com.co

### DIFF
--- a/src/main/java/com/tourya/api/config/OpenApiConfig.java
+++ b/src/main/java/com/tourya/api/config/OpenApiConfig.java
@@ -15,7 +15,7 @@ import io.swagger.v3.oas.annotations.servers.Server;
         info = @Info(
                 contact = @Contact(
                         name = "Tourya",
-                        email = "noreply@wass.com.co",
+                        email = "noreply@tourya.co",
                         url = "https://tourya.co"
                 ),
                 description = "API Tourya — incluye ajustes 27/05/2026 (reviews, reservas, payout, créditos, operadores).",

--- a/src/main/java/com/tourya/api/config/auth/AuthenticationService.java
+++ b/src/main/java/com/tourya/api/config/auth/AuthenticationService.java
@@ -290,7 +290,10 @@ public class AuthenticationService {
         // Generar una contraseña temporal segura
         return UUID.randomUUID().toString().substring(0, 16); // Ejemplo
     }
+    @Value("${spring.mail.username}")
+    private String mailUsername;
+
     public void sendEmailTest(){
-        emailService.sendSimpleMessage("noreply@wass.com.co",  "test-email", "Prueba de email");
+        emailService.sendSimpleMessage(mailUsername,  "test-email", "Prueba de email");
     }
 }


### PR DESCRIPTION
Complemento del switch de MAIL_USERNAME a luis.mendoza@tourya.co en Cloud Run (env var + secret version 2 aplicados el 2026-07-10).

- OpenApiConfig: contact email de Swagger a noreply@tourya.co.
- AuthenticationService.sendEmailTest(): el destinatario ya no está hardcoded a WASS. Ahora usa spring.mail.username (auto-envío) para que funcione como health check sin filtrar dominios ajenos.

SPF/DKIM/DMARC del dominio tourya.co siguen pendientes en el DNS de GoDaddy — los correos salen pero caen en spam hasta que Luis los configure. Bloqueante para prod, tolerable en dev.