### PR TITLE
feat(admin): PATCH /tours/admin/{tourId}/porcentajeTourya (FE-05 back…

### DIFF
--- a/src/main/java/com/tourya/api/controller/TourController.java
+++ b/src/main/java/com/tourya/api/controller/TourController.java
@@ -20,6 +20,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import com.tourya.api.models.request.TourFullDataRequest;
+import com.tourya.api.models.request.UpdatePorcentajeTouryaRequest;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -49,6 +51,14 @@ public class TourController {
             @PathVariable("tourId") Integer tourId, Authentication connectedUser){
         return ResponseEntity.ok(tourService.acceptTourByIdToAdmin(tourId, connectedUser));
     }
+    @PatchMapping("/admin/{tourId}/porcentajeTourya")
+    public ResponseEntity<TourFullDataResponse> updatePorcentajeTourya (
+            @PathVariable("tourId") Integer tourId,
+            @Valid @RequestBody UpdatePorcentajeTouryaRequest request,
+            Authentication connectedUser){
+        return ResponseEntity.ok(tourService.updatePorcentajeTouryaByAdmin(tourId, request, connectedUser));
+    }
+
     @PutMapping("/admin/returnedTourById/{tourId}")
     public ResponseEntity<TourFullDataResponse> returnedTourById (
             @PathVariable("tourId") Integer tourId, Authentication connectedUser){

--- a/src/main/java/com/tourya/api/models/request/UpdatePorcentajeTouryaRequest.java
+++ b/src/main/java/com/tourya/api/models/request/UpdatePorcentajeTouryaRequest.java
@@ -1,5 +1,6 @@
 package com.tourya.api.models.request;
 
+import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
@@ -11,5 +12,6 @@ public class UpdatePorcentajeTouryaRequest {
 
     @NotNull
     @DecimalMin(value = "0.0", inclusive = true)
+    @DecimalMax(value = "1.0", inclusive = true)
     private BigDecimal porcentajeTourya;
 }

--- a/src/main/java/com/tourya/api/services/TourService.java
+++ b/src/main/java/com/tourya/api/services/TourService.java
@@ -733,6 +733,36 @@ public class TourService {
             throw new InsufficientPrivilegesException(NOT_PRIVILEGES);
         }
     }
+    public TourFullDataResponse updatePorcentajeTouryaByAdmin(Integer tourId, UpdatePorcentajeTouryaRequest request, Authentication connectedUser){
+        User user = ((User) connectedUser.getPrincipal());
+        List<Role> roleList = user.getRoles();
+        if(Utils.isTouryaBackoffice(roleList)){
+            Optional<Tour> optionalTour = tourRepository.findById(tourId);
+            if(optionalTour.isPresent()){
+                Tour tour = optionalTour.get();
+                tour.setPorcentajeTourya(request.getPorcentajeTourya());
+                Tour tourUpdate = tourRepository.save(tour);
+                List<Integer> tagIds = tourTagsRepository.getTagIdsByTourId(tourId);
+                return tourMapper.toTourFullDataResponse(
+                        tourUpdate,
+                        consultDataTourAddressListByTourId(tourId),
+                        getAllByTourMainAttractions(tourId),
+                        getAllByTourIncludesExcludes(tourId, IncludeExcludeTypeEnum.INCLUDE),
+                        getAllByTourIncludesExcludes(tourId, IncludeExcludeTypeEnum.EXCLUDE),
+                        getAllByTourFaqs(tourId),
+                        getAllByTourItineraries(tourId),
+                        getAllByTourCancellationPolicy(tourId),
+                        null,
+                        tagIds
+                );
+            }else{
+                throw new ResourceNotFoundException("Tour not found with id = "+tourId);
+            }
+        }else{
+            throw new InsufficientPrivilegesException(NOT_PRIVILEGES);
+        }
+    }
+
     public TourFullDataResponse returnedTourByIdToAdmin(Integer tourId, Authentication connectedUser){
         User user = ((User) connectedUser.getPrincipal());
         List<Role> roleList = user.getRoles();


### PR DESCRIPTION
…end)

Habilita el DTO UpdatePorcentajeTouryaRequest que estaba definido pero sin usar desde el PR #163 (BE-01/02). Cierra el bucle con RN-015: el ADMIN puede ajustar el porcentaje Tourya del tour al momento de aprobarlo (o antes/despues, aunque la UI en v1 solo lo expone en el flujo de aprobacion).

Cambios:
- UpdatePorcentajeTouryaRequest: agregado @DecimalMax(1.0) para no permitir valores fuera del rango 0-1 (viene de BigDecimal, ej. 0.15).
- TourService.updatePorcentajeTouryaByAdmin(tourId, request, connectedUser): valida rol BACKOFFICE (ADMIN + BACKOFFICE_OPERATION) con el patron Utils.isTouryaBackoffice del proyecto, busca el tour, actualiza el campo y retorna el TourFullDataResponse completo (igual que acceptTourByIdToAdmin, para que el frontend refresque su estado).
- TourController: PATCH /admin/{tourId}/porcentajeTourya con @Valid.

No modifica acceptTourById — el flujo de aprobacion queda separado del flujo de update del %, permitiendo que la UI llame primero al PATCH si el admin cambio el valor y luego al PUT accept.