### PR TITLE
feat(auth): SEC-06 Fase A — validacion server-side de tokens sociales…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,8 +118,8 @@
 			<artifactId>modelmapper</artifactId>
 			<version>3.2.1</version>
 		</dependency>-->
-		<!-- https://mvnrepository.com/artifact/com.google.api-client/google-api-client -->
-		<!--<dependency>
+		<!-- SEC-06: verificacion de id_token de Google (Token Exchange) -->
+		<dependency>
 			<groupId>com.google.api-client</groupId>
 			<artifactId>google-api-client</artifactId>
 			<version>2.7.2</version>
@@ -129,7 +129,7 @@
 					<artifactId>commons-logging</artifactId>
 				</exclusion>
 			</exclusions>
-		</dependency>-->
+		</dependency>
 		<dependency>
 			<groupId>com.networknt</groupId>
 			<artifactId>json-schema-validator</artifactId>

--- a/src/main/java/com/tourya/api/config/auth/AuthenticationController.java
+++ b/src/main/java/com/tourya/api/config/auth/AuthenticationController.java
@@ -55,11 +55,30 @@ public class AuthenticationController {
     }
 
     @PostMapping("/social-auth")
-    @Operation(summary = "Login social (Google)")
+    @Operation(summary = "[DEPRECATED SEC-06] Login social sin validacion",
+            description = "Sin validacion server-side del token del proveedor. Mantiene compatibilidad con el frontend viejo mientras se despliega Fase B de SEC-06. Sera removido en la Fase C.")
     public ResponseEntity<AuthenticationResponse> authenticateWithSocial(
             @RequestBody @Valid SocialAuthRequest request
     ){
         return ResponseEntity.ok(service.authenticateWithSocial(request));
+    }
+
+    @PostMapping("/google")
+    @Operation(summary = "Login con Google (Token Exchange, SEC-06)",
+            description = "Recibe el id_token que emitio Google Identity Services, valida su firma contra las claves publicas de Google y verifica que el audience sea el client id de Tourya. Emite JWT propio.")
+    public ResponseEntity<AuthenticationResponse> authenticateWithGoogle(
+            @RequestBody @Valid com.tourya.api.config.auth.request.GoogleAuthRequest request
+    ){
+        return ResponseEntity.ok(service.authenticateWithGoogle(request));
+    }
+
+    @PostMapping("/facebook")
+    @Operation(summary = "Login con Facebook (Token Exchange, SEC-06)",
+            description = "Recibe el accessToken que emitio Facebook JS SDK, lo valida via Graph API debug_token y obtiene el perfil. Emite JWT propio.")
+    public ResponseEntity<AuthenticationResponse> authenticateWithFacebook(
+            @RequestBody @Valid com.tourya.api.config.auth.request.FacebookAuthRequest request
+    ){
+        return ResponseEntity.ok(service.authenticateWithFacebook(request));
     }
 
     @PostMapping("/refresh")

--- a/src/main/java/com/tourya/api/config/auth/AuthenticationService.java
+++ b/src/main/java/com/tourya/api/config/auth/AuthenticationService.java
@@ -2,6 +2,8 @@ package com.tourya.api.config.auth;
 
 import com.tourya.api._utils.Utils;
 import com.tourya.api.config.auth.request.AuthenticationRequest;
+import com.tourya.api.config.auth.request.FacebookAuthRequest;
+import com.tourya.api.config.auth.request.GoogleAuthRequest;
 import com.tourya.api.config.auth.request.SocialAuthRequest;
 import com.tourya.api.config.auth.request.RegistrationRequest;
 import com.tourya.api.config.auth.response.AuthenticationResponse;
