### PR TITLE
hotfix #179b: TemporalReservationExpiryJob resistente a itemId NULL

### DIFF
--- a/src/main/java/com/tourya/api/jobs/TemporalReservationExpiryJob.java
+++ b/src/main/java/com/tourya/api/jobs/TemporalReservationExpiryJob.java
@@ -8,70 +8,96 @@ import com.tourya.api.models.ShoppingCartItem;
 import com.tourya.api.repository.CreditRepository;
 import com.tourya.api.repository.ReservationRepository;
 import com.tourya.api.repository.ShoppingCartItemRepository;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class TemporalReservationExpiryJob {
 
     private final ReservationRepository reservationRepository;
     private final ShoppingCartItemRepository shoppingCartItemRepository;
     private final CreditRepository creditRepository;
+    private final TransactionTemplate perReservationTx;
+
+    public TemporalReservationExpiryJob(ReservationRepository reservationRepository,
+                                        ShoppingCartItemRepository shoppingCartItemRepository,
+                                        CreditRepository creditRepository,
+                                        PlatformTransactionManager transactionManager) {
+        this.reservationRepository = reservationRepository;
+        this.shoppingCartItemRepository = shoppingCartItemRepository;
+        this.creditRepository = creditRepository;
+        // Hotfix #179b: cada reserva se procesa en su propia tx REQUIRES_NEW para
+        // que un fallo aislado no marque rollback-only la tx del batch y arrastre
+        // al resto (el job entraba en loop de UnexpectedRollbackException).
+        this.perReservationTx = new TransactionTemplate(transactionManager);
+        this.perReservationTx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    }
 
     /**
-     * Expira holds temporales vencidos.
-     * Nota: liberación de disponibilidad se recalcula al próximo hold/payment/cancel; aquí solo marca CANCELED.
+     * Expira holds temporales vencidos. Cada reserva corre en su propia transaccion.
+     * Nota: liberacion de disponibilidad se recalcula al proximo hold/payment/cancel; aqui solo marca CANCELED.
      */
     @Scheduled(fixedDelayString = "${tourya.temporalReservationExpiry.fixedDelayMs:60000}")
-    @Transactional
     public void expireTemporalReservations() {
-        // Mantener coherencia con creación del hold (UTC) para evitar expiraciones inmediatas por zona horaria
         LocalDateTime now = LocalDateTime.now(java.time.ZoneId.of("UTC"));
         List<Reservation> expired = reservationRepository.findExpiredTemporalReservations(now);
         if (expired.isEmpty()) return;
 
+        int ok = 0;
+        int failed = 0;
         for (Reservation r : expired) {
             try {
-                r.setDeliveryStatus(DeliveryStatusEnum.CANCELED);
-                r.setCancellationDate(now);
-                r.setExpiresAt(null);
-                reservationRepository.save(r);
-
-                ShoppingCartItem item = shoppingCartItemRepository.findById(r.getItemId()).orElse(null);
-                if (item != null) {
-                    // mantener el item en el carrito pero quitar la reserva temporal para permitir reintento
-                    item.setReservationId(null);
-                    shoppingCartItemRepository.save(item);
-                }
-
-                // Liberar créditos reservados para este item si el pago no se completó
-                // Regla: si Credit está RESERVED y asociado al shopping_cart_item_id, lo devolvemos a CREATED.
-                if (r.getItemId() != null) {
-                    java.util.Set<Long> itemIds = java.util.Set.of(r.getItemId());
-                    List<Credit> reservedCredits = creditRepository.findByShoppingCartItemIdInAndStatusReserved(itemIds);
-                    for (Credit c : reservedCredits) {
-                        c.setReservedAmount(java.math.BigDecimal.ZERO);
-                        c.setShoppingCartItemId(null);
-                        c.setStatus(CreditStatusEnum.CREATED);
-                    }
-                    if (!reservedCredits.isEmpty()) {
-                        creditRepository.saveAll(reservedCredits);
-                    }
-                }
+                perReservationTx.executeWithoutResult(status -> expireOne(r, now));
+                ok++;
             } catch (Exception e) {
+                failed++;
                 log.warn("No se pudo expirar reserva temporal {}: {}", r.getReservationId(), e.getMessage());
             }
         }
 
-        log.info("Expiradas {} reservas temporales vencidas", expired.size());
+        log.info("Expiradas {} reservas temporales vencidas (fallidas aisladas: {})", ok, failed);
+    }
+
+    private void expireOne(Reservation r, LocalDateTime now) {
+        r.setDeliveryStatus(DeliveryStatusEnum.CANCELED);
+        r.setCancellationDate(now);
+        r.setExpiresAt(null);
+        reservationRepository.save(r);
+
+        Long itemId = r.getItemId();
+        if (itemId == null) {
+            // Hotfix #179b: reservas con item_id NULL vienen del FK ON DELETE SET NULL
+            // (migracion 012) cuando el shopping_cart_item asociado se borro por reschedule
+            // u otro flujo. Solo hay que marcar CANCELED — no hay item ni creditos que limpiar.
+            return;
+        }
+
+        ShoppingCartItem item = shoppingCartItemRepository.findById(itemId).orElse(null);
+        if (item != null) {
+            // mantener el item en el carrito pero quitar la reserva temporal para permitir reintento
+            item.setReservationId(null);
+            shoppingCartItemRepository.save(item);
+        }
+
+        // Liberar creditos reservados para este item si el pago no se completo.
+        // Regla: si Credit esta RESERVED y asociado al shopping_cart_item_id, lo devolvemos a CREATED.
+        java.util.Set<Long> itemIds = java.util.Set.of(itemId);
+        List<Credit> reservedCredits = creditRepository.findByShoppingCartItemIdInAndStatusReserved(itemIds);
+        for (Credit c : reservedCredits) {
+            c.setReservedAmount(java.math.BigDecimal.ZERO);
+            c.setShoppingCartItemId(null);
+            c.setStatus(CreditStatusEnum.CREATED);
+        }
+        if (!reservedCredits.isEmpty()) {
+            creditRepository.saveAll(reservedCredits);
+        }
     }
 }
