### PR TITLE
feat(credit): BE-18/BE-19 notificaciones de expiracion (RN-036)

### DIFF
--- a/database/migrations/074_credit_expiration_notifications.sql
+++ b/database/migrations/074_credit_expiration_notifications.sql
@@ -1,0 +1,35 @@
+-- Migration 074: Notificaciones de expiración de créditos (BE-18 + BE-19)
+-- Date: 2026-07-12
+--
+-- BE-18 (RN-036): correo automático "crédito por expirar" 30 y 7 días antes.
+-- BE-19 (RN-036): correo automático "crédito expirado" al vencer.
+--
+-- Agrega 3 columnas para idempotencia (evitar reenvío del mismo correo si el
+-- job corre 2 veces por accidente) y suma el valor 'EXPIRED' al catálogo de
+-- estados de crédito (la columna credit.status es VARCHAR(20), no un ENUM
+-- de PostgreSQL, por lo que no requiere cambio de tipo).
+--
+-- Backfill: marca EXPIRED los créditos que ya vencieron sin haber sido
+-- consumidos. NO envía correo retroactivo (expired_notified_at = NOW() para
+-- que el job los considere ya notificados).
+
+ALTER TABLE public.credit
+    ADD COLUMN IF NOT EXISTS reminder_30d_sent_at TIMESTAMPTZ NULL,
+    ADD COLUMN IF NOT EXISTS reminder_7d_sent_at TIMESTAMPTZ NULL,
+    ADD COLUMN IF NOT EXISTS expired_notified_at TIMESTAMPTZ NULL;
+
+COMMENT ON COLUMN public.credit.reminder_30d_sent_at IS 'BE-18: timestamp del envío del recordatorio 30 días antes de expiration_date. NULL = no enviado. Usado como flag de idempotencia por CreditExpirationJob.';
+COMMENT ON COLUMN public.credit.reminder_7d_sent_at IS 'BE-18: timestamp del envío del recordatorio 7 días antes de expiration_date.';
+COMMENT ON COLUMN public.credit.expired_notified_at IS 'BE-19: timestamp del envío del correo de expiración. NULL = no notificado.';
+
+-- Backfill de créditos ya expirados: marca EXPIRED sin reenviar correo
+-- (llevan meses vencidos, notificarlos ahora seria molesto).
+UPDATE public.credit
+SET status = 'EXPIRED',
+    expired_notified_at = NOW()
+WHERE status = 'CREATED'
+  AND expiration_date < CURRENT_DATE;
+
+-- Indice para el job diario: acelera busqueda de candidatos por fecha exacta.
+CREATE INDEX IF NOT EXISTS idx_credit_status_expiration_date
+    ON public.credit (status, expiration_date);

--- a/src/main/java/com/tourya/api/constans/enums/CreditStatusEnum.java
+++ b/src/main/java/com/tourya/api/constans/enums/CreditStatusEnum.java
@@ -30,7 +30,14 @@ public enum CreditStatusEnum {
     /**
      * Crédito eliminado
      */
-    DELETED
+    DELETED,
+
+    /**
+     * BE-19 (RN-036): crédito con expiration_date vencida. Marca inaccesible en
+     * todos los flujos de checkout y transferencia. El job CreditExpirationJob
+     * hace la transicion CREATED -> EXPIRED en la fecha exacta de expiracion.
+     */
+    EXPIRED
 }
 
 