@@ -52,6 +54,8 @@ public class AuthenticationService {
     private final TokenRepository tokenRepository;
     private final RefreshTokenService refreshTokenService;
     private final AppConfigService appConfigService;
+    private final GoogleTokenVerifier googleTokenVerifier;
+    private final FacebookTokenVerifier facebookTokenVerifier;
 
     private static final long MAX_LOCKOUT_SECONDS = 24 * 60 * 60L;
 
@@ -249,40 +253,94 @@ public class AuthenticationService {
         tokenRepository.save(savedToken);
     }
 
+    /**
+     * SEC-06 legacy: recibe datos del proveedor SIN validarlos.
+     * Vulnerabilidad conocida (RN-006) — mantenido temporalmente durante la transición.
+     * Marcar @Deprecated y eliminar en la Fase C de SEC-06 (después de validar
+     * los endpoints /auth/google y /auth/facebook por N dias en dev).
+     */
+    @Deprecated
     @Transactional
     public AuthenticationResponse authenticateWithSocial(SocialAuthRequest request){
         if (!Utils.isValidEmail(request.getEmail())) {
             throw new EmailInvalidFormatException("Invalid email format: " + request.getEmail());
         }
-        User user = userRepository.findByEmail(request.getEmail().toLowerCase()).orElse(null);
+        VerifiedSocialUser verified = new VerifiedSocialUser(
+                request.getUuidSocial(),
+                request.getEmail(),
+                request.getFirstname(),
+                request.getLastname());
+        return authenticateOrCreateSocialUser(verified);
+    }
+
+    /**
+     * SEC-06: login con Google verificado server-side.
+     * <p>Valida el id_token contra las claves publicas de Google (audience =
+     * GOOGLE_CLIENT_ID) y verifica {@code email_verified = true} antes de
+     * crear/buscar el usuario.</p>
+     */
+    @Transactional
+    public AuthenticationResponse authenticateWithGoogle(GoogleAuthRequest request) {
+        VerifiedSocialUser verified = googleTokenVerifier.verify(request.getIdToken());
+        return authenticateOrCreateSocialUser(verified);
+    }
+
+    /**
+     * SEC-06: login con Facebook verificado server-side.
+     * <p>Valida el accessToken via Graph API (debug_token) y obtiene el perfil
+     * (/me).</p>
+     */
+    @Transactional
+    public AuthenticationResponse authenticateWithFacebook(FacebookAuthRequest request) {
+        VerifiedSocialUser verified = facebookTokenVerifier.verify(request.getAccessToken());
+        return authenticateOrCreateSocialUser(verified);
+    }
+
+    /**
+     * Ruta comun para login social ya verificado: crea el usuario si no existe,
+     * lo habilita si esta deshabilitado, emite JWT propio de Tourya. La
+     * vinculacion se hace por email (RN-006, seccion 9 del doc de propuesta —
+     * opcion A: vincular por email verificado).
+     */
+    private AuthenticationResponse authenticateOrCreateSocialUser(VerifiedSocialUser verified) {
+        if (!Utils.isValidEmail(verified.email())) {
+            throw new EmailInvalidFormatException("Invalid email format: " + verified.email());
+        }
+        String normalizedEmail = verified.email().toLowerCase();
+        User user = userRepository.findByEmail(normalizedEmail).orElse(null);
         if (user == null) {
-            // Registrar al usuario
             var userRole = roleRepository.findByName("USER")
                     .orElseThrow(() -> new IllegalStateException("ROLE USER was not initiated"));
             String tempPassword = generateTemporaryPassword();
             User newUser = User.builder()
-                    .firstname(request.getFirstname())
-                    .lastname(request.getLastname())
-                    .email(request.getEmail().toLowerCase())
+                    .firstname(verified.firstname())
+                    .lastname(verified.lastname())
+                    .email(normalizedEmail)
                     .password(passwordEncoder.encode(tempPassword))
                     .accountLocked(false)
-                    .enabled(true) // Google ya verificó el correo electrónico
+                    .enabled(true) // el proveedor ya verificó el correo (email_verified para Google, presencia para Facebook)
                     .roles(List.of(userRole))
-                    .uuidSocial(request.getUuidSocial())
+                    .uuidSocial(verified.providerSubject())
                     .build();
             userRepository.save(newUser);
-
             RefreshTokenService.IssuedTokens tokens = refreshTokenService.issueForUser(newUser);
             return buildAuthResponse(newUser, tokens, newUser.isMustChangePassword());
-        } else if (!user.isEnabled()) {
-            user.setEnabled(true);
-            userRepository.save(user);
-
-            RefreshTokenService.IssuedTokens tokens = refreshTokenService.issueForUser(user);
-            return buildAuthResponse(user, tokens, user.isMustChangePassword());
         }
-
-        // El usuario ya existe y está habilitado
+        boolean modified = false;
+        if (!user.isEnabled()) {
+            user.setEnabled(true);
+            modified = true;
+        }
+        // Refresh del providerSubject: si el usuario venia de Firebase con un UID
+        // viejo, se sobreescribe al primer login por Token Exchange.
+        if (verified.providerSubject() != null && !verified.providerSubject().isBlank()
+                && !verified.providerSubject().equals(user.getUuidSocial())) {
+            user.setUuidSocial(verified.providerSubject());
+            modified = true;
+        }
+        if (modified) {
+            userRepository.save(user);
+        }
         RefreshTokenService.IssuedTokens tokens = refreshTokenService.issueForUser(user);
         return buildAuthResponse(user, tokens, user.isMustChangePassword());
     }

--- a/src/main/java/com/tourya/api/config/auth/FacebookTokenVerifier.java
+++ b/src/main/java/com/tourya/api/config/auth/FacebookTokenVerifier.java
@@ -1,0 +1,129 @@
+package com.tourya.api.config.auth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tourya.api.exceptions.InvalidSocialTokenException;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
+
+/**
+ * SEC-06: valida access tokens de Facebook contra la Graph API de Facebook.
+ *
+ * <p>El flow es:
+ * <ol>
+ *     <li>Llamar a {@code debug_token} para verificar que el token es valido y
+ *     que fue emitido para nuestra app ({@code app_id} y {@code is_valid=true}).</li>
+ *     <li>Llamar a {@code /me?fields=id,name,email} para obtener el perfil del
+ *     usuario.</li>
+ * </ol>
+ *
+ * <p>Si el usuario oculto su email al autorizar, se rechaza (Tourya requiere
+ * email — ver RN-006).</p>
+ *
+ * <p>Facebook no expone claves publicas para validacion offline, por lo que
+ * cada login hace 2 llamadas HTTP a Facebook. Es aceptable — la frecuencia es
+ * baja y el resultado es cacheable durante la sesion via el JWT propio de
+ * Tourya.</p>
+ */
+@Slf4j
+@Service
+public class FacebookTokenVerifier {
+
+    private static final String GRAPH_BASE = "https://graph.facebook.com";
+    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+    @Value("${social.facebook.app-id:}")
+    private String appId;
+
+    @Value("${social.facebook.app-secret:}")
+    private String appSecret;
+
+    private RestClient restClient;
+    private ObjectMapper objectMapper;
+
+    @PostConstruct
+    void init() {
+        this.restClient = RestClient.builder()
+                .baseUrl(GRAPH_BASE)
+                .build();
+        this.objectMapper = new ObjectMapper();
+        if (appId == null || appId.isBlank() || appSecret == null || appSecret.isBlank()) {
+            log.warn("SEC-06: Facebook app-id/app-secret is not configured. POST /auth/facebook will reject requests until env vars FACEBOOK_APP_ID/FACEBOOK_APP_SECRET are set.");
+        }
+    }
+
+    public VerifiedSocialUser verify(String accessToken) {
+        if (appId == null || appId.isBlank() || appSecret == null || appSecret.isBlank()) {
+            throw new InvalidSocialTokenException("Facebook verifier is not configured");
+        }
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new InvalidSocialTokenException("Missing Facebook accessToken");
+        }
+        try {
+            debugToken(accessToken);
+            return fetchProfile(accessToken);
+        } catch (InvalidSocialTokenException e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("SEC-06: Facebook accessToken verification failed: {}", e.getMessage());
+            throw new InvalidSocialTokenException("Facebook accessToken verification error");
+        }
+    }
+
+    private void debugToken(String accessToken) throws Exception {
+        String appToken = appId + "|" + appSecret;
+        String body = restClient.get()
+                .uri(uriBuilder -> uriBuilder.path("/debug_token")
+                        .queryParam("input_token", accessToken)
+                        .queryParam("access_token", appToken)
+                        .build())
+                .retrieve()
+                .body(String.class);
+        if (body == null) {
+            throw new InvalidSocialTokenException("Facebook debug_token empty response");
+        }
+        JsonNode root = objectMapper.readTree(body);
+        JsonNode data = root.path("data");
+        if (!data.path("is_valid").asBoolean(false)) {
+            throw new InvalidSocialTokenException("Facebook accessToken is not valid");
+        }
+        String tokenAppId = data.path("app_id").asText("");
+        if (!appId.equals(tokenAppId)) {
+            throw new InvalidSocialTokenException("Facebook accessToken belongs to a different app");
+        }
+    }
+
+    private VerifiedSocialUser fetchProfile(String accessToken) throws Exception {
+        String body = restClient.get()
+                .uri(uriBuilder -> uriBuilder.path("/me")
+                        .queryParam("fields", "id,name,email,first_name,last_name")
+                        .queryParam("access_token", accessToken)
+                        .build())
+                .retrieve()
+                .body(String.class);
+        if (body == null) {
+            throw new InvalidSocialTokenException("Facebook /me empty response");
+        }
+        JsonNode profile = objectMapper.readTree(body);
+        String id = profile.path("id").asText("");
+        String email = profile.path("email").asText("");
+        String firstname = profile.path("first_name").asText("");
+        String lastname = profile.path("last_name").asText("");
+        if (id.isBlank()) {
+            throw new InvalidSocialTokenException("Facebook profile has no id");
+        }
+        if (email.isBlank()) {
+            throw new InvalidSocialTokenException("Facebook account has no email available (usuario ocultó email al autorizar)");
+        }
+        if (firstname.isBlank()) {
+            String name = profile.path("name").asText(email);
+            firstname = name;
+        }
+        return new VerifiedSocialUser(id, email, firstname, lastname);
+    }
+}

