### PR TITLE
MO-40b: hooks push a @TransactionalEventListener(AFTER_COMMIT) + @Async

### DIFF
--- a/src/main/java/com/tourya/api/jobs/CreditExpirationJob.java
+++ b/src/main/java/com/tourya/api/jobs/CreditExpirationJob.java
@@ -6,11 +6,12 @@ import com.tourya.api.models.User;
 import com.tourya.api.repository.CreditRepository;
 import com.tourya.api.repository.UserRepository;
 import com.tourya.api.services.EmailService;
-import com.tourya.api.services.PushNotificationService;
+import com.tourya.api.services.push.PushDomainEvent;
 import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,7 +55,7 @@ public class CreditExpirationJob {
     private final CreditRepository creditRepository;
     private final UserRepository userRepository;
     private final EmailService emailService;
-    private final PushNotificationService pushService; // MO-40 Fase D
+    private final ApplicationEventPublisher eventPublisher; // MO-40b
 
     @Value("${application.mailing.frontend.credit-url:https://tourya.co/}")
     private String creditUsageUrl;
@@ -97,8 +98,9 @@ public class CreditExpirationJob {
                     credit.setReminder7dSentAt(LocalDateTime.now());
                 }
                 creditRepository.save(credit);
-                // MO-40 Fase D: push en paralelo al email (best-effort)
-                pushService.notifyCreditExpiringSoonForTourist(credit.getUserId(), daysAdvance);
+                // MO-40b: push via evento AFTER_COMMIT (paralelo al email)
+                eventPublisher.publishEvent(new PushDomainEvent.CreditExpiringSoon(
+                        credit.getUserId(), daysAdvance));
                 sent++;
             } catch (MessagingException | RuntimeException e) {
                 log.warn("CreditExpirationJob: reminder{}d failed for credit {}: {}",
@@ -129,8 +131,8 @@ public class CreditExpirationJob {
                         "Tu crédito Tourya ha vencido"
                 );
                 credit.setExpiredNotifiedAt(LocalDateTime.now());
-                // MO-40 Fase D: push en paralelo al email
-                pushService.notifyCreditExpiredForTourist(credit.getUserId());
+                // MO-40b: push via evento AFTER_COMMIT (paralelo al email)
+                eventPublisher.publishEvent(new PushDomainEvent.CreditExpired(credit.getUserId()));
                 notified++;
             } catch (MessagingException | RuntimeException e) {
                 log.warn("CreditExpirationJob: expired notice failed for credit {}: {}",

--- a/src/main/java/com/tourya/api/jobs/TourReminder24hJob.java
+++ b/src/main/java/com/tourya/api/jobs/TourReminder24hJob.java
@@ -5,9 +5,10 @@ import com.tourya.api.models.ShoppingCartItem;
 import com.tourya.api.models.Tour;
 import com.tourya.api.models.TourSchedule;
 import com.tourya.api.repository.ReservationRepository;
-import com.tourya.api.services.PushNotificationService;
+import com.tourya.api.services.push.PushDomainEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,7 +43,7 @@ public class TourReminder24hJob {
     private static final ZoneId BOGOTA = ZoneId.of("America/Bogota");
 
     private final ReservationRepository reservationRepository;
-    private final PushNotificationService pushService;
+    private final ApplicationEventPublisher eventPublisher; // MO-40b
 
     @Scheduled(cron = "0 0 8 * * *", zone = "America/Bogota")
     @Transactional(readOnly = true)
@@ -69,7 +70,8 @@ public class TourReminder24hJob {
                 Tour tour = schedule != null ? schedule.getTour() : null;
                 String tourName = tour != null && tour.getName() != null ? tour.getName().getEs() : null;
 
-                pushService.notifyTourReminderForTourist(touristUserId, tourName, reservation.getReservationId());
+                eventPublisher.publishEvent(new PushDomainEvent.TourReminder24h(
+                        touristUserId, tourName, reservation.getReservationId()));
                 sent++;
             } catch (Exception ex) {
                 log.warn("TourReminder24hJob: failed for reservation {}: {}",

--- a/src/main/java/com/tourya/api/services/PaymentService.java
+++ b/src/main/java/com/tourya/api/services/PaymentService.java
@@ -20,8 +20,10 @@ import com.tourya.api.constans.enums.CancellationPolicyTypeEnum;
 import com.tourya.api.constans.enums.DeliveryStatusEnum;
 import com.tourya.api.constans.enums.ShoppingCartStatusEnum;
 import com.tourya.api.constans.enums.CreditStatusEnum;
+import com.tourya.api.services.push.PushDomainEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -63,7 +65,7 @@ public class PaymentService {
     private final CreditRepository creditRepository;
     private final PaymentCreditRepository paymentCreditRepository;
     private final EmailService emailService;
-    private final PushNotificationService pushService; // MO-40 Fase D
+    private final ApplicationEventPublisher eventPublisher; // MO-40b: push via eventos AFTER_COMMIT
     private final ReservationPriceBreakdownMapper reservationPriceBreakdownMapper;
     private final ReservationMapper reservationMapper;
     private final TourPrincipalOperatorService tourPrincipalOperatorService;
@@ -213,43 +215,39 @@ public class PaymentService {
 
         PaymentResponse response = buildPaymentResponse(savedPayment, reservations);
         sendPurchaseEmailBestEffort(savedPayment, response);
-        // MO-40 Fase D: push al turista (cada reserva) y al provider (una vez por tour).
-        sendPushOnReservationsConfirmedBestEffort(cartOwnerUserId, reservations);
+        // MO-40b: publica eventos de dominio; el listener corre en AFTER_COMMIT + @Async.
+        // Cualquier fallo del stack de push jamas puede tumbar esta tx.
+        publishReservationConfirmedEvents(cartOwnerUserId, reservations);
         return response;
     }
 
     /**
-     * MO-40 Fase D: envia push al turista por cada reserva confirmada y al
-     * provider titular por cada tour distinto (evita duplicar si un provider
-     * tiene 2 reservas del mismo pago). Best-effort — no falla el pago si push
-     * falla.
+     * MO-40b: resuelve tourName/providerUserId con la sesion JPA aun viva y
+     * publica un evento por-reserva al turista + un evento por-proveedor
+     * (dedup por providerUserId). Los eventos se procesan post-commit en
+     * hilos aparte via {@link com.tourya.api.services.push.PushDomainEventListener}.
      */
-    private void sendPushOnReservationsConfirmedBestEffort(Integer touristUserId, List<Reservation> reservations) {
+    private void publishReservationConfirmedEvents(Integer touristUserId, List<Reservation> reservations) {
         Set<Integer> notifiedProviders = new HashSet<>();
         for (Reservation reservation : reservations) {
-            try {
-                ShoppingCartItem item = shoppingCartItemRepository.findById(reservation.getItemId()).orElse(null);
-                Integer tourId = item != null && item.getTourSchedule() != null
-                        ? item.getTourSchedule().getTourId()
-                        : null;
-                Tour tour = tourId != null ? tourRepository.findById(tourId).orElse(null) : null;
-                String tourName = tour != null && tour.getName() != null ? tour.getName().getEs() : null;
+            ShoppingCartItem item = reservation.getItemId() != null
+                    ? shoppingCartItemRepository.findById(reservation.getItemId()).orElse(null)
+                    : null;
+            Integer tourId = item != null && item.getTourSchedule() != null
+                    ? item.getTourSchedule().getTourId()
+                    : null;
+            Tour tour = tourId != null ? tourRepository.findById(tourId).orElse(null) : null;
+            String tourName = tour != null && tour.getName() != null ? tour.getName().getEs() : null;
 
-                // Push al turista
-                pushService.notifyReservationConfirmedForTourist(
-                        touristUserId, tourName, reservation.getReservationId());
+            eventPublisher.publishEvent(new PushDomainEvent.ReservationConfirmedForTourist(
+                    touristUserId, tourName, reservation.getReservationId()));
 
-                // Push al provider (una sola vez por proveedor por pago)
-                Integer providerUserId = tour != null && tour.getProvider() != null && tour.getProvider().getUser() != null
-                        ? tour.getProvider().getUser().getId()
-                        : null;
-                if (providerUserId != null && notifiedProviders.add(providerUserId)) {
-                    pushService.notifyNewReservationForProvider(
-                            providerUserId, tourName, reservation.getReservationId());
-                }
-            } catch (Exception ex) {
-                log.warn("MO-40 push on reservation confirmed failed reservationId={}: {}",
-                        reservation.getReservationId(), ex.getMessage());
+            Integer providerUserId = tour != null && tour.getProvider() != null && tour.getProvider().getUser() != null
+                    ? tour.getProvider().getUser().getId()
+                    : null;
+            if (providerUserId != null && notifiedProviders.add(providerUserId)) {
+                eventPublisher.publishEvent(new PushDomainEvent.NewReservationForProvider(
+                        providerUserId, tourName, reservation.getReservationId()));
             }
         }
     }

--- a/src/main/java/com/tourya/api/services/ReviewService.java
+++ b/src/main/java/com/tourya/api/services/ReviewService.java
@@ -16,6 +16,8 @@ import com.tourya.api.models.responses.ReviewResponse;
 import com.tourya.api.models.mapper.ReservationMapper;
 import com.tourya.api.models.mapper.ReservationPriceBreakdownMapper;
 import com.tourya.api.repository.*;
+import com.tourya.api.services.push.PushDomainEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -72,7 +74,7 @@ public class ReviewService {
     private final ProviderService providerService;
     private final IStorageService s3Service;
     private final com.tourya.api.config.security.JwtService jwtService;
-    private final PushNotificationService pushService; // MO-40 Fase D
+    private final ApplicationEventPublisher eventPublisher; // MO-40b: push via eventos AFTER_COMMIT
     private final org.springframework.security.core.userdetails.UserDetailsService userDetailsService;
     private final TouristProfileRepository touristProfileRepository;
 
@@ -490,9 +492,8 @@ public class ReviewService {
             if (review.getTourId() != null) {
                 refreshAndPersistTourRating(review.getTourId());
             }
-            // MO-40 Fase D: notificar al turista dueño de la review que el
-            // provider respondió. Best-effort — no falla si push falla.
-            notifyReviewAnsweredBestEffort(review);
+            // MO-40b: publica evento; listener corre AFTER_COMMIT + @Async.
+            publishReviewRepliedEvent(review);
         }
 
         // Cargar relaciones para la respuesta
@@ -502,29 +503,24 @@ public class ReviewService {
     }
 
     /**
-     * MO-40 Fase D: notifica al turista dueño de la review que el provider
-     * respondió. Traza el turista via la reservation asociada a la review.
-     * Silencioso en fallo — la respuesta ya se guardó.
+     * MO-40b: resuelve turista + tourName con la sesion JPA abierta y publica
+     * el evento. El listener corre en AFTER_COMMIT + @Async.
      */
-    private void notifyReviewAnsweredBestEffort(Review review) {
-        try {
-            if (review.getReservationId() == null) return;
-            Reservation reservation = reservationRepository.findById(review.getReservationId()).orElse(null);
-            if (reservation == null) return;
-            ShoppingCartItem item = shoppingCartItemRepository.findById(reservation.getItemId()).orElse(null);
-            if (item == null || item.getShoppingCart() == null || item.getShoppingCart().getUser() == null) return;
-            Integer touristUserId = item.getShoppingCart().getUser().getId();
+    private void publishReviewRepliedEvent(Review review) {
+        if (review.getReservationId() == null) return;
+        Reservation reservation = reservationRepository.findById(review.getReservationId()).orElse(null);
+        if (reservation == null || reservation.getItemId() == null) return;
+        ShoppingCartItem item = shoppingCartItemRepository.findById(reservation.getItemId()).orElse(null);
+        if (item == null || item.getShoppingCart() == null || item.getShoppingCart().getUser() == null) return;
+        Integer touristUserId = item.getShoppingCart().getUser().getId();
 
-            String tourName = null;
-            if (review.getTourId() != null) {
-                Tour tour = tourRepository.findById(review.getTourId()).orElse(null);
-                tourName = tour != null && tour.getName() != null ? tour.getName().getEs() : null;
-            }
-            pushService.notifyReviewRepliedForTourist(touristUserId, tourName, reservation.getReservationId());
-        } catch (Exception ex) {
-            log.warn("MO-40 push on review answered failed reviewId={}: {}",
-                    review.getId(), ex.getMessage());
+        String tourName = null;
+        if (review.getTourId() != null) {
+            Tour tour = tourRepository.findById(review.getTourId()).orElse(null);
+            tourName = tour != null && tour.getName() != null ? tour.getName().getEs() : null;
         }
+        eventPublisher.publishEvent(new PushDomainEvent.ReviewReplied(
+                touristUserId, tourName, reservation.getReservationId()));
     }
 
     /**

--- a/src/main/java/com/tourya/api/services/push/PushDomainEvent.java
+++ b/src/main/java/com/tourya/api/services/push/PushDomainEvent.java
@@ -1,0 +1,59 @@
+package com.tourya.api.services.push;
+
+/**
+ * MO-40b: eventos de dominio de push notifications, publicados con
+ * {@code ApplicationEventPublisher} desde flows de negocio.
+ *
+ * <p>El listener corre con {@code @TransactionalEventListener(AFTER_COMMIT)} y
+ * {@code @Async}. Esto garantiza:</p>
+ * <ul>
+ *   <li>Si la tx principal hace rollback, el push nunca se envia.</li>
+ *   <li>Si el push falla, la tx principal ya cerro — nada afecta al negocio.</li>
+ *   <li>El listener no bloquea al productor (respuesta HTTP mas rapida).</li>
+ * </ul>
+ *
+ * <p>Snapshot: los eventos llevan los datos ya resueltos (tourName,
+ * providerUserId, etc.) en vez de IDs, para evitar rehacer queries en el
+ * listener y evitar problemas de sesion JPA cerrada.</p>
+ */
+public sealed interface PushDomainEvent {
+
+    /** Push al turista al confirmarse una reserva. Uno por reserva. */
+    record ReservationConfirmedForTourist(
+            Integer touristUserId,
+            String tourName,
+            Long reservationId
+    ) implements PushDomainEvent {}
+
+    /** Push al provider por una nueva reserva. Ya dedup-eado por proveedor por pago. */
+    record NewReservationForProvider(
+            Integer providerUserId,
+            String tourName,
+            Long reservationId
+    ) implements PushDomainEvent {}
+
+    /** Push cuando el provider responde una review. */
+    record ReviewReplied(
+            Integer touristUserId,
+            String tourName,
+            Long reservationId
+    ) implements PushDomainEvent {}
+
+    /** Recordatorio 24h antes del tour. */
+    record TourReminder24h(
+            Integer touristUserId,
+            String tourName,
+            Long reservationId
+    ) implements PushDomainEvent {}
+
+    /** Recordatorio 30d/7d antes de que expire un credito. */
+    record CreditExpiringSoon(
+            Integer userId,
+            int daysAdvance
+    ) implements PushDomainEvent {}
+
+    /** Notificacion de que un credito ha expirado. */
+    record CreditExpired(
+            Integer userId
+    ) implements PushDomainEvent {}
+}

--- a/src/main/java/com/tourya/api/services/push/PushDomainEventListener.java
+++ b/src/main/java/com/tourya/api/services/push/PushDomainEventListener.java
@@ -1,0 +1,78 @@
+package com.tourya.api.services.push;
+
+import com.tourya.api.services.PushNotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * MO-40b: listener que reacciona a {@link PushDomainEvent} DESPUES de que la
+ * tx de negocio hizo commit y en un hilo aparte ({@code @Async}). Si el push
+ * falla no afecta al productor ni a la tx original.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PushDomainEventListener {
+
+    private final PushNotificationService pushService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(PushDomainEvent.ReservationConfirmedForTourist e) {
+        safeSend("ReservationConfirmedForTourist", e.reservationId(),
+                () -> pushService.notifyReservationConfirmedForTourist(
+                        e.touristUserId(), e.tourName(), e.reservationId()));
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(PushDomainEvent.NewReservationForProvider e) {
+        safeSend("NewReservationForProvider", e.reservationId(),
+                () -> pushService.notifyNewReservationForProvider(
+                        e.providerUserId(), e.tourName(), e.reservationId()));
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(PushDomainEvent.ReviewReplied e) {
+        safeSend("ReviewReplied", e.reservationId(),
+                () -> pushService.notifyReviewRepliedForTourist(
+                        e.touristUserId(), e.tourName(), e.reservationId()));
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(PushDomainEvent.TourReminder24h e) {
+        safeSend("TourReminder24h", e.reservationId(),
+                () -> pushService.notifyTourReminderForTourist(
+                        e.touristUserId(), e.tourName(), e.reservationId()));
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(PushDomainEvent.CreditExpiringSoon e) {
+        safeSend("CreditExpiringSoon", null,
+                () -> pushService.notifyCreditExpiringSoonForTourist(
+                        e.userId(), e.daysAdvance()));
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(PushDomainEvent.CreditExpired e) {
+        safeSend("CreditExpired", null,
+                () -> pushService.notifyCreditExpiredForTourist(e.userId()));
+    }
+
+    private void safeSend(String eventType, Long correlationId, Runnable send) {
+        try {
+            send.run();
+        } catch (Exception ex) {
+            log.warn("MO-40b push failed type={} correlationId={} msg={}",
+                    eventType, correlationId, ex.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/tourya/api/jobs/CreditExpirationJobTest.java
+++ b/src/test/java/com/tourya/api/jobs/CreditExpirationJobTest.java
@@ -6,6 +6,7 @@ import com.tourya.api.models.User;
 import com.tourya.api.repository.CreditRepository;
 import com.tourya.api.repository.UserRepository;
 import com.tourya.api.services.EmailService;
+import com.tourya.api.services.push.PushDomainEvent;
 import jakarta.mail.MessagingException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
@@ -59,6 +61,7 @@ class CreditExpirationJobTest {
     @Mock private CreditRepository creditRepository;
     @Mock private UserRepository userRepository;
     @Mock private EmailService emailService;
+    @Mock private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private CreditExpirationJob job;
@@ -111,6 +114,8 @@ class CreditExpirationJobTest {
         verify(creditRepository).save(saved.capture());
         assertThat(saved.getValue().getReminder30dSentAt()).isNotNull();
         assertThat(saved.getValue().getReminder7dSentAt()).isNull();
+        // MO-40b: se publica evento de push, no llamada directa
+        verify(eventPublisher).publishEvent(new PushDomainEvent.CreditExpiringSoon(USER_ID, 30));
     }
 
     @Test
@@ -140,6 +145,7 @@ class CreditExpirationJobTest {
         verify(creditRepository).save(saved.capture());
         assertThat(saved.getValue().getReminder7dSentAt()).isNotNull();
         assertThat(saved.getValue().getReminder30dSentAt()).isNull();
+        verify(eventPublisher).publishEvent(new PushDomainEvent.CreditExpiringSoon(USER_ID, 7));
     }
 
     @Test
@@ -167,6 +173,7 @@ class CreditExpirationJobTest {
         verify(creditRepository).save(saved.capture());
         assertThat(saved.getValue().getStatus()).isEqualTo(CreditStatusEnum.EXPIRED);
         assertThat(saved.getValue().getExpiredNotifiedAt()).isNotNull();
+        verify(eventPublisher).publishEvent(new PushDomainEvent.CreditExpired(USER_ID));
     }
 
     @Test

--- a/src/test/java/com/tourya/api/services/push/PushDomainEventListenerTest.java
+++ b/src/test/java/com/tourya/api/services/push/PushDomainEventListenerTest.java
@@ -1,0 +1,116 @@
+package com.tourya.api.services.push;
+
+import com.tourya.api.services.PushNotificationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+/**
+ * MO-40b — cubre el fan-out del listener a cada helper de {@link PushNotificationService}
+ * mas invariantes: cada handler es {@code @Async} + {@code @TransactionalEventListener(AFTER_COMMIT)}
+ * y ninguna excepcion del push propaga fuera del listener (safeSend).
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MO-40b PushDomainEventListener")
+class PushDomainEventListenerTest {
+
+    @Mock private PushNotificationService pushService;
+
+    private PushDomainEventListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new PushDomainEventListener(pushService);
+    }
+
+    @Test
+    @DisplayName("ReservationConfirmedForTourist -> notifyReservationConfirmedForTourist")
+    void reservationConfirmed_fanOut() {
+        listener.on(new PushDomainEvent.ReservationConfirmedForTourist(10, "Rafting", 400L));
+        verify(pushService).notifyReservationConfirmedForTourist(10, "Rafting", 400L);
+    }
+
+    @Test
+    @DisplayName("NewReservationForProvider -> notifyNewReservationForProvider")
+    void newReservationForProvider_fanOut() {
+        listener.on(new PushDomainEvent.NewReservationForProvider(20, "Kayak", 401L));
+        verify(pushService).notifyNewReservationForProvider(20, "Kayak", 401L);
+    }
+
+    @Test
+    @DisplayName("ReviewReplied -> notifyReviewRepliedForTourist")
+    void reviewReplied_fanOut() {
+        listener.on(new PushDomainEvent.ReviewReplied(30, "Snorkel", 402L));
+        verify(pushService).notifyReviewRepliedForTourist(30, "Snorkel", 402L);
+    }
+
+    @Test
+    @DisplayName("TourReminder24h -> notifyTourReminderForTourist")
+    void tourReminder_fanOut() {
+        listener.on(new PushDomainEvent.TourReminder24h(40, "Zipline", 403L));
+        verify(pushService).notifyTourReminderForTourist(40, "Zipline", 403L);
+    }
+
+    @Test
+    @DisplayName("CreditExpiringSoon -> notifyCreditExpiringSoonForTourist")
+    void creditExpiring_fanOut() {
+        listener.on(new PushDomainEvent.CreditExpiringSoon(50, 7));
+        verify(pushService).notifyCreditExpiringSoonForTourist(50, 7);
+    }
+
+    @Test
+    @DisplayName("CreditExpired -> notifyCreditExpiredForTourist")
+    void creditExpired_fanOut() {
+        listener.on(new PushDomainEvent.CreditExpired(60));
+        verify(pushService).notifyCreditExpiredForTourist(60);
+    }
+
+    @Test
+    @DisplayName("safeSend: excepcion en push NO propaga fuera del listener")
+    void pushFailure_isSwallowed() {
+        doThrow(new RuntimeException("FCM down"))
+                .when(pushService).notifyReservationConfirmedForTourist(10, null, 999L);
+
+        // No debe lanzar — safeSend traga el error y solo loguea.
+        listener.on(new PushDomainEvent.ReservationConfirmedForTourist(10, null, 999L));
+
+        verify(pushService).notifyReservationConfirmedForTourist(10, null, 999L);
+    }
+
+    @Test
+    @DisplayName("invariante: todos los handlers son @Async + @TransactionalEventListener(AFTER_COMMIT)")
+    void allHandlers_areAsyncAndAfterCommit() throws NoSuchMethodException {
+        // Este test previene una regresion futura: si alguien quita @Async o cambia
+        // la fase del TransactionalEventListener, este test lo detecta.
+        for (Class<?> eventType : new Class<?>[] {
+                PushDomainEvent.ReservationConfirmedForTourist.class,
+                PushDomainEvent.NewReservationForProvider.class,
+                PushDomainEvent.ReviewReplied.class,
+                PushDomainEvent.TourReminder24h.class,
+                PushDomainEvent.CreditExpiringSoon.class,
+                PushDomainEvent.CreditExpired.class,
+        }) {
+            Method handler = PushDomainEventListener.class.getDeclaredMethod("on", eventType);
+            Async async = AnnotatedElementUtils.findMergedAnnotation(handler, Async.class);
+            TransactionalEventListener tel =
+                    AnnotatedElementUtils.findMergedAnnotation(handler, TransactionalEventListener.class);
+
+            assertThat(async).as("@Async en handler " + eventType.getSimpleName()).isNotNull();
+            assertThat(tel).as("@TransactionalEventListener en handler " + eventType.getSimpleName()).isNotNull();
+            assertThat(tel.phase()).isEqualTo(TransactionPhase.AFTER_COMMIT);
+        }
+    }
+}


### PR DESCRIPTION
## Contexto

Cierra la deuda estructural abierta tras el issue [#179](https://github.com/Touryapp/tourya-api/issues/179): los hooks de push notification de Fase D vivían dentro del `@Transactional` de negocio → cualquier fallo (BD, red a FCM, dependencia) marcaba la tx como rollback-only y tumbaba el pago aunque Wompi ya hubiera cobrado.

## Cambio

Se introduce una capa de eventos de dominio con un listener que corre con `@TransactionalEventListener(phase = AFTER_COMMIT)` y `@Async`. Los productores solo publican; el listener consume después del commit y en otro hilo.

### Nuevos archivos

- `services/push/PushDomainEvent.java` — `sealed interface` + 6 `record`s (uno por acción de dominio). Cada evento **snapshotea** los datos ya resueltos (`tourName`, `providerUserId`) para no re-consultar en el listener y evitar problemas de sesión JPA cerrada.
- `services/push/PushDomainEventListener.java` — un `@Async @TransactionalEventListener(AFTER_COMMIT)` por tipo, con `safeSend` que traga excepciones del stack de push y las loguea WARN.

### 5 flows migrados (`pushService.notify…` → `eventPublisher.publishEvent(...)`)

1. `PaymentService.processPayment` — turista + provider (dedup por proveedor).
2. `ReviewService.updateReview` — turista cuando provider responde review.
3. `TourReminder24hJob` — turista recordatorio 24h antes.
4. `CreditExpirationJob.sendReminders` — turista crédito por expirar.
5. `CreditExpirationJob.markAndNotifyExpired` — turista crédito expirado.

## Garantías nuevas

| Antes | Ahora |
|---|---|
| Push falla dentro de tx → tx marcada rollback-only → pago se pierde | Push falla → tx ya cerró → nada afecta al negocio |
| Push síncrono bloquea la respuesta al cliente | `@Async` → POST /payment responde antes |
| Rollback del pago igual disparaba push fantasma en el catch | `AFTER_COMMIT` → si hay rollback, evento nunca corre |

## Test plan

- [x] `PushDomainEventListenerTest` — 8 nuevos (6 fan-out por tipo, 1 safeSend traga error, 1 invariante `@Async + AFTER_COMMIT` en TODOS los handlers para prevenir regresiones futuras).
- [x] `CreditExpirationJobTest` — 7 verdes, actualizados para verificar `publishEvent` en vez de la llamada directa a `pushService`.
- [x] `TemporalReservationExpiryJobTest`, `ReservationServiceRescheduleTest`, `BudgetGuardTest`, `PromptTemplateTest` — sin cambios y verdes.
- [x] `./mvnw test`: **46/47 verdes** (el 1 restante es `TouryaApiApplicationTests.contextLoads` — falla también en develop porque no hay Postgres local; no es regresión).
- [ ] Post-deploy dev: validar que `POST /payment` sigue en 2xx, que aparecen push al mobile de Luis, y que `TourReminder24hJob` no rompe pushes.

## Riesgo residual

`@Async` requiere que `@EnableAsync` esté activo — ya lo está (`TouryaApiApplication.java` línea 13). Sin él, los handlers correrían síncronos pero seguirían siendo `AFTER_COMMIT` → seguiría siendo un fix válido, solo perderíamos el paralelismo.