-

--- a/src/test/java/com/tourya/api/jobs/TemporalReservationExpiryJobTest.java
+++ b/src/test/java/com/tourya/api/jobs/TemporalReservationExpiryJobTest.java
@@ -1,0 +1,153 @@
+package com.tourya.api.jobs;
+
+import com.tourya.api.constans.enums.CreditStatusEnum;
+import com.tourya.api.constans.enums.DeliveryStatusEnum;
+import com.tourya.api.models.Credit;
+import com.tourya.api.models.Reservation;
+import com.tourya.api.models.ShoppingCartItem;
+import com.tourya.api.repository.CreditRepository;
+import com.tourya.api.repository.ReservationRepository;
+import com.tourya.api.repository.ShoppingCartItemRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Hotfix #179b: garantiza que el job maneja reservas con {@code item_id NULL}
+ * (huerfanas por FK ON DELETE SET NULL) y que un error en una reserva no
+ * arrastra al resto (cada iteracion en su propia TX REQUIRES_NEW).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("TemporalReservationExpiryJob")
+class TemporalReservationExpiryJobTest {
+
+    @Mock private ReservationRepository reservationRepository;
+    @Mock private ShoppingCartItemRepository shoppingCartItemRepository;
+    @Mock private CreditRepository creditRepository;
+    @Mock private PlatformTransactionManager transactionManager;
+
+    private TemporalReservationExpiryJob job;
+
+    @BeforeEach
+    void setUp() {
+        // TransactionManager mock devuelve un status funcional para que TransactionTemplate
+        // ejecute el callback en cada iteracion.
+        when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+        job = new TemporalReservationExpiryJob(
+                reservationRepository, shoppingCartItemRepository, creditRepository, transactionManager);
+    }
+
+    @Test
+    @DisplayName("no hace nada si no hay reservas expiradas")
+    void noExpired_skipsBatch() {
+        when(reservationRepository.findExpiredTemporalReservations(any())).thenReturn(List.of());
+
+        job.expireTemporalReservations();
+
+        verify(reservationRepository, never()).save(any());
+        verify(transactionManager, never()).getTransaction(any());
+    }
+
+    @Test
+    @DisplayName("reserva con itemId=NULL: solo marca CANCELED, no toca item ni creditos")
+    void expiredWithNullItemId_marksCanceledOnly() {
+        Reservation r = temporalReservation(305L, null);
+        when(reservationRepository.findExpiredTemporalReservations(any())).thenReturn(List.of(r));
+
+        job.expireTemporalReservations();
+
+        ArgumentCaptor<Reservation> saved = ArgumentCaptor.forClass(Reservation.class);
+        verify(reservationRepository).save(saved.capture());
+        assertThat(saved.getValue().getDeliveryStatus()).isEqualTo(DeliveryStatusEnum.CANCELED);
+        assertThat(saved.getValue().getExpiresAt()).isNull();
+        assertThat(saved.getValue().getCancellationDate()).isNotNull();
+
+        // No debe consultar item ni creditos si itemId es NULL
+        verify(shoppingCartItemRepository, never()).findById(any());
+        verify(creditRepository, never()).findByShoppingCartItemIdInAndStatusReserved(anySet());
+    }
+
+    @Test
+    @DisplayName("reserva con itemId valido: cancela + libera item y creditos RESERVED")
+    void expiredWithItemId_releasesItemAndCredits() {
+        Reservation r = temporalReservation(400L, 487L);
+        ShoppingCartItem item = new ShoppingCartItem();
+        item.setId(487L);
+        item.setReservationId(400L);
+        Credit credit = new Credit();
+        credit.setId(10L);
+        credit.setStatus(CreditStatusEnum.RESERVED);
+        credit.setReservedAmount(new BigDecimal("50.00"));
+        credit.setShoppingCartItemId(487L);
+
+        when(reservationRepository.findExpiredTemporalReservations(any())).thenReturn(List.of(r));
+        when(shoppingCartItemRepository.findById(487L)).thenReturn(Optional.of(item));
+        when(creditRepository.findByShoppingCartItemIdInAndStatusReserved(eq(Set.of(487L))))
+                .thenReturn(new ArrayList<>(List.of(credit)));
+
+        job.expireTemporalReservations();
+
+        verify(reservationRepository).save(r);
+        verify(shoppingCartItemRepository).save(item);
+        assertThat(item.getReservationId()).isNull();
+
+        ArgumentCaptor<List<Credit>> creditsCap = ArgumentCaptor.forClass(List.class);
+        verify(creditRepository).saveAll(creditsCap.capture());
+        Credit updated = creditsCap.getValue().get(0);
+        assertThat(updated.getStatus()).isEqualTo(CreditStatusEnum.CREATED);
+        assertThat(updated.getReservedAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(updated.getShoppingCartItemId()).isNull();
+    }
+
+    @Test
+    @DisplayName("hotfix: error en una reserva NO impide procesar las demas")
+    void errorInOneReservation_doesNotBlockOthers() {
+        Reservation ok1 = temporalReservation(500L, null);
+        Reservation boom = temporalReservation(501L, 999L);
+        Reservation ok2 = temporalReservation(502L, null);
+
+        when(reservationRepository.findExpiredTemporalReservations(any())).thenReturn(List.of(ok1, boom, ok2));
+        // El save de la reserva "boom" lanza — su tx REQUIRES_NEW se aisla,
+        // el resto sigue vivo.
+        when(reservationRepository.save(boom)).thenThrow(new RuntimeException("simulated DB error"));
+
+        job.expireTemporalReservations();
+
+        verify(reservationRepository).save(ok1);
+        verify(reservationRepository).save(boom);
+        verify(reservationRepository).save(ok2);
+    }
+
+    private Reservation temporalReservation(Long id, Long itemId) {
+        Reservation r = new Reservation();
+        r.setReservationId(id);
+        r.setItemId(itemId);
+        r.setDeliveryStatus(DeliveryStatusEnum.TEMPORAL);
+        r.setExpiresAt(LocalDateTime.now().minusMinutes(1));
+        return r;
+    }
+}


### PR DESCRIPTION
## Contexto

Continuación del hotfix del [issue #179](https://github.com/Touryapp/tourya-api/issues/179). El primer fix (aplicar migración 075 a Cloud SQL dev) desatasca POST /payment. **Este PR desatasca el job de expiración** que estaba en loop infinito de `UnexpectedRollbackException` desde el 2026-07-15.

## Root cause

- Migración 012 (feb/2026, feature de reschedule de Donnaly) puso el FK `reservation.item_id → shopping_cart_item.id` con `ON DELETE SET NULL`.
- Cuando un `shopping_cart_item` se borra (p.ej. `removeActiveItemsFromUserCart` en reschedule), la reserva TEMPORAL vinculada queda con `item_id = NULL`.
- `TemporalReservationExpiryJob` no cubría ese caso: hacía `shoppingCartItemRepository.findById(null)` → `IllegalArgumentException` → `try/catch` lo atrapaba pero JPA ya había marcado la tx como rollback-only → commit terminaba en `UnexpectedRollbackException` → **nada se guardaba**, siguiente corrida encontraba las mismas 8 reservas.
- Detonante: MO-40 Fase D del 15-jul rompió POST /payment. Los retries de Luis dispararon el flujo que dejó reservas TEMPORAL huérfanas → activó el bug latente.

## Cambios

- **Guard `if (itemId == null)`**: solo se marca CANCELED, no se toca item ni créditos.
- **Aislamiento por reserva**: cada iteración corre en `TransactionTemplate` con `PROPAGATION_REQUIRES_NEW`, así un fallo individual no arrastra al batch.
- **Log final** distingue procesadas OK vs fallidas aisladas.

## Test plan

- [x] `TemporalReservationExpiryJobTest` 4/4 verdes:
  - [x] no-op sin reservas expiradas
  - [x] `itemId == null` → solo CANCELED, no toca item ni créditos
  - [x] `itemId` válido → cancela + libera `reservationId` + devuelve créditos RESERVED→CREATED
  - [x] error en 1 reserva no bloquea las otras 2
- [x] Suite existente (`CreditExpirationJobTest`, `ReservationServiceRescheduleTest`) sigue verde.
- [ ] Tras merge + deploy: verificar en Cloud Logging que ya no aparece `UnexpectedRollbackException` cada minuto en `TemporalReservationExpiryJob` y que las 8 huérfanas pasan a CANCELED.

## Deudas relacionadas

- **MO-40b** (ya en backlog): mover hooks push a `@TransactionalEventListener(AFTER_COMMIT)` — evita que se repita el patrón "flow lateral tumba tx principal".
- **Conciliación Wompi**: revisar si las reservas 305–312 corresponden a cargos reales antes de dejarlas todas en CANCELED (dejo la limpieza SQL para hacer manualmente post-deploy, con confirmación previa).