--- a/src/main/java/com/tourya/api/config/auth/GoogleTokenVerifier.java
+++ b/src/main/java/com/tourya/api/config/auth/GoogleTokenVerifier.java
@@ -1,0 +1,88 @@
+package com.tourya.api.config.auth;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.tourya.api.exceptions.InvalidSocialTokenException;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.security.GeneralSecurityException;
+import java.util.Collections;
+
+/**
+ * SEC-06: valida id_tokens de Google contra las claves publicas de Google
+ * (JWKS descargadas desde https://www.googleapis.com/oauth2/v3/certs). La
+ * verificacion es local (sin llamada a Google en cada login), solo verifica
+ * la firma criptografica del JWT y que fue emitido para nuestro
+ * {@code GOOGLE_CLIENT_ID}.
+ *
+ * <p>Se valida ademas que el claim {@code email_verified = true} — no
+ * aceptamos usuarios cuya cuenta Google no confirmo el correo.</p>
+ */
+@Slf4j
+@Service
+public class GoogleTokenVerifier {
+
+    @Value("${social.google.client-id:}")
+    private String clientId;
+
+    private GoogleIdTokenVerifier verifier;
+
+    @PostConstruct
+    void init() {
+        if (clientId == null || clientId.isBlank()) {
+            log.warn("SEC-06: social.google.client-id is not configured. POST /auth/google will reject requests until env var GOOGLE_CLIENT_ID is set.");
+            return;
+        }
+        this.verifier = new GoogleIdTokenVerifier.Builder(
+                new NetHttpTransport(),
+                GsonFactory.getDefaultInstance())
+                .setAudience(Collections.singletonList(clientId))
+                .build();
+    }
+
+    /**
+     * Verifica el id_token y devuelve los datos ya validados.
+     *
+     * @throws InvalidSocialTokenException si el token es invalido, expirado,
+     *                                     firmado por otro emisor, con audience
+     *                                     distinto o con email no verificado.
+     */
+    public VerifiedSocialUser verify(String idTokenString) {
+        if (verifier == null) {
+            throw new InvalidSocialTokenException("Google verifier is not configured (missing social.google.client-id)");
+        }
+        if (idTokenString == null || idTokenString.isBlank()) {
+            throw new InvalidSocialTokenException("Missing Google idToken");
+        }
+        try {
+            GoogleIdToken idToken = verifier.verify(idTokenString);
+            if (idToken == null) {
+                throw new InvalidSocialTokenException("Google idToken failed verification");
+            }
+            GoogleIdToken.Payload payload = idToken.getPayload();
+            if (!Boolean.TRUE.equals(payload.getEmailVerified())) {
+                throw new InvalidSocialTokenException("Google account email is not verified");
+            }
+            String email = payload.getEmail();
+            if (email == null || email.isBlank()) {
+                throw new InvalidSocialTokenException("Google idToken has no email claim");
+            }
+            String subject = payload.getSubject();
+            String givenName = (String) payload.get("given_name");
+            String familyName = (String) payload.get("family_name");
+            if (givenName == null || givenName.isBlank()) {
+                String name = (String) payload.get("name");
+                givenName = name != null ? name : email;
+            }
+            return new VerifiedSocialUser(subject, email, givenName, familyName != null ? familyName : "");
+        } catch (GeneralSecurityException | java.io.IOException e) {
+            log.warn("SEC-06: Google idToken verification failed: {}", e.getMessage());
+            throw new InvalidSocialTokenException("Google idToken verification error");
+        }
+    }
+}

