### PR TITLE
fix(auth): AppConfigController usa hasAuthority en vez de hasRole

### DIFF
--- a/src/main/java/com/tourya/api/controller/AppConfigController.java
+++ b/src/main/java/com/tourya/api/controller/AppConfigController.java
@@ -69,7 +69,7 @@ public class AppConfigController {
      * Body: { "value": {...}, "description": "..." } — description es opcional.
      */
     @PutMapping("/{configKey}")
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasAuthority('ADMIN')")
     @Operation(summary = "Crear o actualizar configuracion",
             description = "Solo ADMIN. Upsert por clave. El cuerpo debe incluir 'value' (Map<String,Object>).")
     @ApiResponses(value = {


### PR DESCRIPTION
Bug detectado al probar el panel FE-04 con un usuario ADMIN real: PUT /config/{key} devolvia 500 con AuthorizationDeniedException aunque el JWT tuviera authorities=[USER, ADMIN].

Causa: en Spring Security, @PreAuthorize("hasRole('ADMIN')") equivale a hasAuthority('ROLE_ADMIN') — agrega el prefijo ROLE_ al comparar. Pero User.getAuthorities() en este proyecto devuelve las authorities SIN prefijo (solo "USER", "ADMIN", "PROVIDER", etc), asi que hasRole falla siempre contra cualquier usuario.

Fix quirurgico: cambiar a hasAuthority('ADMIN'), que compara literal contra los valores tal como los pone User. Es el unico @PreAuthorize con hasRole en el proyecto, no hay riesgo de contagio.

Alternativa descartada (fix global): agregar prefijo ROLE_ en User.getAuthorities(). Cambia el comportamiento de todas las verificaciones de autoridad; muchas partes del codigo asumen los valores sin prefijo. Se documenta como deuda futura si algun dia decidimos alinearnos al idioma Spring: entonces auditar todos los `.getAuthority()` y decidir en bloque.

Endpoint afectado: PUT /config/{configKey} — BE-09 (PR #160).