--- a/src/main/java/com/tourya/api/jobs/CreditExpirationJob.java
+++ b/src/main/java/com/tourya/api/jobs/CreditExpirationJob.java
@@ -1,0 +1,147 @@
+package com.tourya.api.jobs;
+
+import com.tourya.api.constans.enums.CreditStatusEnum;
+import com.tourya.api.models.Credit;
+import com.tourya.api.models.User;
+import com.tourya.api.repository.CreditRepository;
+import com.tourya.api.repository.UserRepository;
+import com.tourya.api.services.EmailService;
+import jakarta.mail.MessagingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * BE-18 (recordatorios 30 y 7 dias antes) + BE-19 (marca EXPIRED y notifica).
+ *
+ * <p>Corre a las 5:00 AM Bogota, igual patron que {@link ReservationCancellationFlagsJob}.
+ * Cada corrida hace 3 pases:</p>
+ * <ol>
+ *   <li>Reminder 30 dias: creditos {@code CREATED} con {@code expiration_date =
+ *   today + 30} y {@code reminder_30d_sent_at IS NULL}.</li>
+ *   <li>Reminder 7 dias: idem con 7 dias y {@code reminder_7d_sent_at}.</li>
+ *   <li>Expirados: creditos {@code CREATED} con {@code expiration_date < today}
+ *   pasan a {@code EXPIRED} y se notifica una vez.</li>
+ * </ol>
+ *
+ * <p>Idempotencia via los timestamps: si el job corre 2 veces el mismo dia,
+ * los creditos ya notificados no se reprocesan (el query los filtra por
+ * {@code IS NULL}).</p>
+ *
+ * <p>Si el envio de correo falla para un credito, se loguea WARN y el
+ * timestamp NO se marca — la proxima corrida reintenta ese credito. Esto
+ * evita perder notificaciones por errores transitorios de SMTP.</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CreditExpirationJob {
+
+    private static final ZoneId BOGOTA = ZoneId.of("America/Bogota");
+    private static final int REMINDER_30D_DAYS = 30;
+    private static final int REMINDER_7D_DAYS = 7;
+
+    private final CreditRepository creditRepository;
+    private final UserRepository userRepository;
+    private final EmailService emailService;
+
+    @Value("${application.mailing.frontend.credit-url:https://tourya.co/}")
+    private String creditUsageUrl;
+
+    @Scheduled(cron = "0 0 5 * * *", zone = "America/Bogota")
+    @Transactional
+    public void runDaily() {
+        LocalDate today = LocalDate.now(BOGOTA);
+        int r30 = sendReminders(today.plusDays(REMINDER_30D_DAYS), REMINDER_30D_DAYS, true);
+        int r7 = sendReminders(today.plusDays(REMINDER_7D_DAYS), REMINDER_7D_DAYS, false);
+        int exp = markAndNotifyExpired(today);
+        log.info("CreditExpirationJob: reminders30d={}, reminders7d={}, expired={}", r30, r7, exp);
+    }
+
+    private int sendReminders(LocalDate targetDate, int daysAdvance, boolean is30d) {
+        List<Credit> candidates = is30d
+                ? creditRepository.findExpiringInNeedingReminder30d(targetDate)
+                : creditRepository.findExpiringInNeedingReminder7d(targetDate);
+        int sent = 0;
+        for (Credit credit : candidates) {
+            Optional<User> user = userRepository.findById(credit.getUserId());
+            if (user.isEmpty() || user.get().getEmail() == null || user.get().getEmail().isBlank()) {
+                log.warn("CreditExpirationJob: credit {} without user or email, skipping reminder{}d",
+                        credit.getId(), daysAdvance);
+                continue;
+            }
+            try {
+                emailService.sendCreditExpiringReminder(
+                        user.get().getEmail(),
+                        buildDisplayName(user.get()),
+                        credit.getAmount(),
+                        credit.getExpirationDate(),
+                        daysAdvance,
+                        creditUsageUrl,
+                        "Tu crédito Tourya vence en " + daysAdvance + " días"
+                );
+                if (is30d) {
+                    credit.setReminder30dSentAt(LocalDateTime.now());
+                } else {
+                    credit.setReminder7dSentAt(LocalDateTime.now());
+                }
+                creditRepository.save(credit);
+                sent++;
+            } catch (MessagingException | RuntimeException e) {
+                log.warn("CreditExpirationJob: reminder{}d failed for credit {}: {}",
+                        daysAdvance, credit.getId(), e.getMessage());
+            }
+        }
+        return sent;
+    }
+
+    private int markAndNotifyExpired(LocalDate today) {
+        List<Credit> expired = creditRepository.findExpiredNotYetMarked(today);
+        int notified = 0;
+        for (Credit credit : expired) {
+            credit.setStatus(CreditStatusEnum.EXPIRED);
+            Optional<User> user = userRepository.findById(credit.getUserId());
+            if (user.isEmpty() || user.get().getEmail() == null || user.get().getEmail().isBlank()) {
+                log.warn("CreditExpirationJob: credit {} without user or email, marking EXPIRED without notification",
+                        credit.getId());
+                creditRepository.save(credit);
+                continue;
+            }
+            try {
+                emailService.sendCreditExpiredNotice(
+                        user.get().getEmail(),
+                        buildDisplayName(user.get()),
+                        credit.getAmount(),
+                        credit.getExpirationDate(),
+                        "Tu crédito Tourya ha vencido"
+                );
+                credit.setExpiredNotifiedAt(LocalDateTime.now());
+                notified++;
+            } catch (MessagingException | RuntimeException e) {
+                log.warn("CreditExpirationJob: expired notice failed for credit {}: {}",
+                        credit.getId(), e.getMessage());
+                // Aun asi marca EXPIRED — el estado en BD debe reflejar la realidad.
+                // La proxima corrida no lo reprocesa porque ya no esta CREATED.
+            }
+            creditRepository.save(credit);
+        }
+        return notified;
+    }
+
+    private String buildDisplayName(User user) {
+        String first = user.getFirstname();
+        if (first == null || first.isBlank()) {
+            return user.getEmail();
+        }
+        return first;
+    }
+}