--- a/src/main/java/com/tourya/api/config/auth/VerifiedSocialUser.java
+++ b/src/main/java/com/tourya/api/config/auth/VerifiedSocialUser.java
@@ -1,0 +1,24 @@
+package com.tourya.api.config.auth;
+
+/**
+ * Datos ya validados de un usuario que se autentico contra un proveedor social
+ * (Google, Facebook, etc). Es la salida de un TokenVerifier — el email/name/sub
+ * vienen del proveedor tras verificar la firma/validez del token, no del cliente.
+ *
+ * <p>SEC-06 (RN-006): el flujo de login social nunca debe confiar en datos que
+ * envie el cliente. Este record modela ese contrato: el {@link com.tourya.api.config.auth.AuthenticationService}
+ * consume este objeto en lugar de un DTO controlado por el cliente.</p>
+ *
+ * @param providerSubject identificador estable del usuario en el proveedor
+ *                        (sub en Google, id en Facebook)
+ * @param email           email verificado por el proveedor
+ * @param firstname       nombre (best-effort, puede venir vacio en Facebook)
+ * @param lastname        apellido (best-effort)
+ */
+public record VerifiedSocialUser(
+        String providerSubject,
+        String email,
+        String firstname,
+        String lastname
+) {
+}

--- a/src/main/java/com/tourya/api/config/auth/request/FacebookAuthRequest.java
+++ b/src/main/java/com/tourya/api/config/auth/request/FacebookAuthRequest.java
@@ -1,0 +1,17 @@
+package com.tourya.api.config.auth.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * SEC-06: request de POST /auth/facebook. El frontend envia el
+ * {@code accessToken} que obtuvo de Facebook JavaScript SDK; el backend valida
+ * via Graph API {@code debug_token} y recupera el perfil.
+ */
+@Getter
+@Setter
+public class FacebookAuthRequest {
+    @NotBlank(message = "accessToken is mandatory")
+    private String accessToken;
+}

