### PR TITLE
fix(auth): GoogleTokenVerifier atrapa IllegalArgumentException del pa…

### DIFF
--- a/src/main/java/com/tourya/api/config/auth/GoogleTokenVerifier.java
+++ b/src/main/java/com/tourya/api/config/auth/GoogleTokenVerifier.java
@@ -80,7 +80,10 @@ public class GoogleTokenVerifier {
                 givenName = name != null ? name : email;
             }
             return new VerifiedSocialUser(subject, email, givenName, familyName != null ? familyName : "");
-        } catch (GeneralSecurityException | java.io.IOException e) {
+        } catch (GeneralSecurityException | java.io.IOException | IllegalArgumentException e) {
+            // IllegalArgumentException salta desde JsonWebSignature.Parser cuando el string
+            // no tiene el formato de JWT (3 secciones separadas por punto). Se trata igual
+            // que un token invalido: 401.
             log.warn("SEC-06: Google idToken verification failed: {}", e.getMessage());
             throw new InvalidSocialTokenException("Google idToken verification error");
         }


### PR DESCRIPTION
…rser

Cuando el frontend envia un idToken que no tiene formato de JWT (por ej. una string aleatoria), la libreria google-api-client tira IllegalArgumentException desde JsonWebSignature\$Parser.parse (via Preconditions.checkArgument), antes de la verificacion de firma. Ese error salia como 500 en vez del 401 esperado.

Detectado en smoke test post-deploy de SEC-06 Fase A (revision tourya-dev-api-00121-ccs): POST /auth/google con idToken="token-invalido" retorno 500 sin cuerpo.

Fix: agregar IllegalArgumentException al catch de GoogleTokenVerifier.verify. Se propaga como InvalidSocialTokenException -> 401 con errorCode 304.