--- a/src/main/java/com/tourya/api/models/Credit.java
+++ b/src/main/java/com/tourya/api/models/Credit.java
@@ -70,6 +70,24 @@ public class Credit extends BaseEntity {
     @Column(name = "transferred_at")
     private LocalDateTime transferredAt;
 
+    /**
+     * BE-18: timestamp del envío del recordatorio 30 días antes. NULL = pendiente.
+     */
+    @Column(name = "reminder_30d_sent_at")
+    private LocalDateTime reminder30dSentAt;
+
+    /**
+     * BE-18: timestamp del envío del recordatorio 7 días antes.
+     */
+    @Column(name = "reminder_7d_sent_at")
+    private LocalDateTime reminder7dSentAt;
+
+    /**
+     * BE-19: timestamp del envío del correo de expiración.
+     */
+    @Column(name = "expired_notified_at")
+    private LocalDateTime expiredNotifiedAt;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reservation_id", insertable = false, updatable = false)
     private Reservation reservation;

--- a/src/main/java/com/tourya/api/repository/CreditRepository.java
+++ b/src/main/java/com/tourya/api/repository/CreditRepository.java
@@ -74,5 +74,37 @@ public interface CreditRepository extends JpaRepository<Credit, Long> {
      */
     @Query("SELECT c FROM Credit c WHERE c.shoppingCartItemId IN :itemIds AND c.status = 'RESERVED'")
     List<Credit> findByShoppingCartItemIdInAndStatusReserved(@Param("itemIds") Set<Long> itemIds);
+
+    /**
+     * BE-18: créditos CREATED con expiration_date = targetDate y sin recordatorio 30d enviado.
+     */
+    @Query("""
+        SELECT c FROM Credit c
+        WHERE c.status = 'CREATED'
+          AND c.expirationDate = :targetDate
+          AND c.reminder30dSentAt IS NULL
+        """)
+    List<Credit> findExpiringInNeedingReminder30d(@Param("targetDate") LocalDate targetDate);
+
+    /**
+     * BE-18: créditos CREATED con expiration_date = targetDate y sin recordatorio 7d enviado.
+     */
+    @Query("""
+        SELECT c FROM Credit c
+        WHERE c.status = 'CREATED'
+          AND c.expirationDate = :targetDate
+          AND c.reminder7dSentAt IS NULL
+        """)
+    List<Credit> findExpiringInNeedingReminder7d(@Param("targetDate") LocalDate targetDate);
+
+    /**
+     * BE-19: créditos que ya expiraron y aun estan en CREATED (candidatos a marcar EXPIRED).
+     */
+    @Query("""
+        SELECT c FROM Credit c
+        WHERE c.status = 'CREATED'
+          AND c.expirationDate < :today
+        """)
+    List<Credit> findExpiredNotYetMarked(@Param("today") LocalDate today);
 }
 

--- a/src/main/java/com/tourya/api/services/EmailService.java
+++ b/src/main/java/com/tourya/api/services/EmailService.java
@@ -118,6 +118,71 @@ public class EmailService {
         mailSender.send(message);
     }
 
+    /**
+     * BE-18 (RN-036): recordatorio de crédito por vencer. Se envia 30 y 7 dias
+     * antes de {@code expirationDate} desde {@code CreditExpirationJob}.
+     */
+    @Async
+    public void sendCreditExpiringReminder(
+            String to,
+            String username,
+            java.math.BigDecimal amount,
+            java.time.LocalDate expirationDate,
+            long daysRemaining,
+            String usageUrl,
+            String subject
+    ) throws MessagingException {
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(
+                mimeMessage,
+                MULTIPART_MODE_MIXED,
+                UTF_8.name());
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("username", username);
+        properties.put("amount", amount);
+        properties.put("expirationDate", expirationDate);
+        properties.put("daysRemaining", daysRemaining);
+        properties.put("usageUrl", usageUrl);
+        Context context = new Context();
+        context.setVariables(properties);
+        helper.setFrom(fromEmail);
+        helper.setTo(to);
+        helper.setSubject(subject);
+        String template = templateEngine.process("credit_expiring_reminder", context);
+        helper.setText(template, true);
+        mailSender.send(mimeMessage);
+    }
+
+    /**
+     * BE-19 (RN-036): notificacion de credito expirado.
+     */
+    @Async
+    public void sendCreditExpiredNotice(
+            String to,
+            String username,
+            java.math.BigDecimal amount,
+            java.time.LocalDate expirationDate,
+            String subject
+    ) throws MessagingException {
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(
+                mimeMessage,
+                MULTIPART_MODE_MIXED,
+                UTF_8.name());
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("username", username);
+        properties.put("amount", amount);
+        properties.put("expirationDate", expirationDate);
+        Context context = new Context();
+        context.setVariables(properties);
+        helper.setFrom(fromEmail);
+        helper.setTo(to);
+        helper.setSubject(subject);
+        String template = templateEngine.process("credit_expired", context);
+        helper.setText(template, true);
+        mailSender.send(mimeMessage);
+    }
+
     @Async
     public void sendPurchaseConfirmationEmail(
             String to,

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -89,6 +89,10 @@ application.security.jwt.expiration=86400000
 # refresh token: 30 dias por default; sobreescribir via JWT_REFRESH_EXPIRATION (ms)
 application.security.jwt.refresh-expiration=${JWT_REFRESH_EXPIRATION:2592000000}
 application.mailing.frontend.activation-url=${ACTIVATION_URL:http://44.203.38.85:8088/api/v1/auth/activar-cuenta-web?token=}
+
+# BE-18/19 (RN-036): URL a la que apunta el CTA "Usar mi credito" en el correo
+# de recordatorio de expiracion. Por defecto apunta al home del frontend.
+application.mailing.frontend.credit-url=${CREDIT_URL:https://tourya.co/}
 #application.mailing.frontend.activation-url=http://localhost:8088/api/v1/auth/activar-cuenta-web?token=
 
 #GOOGLE

--- a/src/main/resources/templates/credit_expired.html
+++ b/src/main/resources/templates/credit_expired.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tu crédito Tourya ha vencido</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #f4f4f4;
+        }
+        .container {
+            max-width: 600px;
+            margin: 10px auto;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+        }
+        h1 {
+            color: #1f2937;
+            margin-top: 0;
+        }
+        .amount-badge {
+            font-size: 28px;
+            font-weight: bold;
+            color: #6b7280;
+            text-align: center;
+            padding: 16px;
+            background-color: #f3f4f6;
+            border-radius: 8px;
+            margin: 20px 0;
+            text-decoration: line-through;
+        }
+        .details {
+            background-color: #f9fafb;
+            padding: 16px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+        }
+        .details p {
+            margin: 6px 0;
+        }
+        .footer {
+            margin-top: 24px;
+            font-size: 12px;
+            color: #6b7280;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Tu crédito Tourya ha vencido</h1>
+    <p th:text="'Hola ' + ${username} + ','"></p>
+    <p>
+        Te informamos que un crédito disponible en tu cuenta ha llegado a su fecha de expiración
+        y ya no puede utilizarse.
+    </p>
+
+    <div class="amount-badge">
+        <span th:text="'$' + ${amount}"></span>
+    </div>
+
+    <div class="details">
+        <p><strong>Fecha de expiración:</strong> <span th:text="${expirationDate}"></span></p>
+    </div>
+
+    <p>
+        Los créditos tienen una vigencia limitada según los términos y condiciones. Si tienes dudas
+        sobre esta política o consideras que deberíamos revisar tu caso, contáctanos.
+    </p>
+
+    <div class="footer">
+        <p>Tourya — Marketplace de experiencias turísticas.</p>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/credit_expiring_reminder.html
+++ b/src/main/resources/templates/credit_expiring_reminder.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tu crédito Tourya está por vencer</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #f4f4f4;
+        }
+        .container {
+            max-width: 600px;
+            margin: 10px auto;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+        }
+        h1 {
+            color: #1f2937;
+            margin-top: 0;
+        }
+        .amount-badge {
+            font-size: 32px;
+            font-weight: bold;
+            color: #007bff;
+            text-align: center;
+            padding: 16px;
+            background-color: #eff6ff;
+            border-radius: 8px;
+            margin: 20px 0;
+        }
+        .details {
+            background-color: #f9fafb;
+            padding: 16px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+        }
+        .details p {
+            margin: 6px 0;
+        }
+        .cta {
+            text-align: center;
+            margin-top: 24px;
+        }
+        .cta a {
+            display: inline-block;
+            padding: 12px 28px;
+            background-color: #007bff;
+            color: #fff;
+            text-decoration: none;
+            border-radius: 5px;
+            font-weight: bold;
+        }
+        .footer {
+            margin-top: 24px;
+            font-size: 12px;
+            color: #6b7280;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Tu crédito Tourya está por vencer</h1>
+    <p th:text="'Hola ' + ${username} + ','"></p>
+    <p>
+        Te recordamos que tienes un crédito disponible en Tourya que se acerca a su fecha de expiración.
+        Aún estás a tiempo de usarlo en una reserva.
+    </p>
+
+    <div class="amount-badge">
+        <span th:text="'$' + ${amount}"></span>
+    </div>
+
+    <div class="details">
+        <p><strong>Fecha de expiración:</strong> <span th:text="${expirationDate}"></span></p>
+        <p><strong>Días restantes:</strong> <span th:text="${daysRemaining}"></span></p>
+    </div>
+
+    <p>Después de la fecha de expiración, el crédito no podrá utilizarse.</p>
+
+    <div class="cta">
+        <a th:href="${usageUrl}" target="_blank">Usar mi crédito</a>
+    </div>
+
+    <div class="footer">
+        <p>Si tienes preguntas, responde a este correo o escríbenos por WhatsApp.</p>
+        <p>Tourya — Marketplace de experiencias turísticas.</p>
+    </div>
+</div>
+</body>
+</html>

--- a/src/test/java/com/tourya/api/jobs/CreditExpirationJobTest.java
+++ b/src/test/java/com/tourya/api/jobs/CreditExpirationJobTest.java
@@ -1,0 +1,248 @@
+package com.tourya.api.jobs;
+
+import com.tourya.api.constans.enums.CreditStatusEnum;
+import com.tourya.api.models.Credit;
+import com.tourya.api.models.User;
+import com.tourya.api.repository.CreditRepository;
+import com.tourya.api.repository.UserRepository;
+import com.tourya.api.services.EmailService;
+import jakarta.mail.MessagingException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * BE-18 (recordatorios) + BE-19 (marcar EXPIRED y notificar). Tests con Mockito
+ * — sin BD ni SMTP reales. Cubren los 3 pases del job:
+ * <ul>
+ *   <li>Reminder 30d marca {@code reminder_30d_sent_at}.</li>
+ *   <li>Reminder 7d marca {@code reminder_7d_sent_at}.</li>
+ *   <li>Expirado pasa a status EXPIRED y setea {@code expired_notified_at}.</li>
+ * </ul>
+ * Verifican idempotencia (si el mail falla, el timestamp no se marca; en el caso
+ * de EXPIRED el status se persiste igual porque debe reflejar la realidad de BD).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("BE-18/19 CreditExpirationJob")
+class CreditExpirationJobTest {
+
+    private static final String USER_EMAIL = "turista@example.com";
+    private static final String USER_FIRSTNAME = "Ana";
+    private static final Integer USER_ID = 100;
+    private static final Long CREDIT_ID = 500L;
+
+    @Mock private CreditRepository creditRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private EmailService emailService;
+
+    @InjectMocks
+    private CreditExpirationJob job;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(job, "creditUsageUrl", "https://tourya.co/mis-creditos");
+        user = new User();
+        user.setId(USER_ID);
+        user.setEmail(USER_EMAIL);
+        user.setFirstname(USER_FIRSTNAME);
+    }
+
+    private Credit newCredit() {
+        Credit c = new Credit();
+        c.setId(CREDIT_ID);
+        c.setUserId(USER_ID);
+        c.setAmount(new BigDecimal("50000"));
+        c.setStatus(CreditStatusEnum.CREATED);
+        c.setExpirationDate(LocalDate.now().plusDays(30));
+        c.setReservedAmount(BigDecimal.ZERO);
+        return c;
+    }
+
+    @Test
+    @DisplayName("reminder 30d: envia correo y marca timestamp")
+    void reminder30d_sendsEmailAndMarksTimestamp() throws Exception {
+        Credit credit = newCredit();
+        LocalDate today = LocalDate.now();
+        when(creditRepository.findExpiringInNeedingReminder30d(today.plusDays(30)))
+                .thenReturn(List.of(credit));
+        when(creditRepository.findExpiringInNeedingReminder7d(today.plusDays(7)))
+                .thenReturn(Collections.emptyList());
+        when(creditRepository.findExpiredNotYetMarked(today)).thenReturn(Collections.emptyList());
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+        job.runDaily();
+
+        verify(emailService).sendCreditExpiringReminder(
+                eq(USER_EMAIL),
+                eq(USER_FIRSTNAME),
+                eq(credit.getAmount()),
+                eq(credit.getExpirationDate()),
+                eq(30L),
+                anyString(),
+                anyString());
+        ArgumentCaptor<Credit> saved = ArgumentCaptor.forClass(Credit.class);
+        verify(creditRepository).save(saved.capture());
+        assertThat(saved.getValue().getReminder30dSentAt()).isNotNull();
+        assertThat(saved.getValue().getReminder7dSentAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("reminder 7d: envia correo y marca timestamp")
+    void reminder7d_sendsEmailAndMarksTimestamp() throws Exception {
+        Credit credit = newCredit();
+        credit.setExpirationDate(LocalDate.now().plusDays(7));
+        LocalDate today = LocalDate.now();
+        when(creditRepository.findExpiringInNeedingReminder30d(today.plusDays(30)))
+                .thenReturn(Collections.emptyList());
+        when(creditRepository.findExpiringInNeedingReminder7d(today.plusDays(7)))
+                .thenReturn(List.of(credit));
+        when(creditRepository.findExpiredNotYetMarked(today)).thenReturn(Collections.emptyList());
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+        job.runDaily();
+
+        verify(emailService).sendCreditExpiringReminder(
+                eq(USER_EMAIL),
+                eq(USER_FIRSTNAME),
+                eq(credit.getAmount()),
+                eq(credit.getExpirationDate()),
+                eq(7L),
+                anyString(),
+                anyString());
+        ArgumentCaptor<Credit> saved = ArgumentCaptor.forClass(Credit.class);
+        verify(creditRepository).save(saved.capture());
+        assertThat(saved.getValue().getReminder7dSentAt()).isNotNull();
+        assertThat(saved.getValue().getReminder30dSentAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("expirado: cambia status a EXPIRED, envia notice y marca timestamp")
+    void expired_marksExpiredSendsNoticeAndTimestamps() throws Exception {
+        Credit credit = newCredit();
+        credit.setExpirationDate(LocalDate.now().minusDays(1));
+        LocalDate today = LocalDate.now();
+        when(creditRepository.findExpiringInNeedingReminder30d(today.plusDays(30)))
+                .thenReturn(Collections.emptyList());
+        when(creditRepository.findExpiringInNeedingReminder7d(today.plusDays(7)))
+                .thenReturn(Collections.emptyList());
+        when(creditRepository.findExpiredNotYetMarked(today)).thenReturn(List.of(credit));
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+        job.runDaily();
+
+        verify(emailService).sendCreditExpiredNotice(
+                eq(USER_EMAIL),
+                eq(USER_FIRSTNAME),
+                eq(credit.getAmount()),
+                eq(credit.getExpirationDate()),
+                anyString());
+        ArgumentCaptor<Credit> saved = ArgumentCaptor.forClass(Credit.class);
+        verify(creditRepository).save(saved.capture());
+        assertThat(saved.getValue().getStatus()).isEqualTo(CreditStatusEnum.EXPIRED);
+        assertThat(saved.getValue().getExpiredNotifiedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("expirado sin email: marca EXPIRED igual pero no notifica")
+    void expired_withoutEmail_stillMarksExpired() {
+        Credit credit = newCredit();
+        credit.setExpirationDate(LocalDate.now().minusDays(1));
+        User userNoEmail = new User();
+        userNoEmail.setId(USER_ID);
+        userNoEmail.setEmail(null);
+        LocalDate today = LocalDate.now();
+        when(creditRepository.findExpiringInNeedingReminder30d(today.plusDays(30)))
+                .thenReturn(Collections.emptyList());
+        when(creditRepository.findExpiringInNeedingReminder7d(today.plusDays(7)))
+                .thenReturn(Collections.emptyList());
+        when(creditRepository.findExpiredNotYetMarked(today)).thenReturn(List.of(credit));
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(userNoEmail));
+
+        job.runDaily();
+
+        ArgumentCaptor<Credit> saved = ArgumentCaptor.forClass(Credit.class);
+        verify(creditRepository).save(saved.capture());
+        assertThat(saved.getValue().getStatus()).isEqualTo(CreditStatusEnum.EXPIRED);
+        assertThat(saved.getValue().getExpiredNotifiedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("reminder falla en SMTP: no marca timestamp (reintenta al dia siguiente)")
+    void reminder30d_smtpFails_doesNotMarkTimestamp() throws Exception {
+        Credit credit = newCredit();
+        LocalDate today = LocalDate.now();
+        when(creditRepository.findExpiringInNeedingReminder30d(today.plusDays(30)))
+                .thenReturn(List.of(credit));
+        when(creditRepository.findExpiringInNeedingReminder7d(today.plusDays(7)))
+                .thenReturn(Collections.emptyList());
+        when(creditRepository.findExpiredNotYetMarked(today)).thenReturn(Collections.emptyList());
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        doThrow(new MessagingException("SMTP down")).when(emailService).sendCreditExpiringReminder(
+                anyString(), anyString(), any(), any(), anyLong(), anyString(), anyString());
+
+        job.runDaily();
+
+        verify(creditRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("reminder sin usuario: skipea sin exception")
+    void reminder_userNotFound_skipsGracefully() throws Exception {
+        Credit credit = newCredit();
+        LocalDate today = LocalDate.now();
+        when(creditRepository.findExpiringInNeedingReminder30d(today.plusDays(30)))
+                .thenReturn(List.of(credit));
+        when(creditRepository.findExpiringInNeedingReminder7d(today.plusDays(7)))
+                .thenReturn(Collections.emptyList());
+        when(creditRepository.findExpiredNotYetMarked(today)).thenReturn(Collections.emptyList());
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+
+        job.runDaily();
+
+        verify(emailService, never()).sendCreditExpiringReminder(
+                anyString(), anyString(), any(), any(), anyLong(), anyString(), anyString());
+        verify(creditRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("dia sin candidatos: job corre y no envia nada")
+    void emptyDay_runsSilently() {
+        LocalDate today = LocalDate.now();
+        when(creditRepository.findExpiringInNeedingReminder30d(today.plusDays(30)))
+                .thenReturn(Collections.emptyList());
+        when(creditRepository.findExpiringInNeedingReminder7d(today.plusDays(7)))
+                .thenReturn(Collections.emptyList());
+        when(creditRepository.findExpiredNotYetMarked(today)).thenReturn(Collections.emptyList());
+
+        job.runDaily();
+
+        verify(creditRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
Cierra RN-036 con notificaciones automaticas: recordatorio 30 y 7 dias antes de expirar (BE-18) y aviso al expirar (BE-19). Implementado en un unico Job cron que corre 5am Bogota diariamente — mismo patron que ReservationCancellationFlagsJob.

Backend:
- Migracion 074:
  - Agrega columnas credit.reminder_30d_sent_at, reminder_7d_sent_at, expired_notified_at (TIMESTAMPTZ, idempotencia del job).
  - Backfill de creditos ya expirados: los pasa a status EXPIRED sin reenviar correo (llevan meses vencidos, notificarlos ahora seria molesto).
  - Indice idx_credit_status_expiration_date para acelerar el job.
- CreditStatusEnum: nuevo valor EXPIRED. Todos los checks existentes (status != CREATED) automaticamente rechazan EXPIRED como se espera — cero regresion en checkout/reserva/transferencia.
- Credit entity: 3 nuevas columnas mapeadas a las de la migracion.
- CreditRepository: 3 nuevos queries (findExpiringInNeedingReminder30d, findExpiringInNeedingReminder7d, findExpiredNotYetMarked).
- EmailService: 2 nuevos metodos @Async (sendCreditExpiringReminder, sendCreditExpiredNotice).
- CreditExpirationJob: 3 pases por corrida (r30d, r7d, expired). Idempotencia via timestamps: si el mail falla, el timestamp no se marca — la proxima corrida reintenta. Si el usuario no tiene email o no existe, se skipea gracefully (los expirados igual se marcan EXPIRED en BD para reflejar la realidad).
- application.properties: nueva property application.mailing.frontend.credit-url (CTA del correo de recordatorio).

Templates (Thymeleaf, patron identico al de activate_account.html):
- credit_expiring_reminder.html: usa {username}, {amount}, {expirationDate}, {daysRemaining}, {usageUrl}.
- credit_expired.html: usa {username}, {amount}, {expirationDate}.

Tests (7, todos verdes con Mockito):
- Reminder 30d envia y marca timestamp.
- Reminder 7d idem.
- Expirado pasa a EXPIRED, envia notice, marca expiredNotifiedAt.
- Expirado sin email: se marca EXPIRED sin notificar.
- Reminder con SMTP caido: no marca timestamp (reintenta al dia siguiente).
- Usuario no encontrado: skipea gracefully.
- Dia sin candidatos: corre silencioso.

Nota operativa: los correos dependen del SMTP que hoy 2026-07-12 esta caido (535 BadCredentials). El codigo esta listo y probado con Mockito — cuando Luis regenere el app-password del Workspace Tourya, el job empieza a enviar sin cambios adicionales.