--- a/src/main/java/com/tourya/api/config/auth/request/GoogleAuthRequest.java
+++ b/src/main/java/com/tourya/api/config/auth/request/GoogleAuthRequest.java
@@ -1,0 +1,18 @@
+package com.tourya.api.config.auth.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * SEC-06: request de POST /auth/google. El frontend envia el {@code idToken}
+ * que obtuvo de Google Identity Services; el backend valida su firma contra
+ * las claves publicas de Google y verifica que fue emitido para nuestro
+ * client id (audience check).
+ */
+@Getter
+@Setter
+public class GoogleAuthRequest {
+    @NotBlank(message = "idToken is mandatory")
+    private String idToken;
+}

--- a/src/main/java/com/tourya/api/exceptions/InvalidSocialTokenException.java
+++ b/src/main/java/com/tourya/api/exceptions/InvalidSocialTokenException.java
@@ -1,0 +1,12 @@
+package com.tourya.api.exceptions;
+
+/**
+ * SEC-06: se lanza cuando un token de un proveedor social (Google id_token o
+ * Facebook accessToken) no supera la verificacion server-side. El
+ * {@link com.tourya.api.handler.GlobalExceptionHandler} lo mapea a HTTP 401.
+ */
+public class InvalidSocialTokenException extends RuntimeException {
+    public InvalidSocialTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/tourya/api/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/tourya/api/handler/GlobalExceptionHandler.java
@@ -106,6 +106,17 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(exceptionResponse, UNAUTHORIZED);
     }
 
+    @ExceptionHandler(com.tourya.api.exceptions.InvalidSocialTokenException.class)
+    public ResponseEntity<Object> handleInvalidSocialToken(
+            com.tourya.api.exceptions.InvalidSocialTokenException exp) {
+        ExceptionResponse exceptionResponse = ExceptionResponse.builder()
+                .errorCode(BAD_CREDENTIALS.getCode())
+                .message(BAD_CREDENTIALS.getDescription())
+                .error(exp.getMessage())
+                .build();
+        return buildErrorResponse(exceptionResponse, UNAUTHORIZED);
+    }
+
     @ExceptionHandler(com.tourya.api.config.auth.RefreshTokenService.RefreshTokenException.class)
     public ResponseEntity<Object> handleRefreshTokenException(
             com.tourya.api.config.auth.RefreshTokenService.RefreshTokenException exp) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,6 +14,13 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 payment.wompi.integrity.secret=${WOMPI_INTEGRITY_SECRET}
 payment.wompi.events.secret=${WOMPI_EVENTS_SECRET}
 
+# SEC-06: Social login (Token Exchange). Los valores reales vienen de GCP Secret Manager
+# a traves de env vars en Cloud Run. Sin ellos, los endpoints /auth/google y /auth/facebook
+# rechazan las requests (safe default).
+social.google.client-id=${GOOGLE_CLIENT_ID:}
+social.facebook.app-id=${FACEBOOK_APP_ID:}
+social.facebook.app-secret=${FACEBOOK_APP_SECRET:}
+
 
 # Actuator: exponer solo endpoints publicos necesarios (health, info)
 # No exponer *, evita filtrar env, beans, mappings, heapdump, threaddump, etc.


### PR DESCRIPTION
… (Google + Facebook)

Cierra la vulnerabilidad C-6 / RN-006: hasta ahora POST /auth/social-auth confiaba ciegamente en el uuidSocial que enviaba el frontend, permitiendo a cualquiera con curl hacerse pasar por otro usuario si conocia su correo.

Nuevos endpoints (Token Exchange, validacion real server-side):
- POST /auth/google — recibe id_token, valida firma contra las claves publicas de Google (verifica audience=GOOGLE_CLIENT_ID + email_verified=true). Sin llamada externa por login (verificacion local via JWKS).
- POST /auth/facebook — recibe accessToken, valida via Graph API debug_token (is_valid=true + app_id matcheado) y obtiene el perfil via /me.

Componentes:
- GoogleTokenVerifier: usa com.google.api-client (2.7.2) con GoogleIdTokenVerifier. Rechaza tokens sin email_verified.
- FacebookTokenVerifier: usa RestClient de Spring (sin libreria extra). Rechaza si el usuario oculto su email al autorizar.
- VerifiedSocialUser record: modela la salida ya validada del verificador. Rompe el contrato de "datos que envia el cliente".
- InvalidSocialTokenException + handler global -> HTTP 401 con errorCode 304.

AuthenticationService:
- authenticateWithGoogle(GoogleAuthRequest) y authenticateWithFacebook( FacebookAuthRequest) - nuevos metodos que consumen los verificadores.
- authenticateOrCreateSocialUser(VerifiedSocialUser) - ruta comun extraida: crea/busca usuario por email (opcion A de vinculacion, ver social-login-google-facebook.md seccion 9). Sobrescribe uuid_social si el providerSubject nuevo difiere del guardado (util para migracion desde UIDs Firebase viejos a subs de Google/Facebook nuevos).
- authenticateWithSocial (viejo) marcado @Deprecated pero mantenido operativo para compat con el frontend actual. Se elimina en Fase C.

Config:
- application.properties: 3 properties nuevas (social.google.client-id, social.facebook.app-id, social.facebook.app-secret), con defaults vacios (los endpoints rechazan si estan ausentes).
- Env vars en Cloud Run tourya-dev-api ya apuntan a los 3 secretos en Secret Manager (tourya-google-web-client-id, tourya-facebook-app-id, tourya-facebook-app-secret), aplicados antes de este merge para que la nueva revision arranque con properties listas.

Frontend, MAUI, docs y limpieza del endpoint viejo van en Fase B y C.