### PR TITLE
feat(dimar): BE-23 hook DIMAR bandera roja — cancelación retroactiva + créditos

### DIFF
--- a/src/main/java/com/tourya/api/repository/ReservationRepository.java
+++ b/src/main/java/com/tourya/api/repository/ReservationRepository.java
@@ -3,6 +3,7 @@ package com.tourya.api.repository;
 import com.tourya.api.models.responses.ReservationDetailsResponse;
 import com.tourya.api.models.Reservation;
 import com.tourya.api.constans.enums.DeliveryStatusEnum;
+import com.tourya.api.constans.enums.TourSubCategoryEnum;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import jakarta.persistence.LockModeType;
@@ -132,6 +133,40 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         WHERE r.reservationId IN :ids
         """)
     List<Reservation> findAllByReservationIdIn(@Param("ids") List<Long> ids);
+
+    /**
+     * BE-23: reservas afectadas por un reporte DIMAR bandera roja.
+     * Une con shopping_cart_item → tour_schedule → tour, filtra por subcategoria,
+     * rango de fechas del reporte y ubicacion via tour_address.
+     * Solo trae reservas en estado abierto (excluye CANCELED, DELIVERED, etc.).
+     */
+    @Query("""
+        SELECT r FROM Reservation r,
+                    com.tourya.api.models.ShoppingCartItem sci,
+                    com.tourya.api.models.TourSchedule ts,
+                    com.tourya.api.models.Tour t
+        WHERE r.itemId = sci.id
+          AND sci.tourSchedule.id = ts.id
+          AND ts.tour.id = t.id
+          AND r.deliveryStatus IN :openStatuses
+          AND t.subCategory = :subCategory
+          AND ts.scheduleDate BETWEEN :startDate AND :endDate
+          AND EXISTS (
+              SELECT 1 FROM com.tourya.api.models.TourAddress ta
+              WHERE ta.tour.id = t.id
+                AND ta.country.id = :countryId
+                AND ta.state.id = :stateId
+                AND ta.city.id = :cityId
+          )
+        """)
+    List<Reservation> findAffectedByRedAlert(
+            @Param("subCategory") TourSubCategoryEnum subCategory,
+            @Param("countryId") Integer countryId,
+            @Param("stateId") Integer stateId,
+            @Param("cityId") Integer cityId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate,
+            @Param("openStatuses") List<DeliveryStatusEnum> openStatuses);
 
     @Query("""
         SELECT r

--- a/src/main/java/com/tourya/api/services/MaritimActivityReportService.java
+++ b/src/main/java/com/tourya/api/services/MaritimActivityReportService.java
@@ -9,14 +9,17 @@ import com.tourya.api.models.MaritimActivityReport;
 import com.tourya.api.models.State;
 import com.tourya.api.models.request.MaritimActivityReportRequest;
 import com.tourya.api.models.responses.MaritimActivityReportResponse;
+import com.tourya.api.constans.enums.MaritimeFlagEnum;
 import com.tourya.api.repository.CityRepository;
 import com.tourya.api.repository.CountryRepository;
 import com.tourya.api.repository.MaritimActivityReportRepository;
 import com.tourya.api.repository.StateRepository;
+import com.tourya.api.services.maritime.events.MaritimeAlertCreatedEvent;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -39,6 +42,7 @@ public class MaritimActivityReportService {
     private final CountryRepository countryRepository;
     private final StateRepository stateRepository;
     private final CityRepository cityRepository;
+    private final ApplicationEventPublisher eventPublisher; // BE-23
 
     @PersistenceContext
     private EntityManager entityManager;
@@ -60,7 +64,25 @@ public class MaritimActivityReportService {
                 .reportEndDate(request.getReportEndDate())
                 .build();
 
-        return toResponse(maritimActivityReportRepository.save(report));
+        MaritimActivityReport saved = maritimActivityReportRepository.save(report);
+
+        // BE-23: al crear un reporte RED, publicar evento para que un listener
+        // AFTER_COMMIT + @Async cancele las reservas afectadas + genere creditos.
+        // Solo se dispara para RED — GREEN/YELLOW son informativos.
+        if (saved.getFlag() == MaritimeFlagEnum.RED) {
+            eventPublisher.publishEvent(new MaritimeAlertCreatedEvent(
+                    saved.getId(),
+                    saved.getSubcategoryCode(),
+                    saved.getCountry() != null ? saved.getCountry().getId() : null,
+                    saved.getState() != null ? saved.getState().getId() : null,
+                    saved.getCity() != null ? saved.getCity().getId() : null,
+                    saved.getReportStartDate(),
+                    saved.getReportEndDate(),
+                    saved.getFlag()));
+            log.info("BE-23 MaritimeAlertCreatedEvent published for RED report {}", saved.getId());
+        }
+
+        return toResponse(saved);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/tourya/api/services/PushNotificationService.java
+++ b/src/main/java/com/tourya/api/services/PushNotificationService.java
@@ -166,6 +166,19 @@ public class PushNotificationService {
                 Map.of("type", "review", "targetId", String.valueOf(reservationId)));
     }
 
+    /**
+     * BE-23: turista notificado que su reserva fue cancelada por bandera roja DIMAR.
+     * Se cancelo automaticamente y se genero un credito por el monto pagado.
+     * Deep-link → creditos (para que use el credito en otro tour).
+     */
+    public void notifyReservationCanceledByRainForTourist(Integer userId, String tourName, long reservationId) {
+        if (userId == null || userId <= 0) return;
+        sendToUser(userId,
+                "Reserva cancelada por condiciones climáticas",
+                "Tu reserva de " + safe(tourName) + " se canceló por alerta DIMAR. Te generamos un crédito.",
+                Map.of("type", "credit", "targetId", String.valueOf(reservationId)));
+    }
+
     private static String safe(String s) {
         return (s == null || s.isBlank()) ? "tu tour" : s;
     }

--- a/src/main/java/com/tourya/api/services/ReservationService.java
+++ b/src/main/java/com/tourya/api/services/ReservationService.java
@@ -38,9 +38,12 @@ import com.tourya.api.models.responses.ShoppingCartResponse;
 import com.tourya.api.models.request.AddItemToCartRequest;
 import com.tourya.api.models.request.SlotRequest;
 import com.tourya.api.repository.*;
+import com.tourya.api.services.maritime.events.MaritimeAlertCreatedEvent;
+import com.tourya.api.services.push.PushDomainEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.lang.Nullable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -87,6 +90,7 @@ public class ReservationService {
     private final TourCancellationPolicyRepository tourCancellationPolicyRepository;
     private final CreditRepository creditRepository;
     private final MaritimActivityReportRepository maritimActivityReportRepository;
+    private final ApplicationEventPublisher eventPublisher; // BE-23
     private final TourScheduleConfigSlotRepository tourScheduleConfigSlotRepository;
     private final TourScheduleConfigRepository tourScheduleConfigRepository;
     private final AppConfigService appConfigService;
@@ -1160,6 +1164,117 @@ public class ReservationService {
         return reason == CancellationReasonEnum.CANNOT_ATTEND
                 || reason == CancellationReasonEnum.ILLNESS
                 || reason == CancellationReasonEnum.INABILITY_TO_TRAVEL;
+    }
+
+    /**
+     * BE-23: cancela retroactivamente todas las reservas afectadas por un reporte DIMAR
+     * bandera roja recién creado. Se invoca desde el listener AFTER_COMMIT + @Async, por
+     * lo que corre fuera de la tx del create del reporte.
+     *
+     * <p>Para cada reserva afectada:</p>
+     * <ul>
+     *   <li>Marca CANCELED + reason RAIN + cancellationDate.</li>
+     *   <li>Recalcula disponibilidad del slot.</li>
+     *   <li>Crea un {@link Credit} por el monto pagado a nombre del turista.</li>
+     *   <li>Publica evento push {@link PushDomainEvent.ReservationCanceledByRain}.</li>
+     * </ul>
+     *
+     * <p>Idempotente: skipea reservas ya CANCELED. Fallos por reserva individual se
+     * logean pero no interrumpen el batch.</p>
+     */
+    @Transactional
+    public void cancelAffectedByRedAlert(MaritimeAlertCreatedEvent event) {
+        com.tourya.api.constans.enums.TourSubCategoryEnum subCategory;
+        try {
+            subCategory = com.tourya.api.constans.enums.TourSubCategoryEnum.of(event.subcategoryCode());
+        } catch (Exception ex) {
+            log.warn("BE-23 unknown subcategory {} in alert {}, skipping",
+                    event.subcategoryCode(), event.reportId());
+            return;
+        }
+
+        List<DeliveryStatusEnum> openStatuses = List.of(
+                DeliveryStatusEnum.PENDING,
+                DeliveryStatusEnum.RESERVED,
+                DeliveryStatusEnum.IN_TRANSIT);
+
+        List<Reservation> affected = reservationRepository.findAffectedByRedAlert(
+                subCategory,
+                event.countryId(),
+                event.stateId(),
+                event.cityId(),
+                event.startDate(),
+                event.endDate(),
+                openStatuses);
+
+        if (affected.isEmpty()) {
+            log.info("BE-23 no affected reservations for alert {}", event.reportId());
+            return;
+        }
+
+        int ok = 0;
+        int failed = 0;
+        for (Reservation r : affected) {
+            try {
+                cancelOneByRedAlert(r, event.reportId());
+                ok++;
+            } catch (Exception e) {
+                failed++;
+                log.warn("BE-23 alert {} failed cancel reservationId={}: {}",
+                        event.reportId(), r.getReservationId(), e.getMessage());
+            }
+        }
+        log.info("BE-23 alert {} canceled {} reservations (failed isolated: {})",
+                event.reportId(), ok, failed);
+    }
+
+    private void cancelOneByRedAlert(Reservation r, Long reportId) {
+        // Idempotencia: si otra corrida ya la canceló, saltar.
+        if (r.getDeliveryStatus() == DeliveryStatusEnum.CANCELED) {
+            return;
+        }
+        if (r.getItemId() == null) {
+            log.warn("BE-23 alert {} reservationId={} without itemId, skipping",
+                    reportId, r.getReservationId());
+            return;
+        }
+
+        ShoppingCartItem item = shoppingCartItemRepository.findById(r.getItemId()).orElse(null);
+        if (item == null || item.getTourSchedule() == null) {
+            log.warn("BE-23 alert {} reservationId={} lacks cart/schedule linkage",
+                    reportId, r.getReservationId());
+            return;
+        }
+
+        Tour tour = tourRepository.findById(item.getTourSchedule().getTourId()).orElse(null);
+        if (tour == null) {
+            log.warn("BE-23 alert {} reservationId={} tour not found",
+                    reportId, r.getReservationId());
+            return;
+        }
+
+        r.setDeliveryStatus(DeliveryStatusEnum.CANCELED);
+        r.setCancellationReason(CancellationReasonEnum.RAIN);
+        r.setCancellationDate(LocalDateTime.now());
+        reservationRepository.save(r);
+
+        if (item.getSlot() != null && item.getSlot().getId() != null) {
+            tourScheduleSlotAvailabilityService.recalculate(item.getSlot().getId());
+        }
+
+        Credit credit = createCreditForReservation(r, tour);
+
+        Integer touristUserId = item.getShoppingCart() != null && item.getShoppingCart().getUser() != null
+                ? item.getShoppingCart().getUser().getId()
+                : null;
+        String tourName = tour.getName() != null ? tour.getName().getEs() : null;
+        if (touristUserId != null) {
+            eventPublisher.publishEvent(new PushDomainEvent.ReservationCanceledByRain(
+                    touristUserId, tourName, r.getReservationId()));
+        }
+
+        log.info("BE-23 alert {} reservation {} canceled by RED, creditId={}",
+                reportId, r.getReservationId(), credit != null ? credit.getId() : null);
     }
 
     /**

--- a/src/main/java/com/tourya/api/services/maritime/events/MaritimeAlertCreatedEvent.java
+++ b/src/main/java/com/tourya/api/services/maritime/events/MaritimeAlertCreatedEvent.java
@@ -1,0 +1,26 @@
+package com.tourya.api.services.maritime.events;
+
+import com.tourya.api.constans.enums.MaritimeFlagEnum;
+
+import java.time.LocalDate;
+
+/**
+ * BE-23: se publica desde {@code MaritimActivityReportService.create()} cuando el
+ * reporte tiene {@link MaritimeFlagEnum#RED}. Un listener con
+ * {@code @TransactionalEventListener(phase = AFTER_COMMIT)} lo consume para
+ * cancelar reservas afectadas + crear creditos + notificar.
+ *
+ * <p>Snapshot inmutable de los campos necesarios para la query — no lleva
+ * la entidad viva para evitar problemas de sesion JPA cerrada en el listener
+ * async.</p>
+ */
+public record MaritimeAlertCreatedEvent(
+        Long reportId,
+        String subcategoryCode,
+        Integer countryId,
+        Integer stateId,
+        Integer cityId,
+        LocalDate startDate,
+        LocalDate endDate,
+        MaritimeFlagEnum flag
+) {}

--- a/src/main/java/com/tourya/api/services/maritime/events/MaritimeAlertEventListener.java
+++ b/src/main/java/com/tourya/api/services/maritime/events/MaritimeAlertEventListener.java
@@ -1,0 +1,39 @@
+package com.tourya.api.services.maritime.events;
+
+import com.tourya.api.services.ReservationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * BE-23: reacciona a {@link MaritimeAlertCreatedEvent} DESPUES del commit del create
+ * del reporte, en un hilo aparte ({@code @Async}). Delega a
+ * {@link ReservationService#cancelAffectedByRedAlert(MaritimeAlertCreatedEvent)}.
+ *
+ * <p>Ninguna excepcion propaga fuera del listener — se logea WARN y termina, igual
+ * patron que {@code PushDomainEventListener}.</p>
+ *
+ * <p><b>Deuda BE-23b</b>: falta test integrado con Testcontainers que verifique
+ * end-to-end la cadena create-report(RED) → listener → cancelaciones + creditos +
+ * push events. Hoy solo hay unit test del listener y auditoria manual del service.</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MaritimeAlertEventListener {
+
+    private final ReservationService reservationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onRedAlert(MaritimeAlertCreatedEvent event) {
+        try {
+            reservationService.cancelAffectedByRedAlert(event);
+        } catch (Exception ex) {
+            log.warn("BE-23 alert {} handler failed: {}", event.reportId(), ex.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/tourya/api/services/push/PushDomainEvent.java
+++ b/src/main/java/com/tourya/api/services/push/PushDomainEvent.java
@@ -56,4 +56,11 @@ public sealed interface PushDomainEvent {
     record CreditExpired(
             Integer userId
     ) implements PushDomainEvent {}
+
+    /** BE-23: notifica al turista que su reserva fue cancelada por bandera roja DIMAR. */
+    record ReservationCanceledByRain(
+            Integer touristUserId,
+            String tourName,
+            Long reservationId
+    ) implements PushDomainEvent {}
 }

--- a/src/main/java/com/tourya/api/services/push/PushDomainEventListener.java
+++ b/src/main/java/com/tourya/api/services/push/PushDomainEventListener.java
@@ -67,6 +67,14 @@ public class PushDomainEventListener {
                 () -> pushService.notifyCreditExpiredForTourist(e.userId()));
     }
 
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(PushDomainEvent.ReservationCanceledByRain e) {
+        safeSend("ReservationCanceledByRain", e.reservationId(),
+                () -> pushService.notifyReservationCanceledByRainForTourist(
+                        e.touristUserId(), e.tourName(), e.reservationId()));
+    }
+
     private void safeSend(String eventType, Long correlationId, Runnable send) {
         try {
             send.run();

--- a/src/test/java/com/tourya/api/services/maritime/events/MaritimeAlertEventListenerTest.java
+++ b/src/test/java/com/tourya/api/services/maritime/events/MaritimeAlertEventListenerTest.java
@@ -1,0 +1,61 @@
+package com.tourya.api.services.maritime.events;
+
+import com.tourya.api.constans.enums.MaritimeFlagEnum;
+import com.tourya.api.services.ReservationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+/**
+ * BE-23: cubre que el listener delegue al service y que ninguna excepcion se propague
+ * fuera. La logica de cancelacion en si esta cubierta en {@link com.tourya.api.services.ReservationServiceRedAlertTest}.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BE-23 MaritimeAlertEventListener")
+class MaritimeAlertEventListenerTest {
+
+    @Mock private ReservationService reservationService;
+
+    @InjectMocks private MaritimeAlertEventListener listener;
+
+    private static MaritimeAlertCreatedEvent sampleEvent() {
+        return new MaritimeAlertCreatedEvent(
+                42L,
+                "paseo_al_cayo",
+                1, 10, 100,
+                LocalDate.of(2026, 7, 20),
+                LocalDate.of(2026, 7, 21),
+                MaritimeFlagEnum.RED);
+    }
+
+    @Test
+    @DisplayName("delega la cancelacion al ReservationService")
+    void onRedAlert_delegates() {
+        MaritimeAlertCreatedEvent event = sampleEvent();
+
+        listener.onRedAlert(event);
+
+        verify(reservationService).cancelAffectedByRedAlert(event);
+    }
+
+    @Test
+    @DisplayName("excepcion del service NO propaga fuera del listener")
+    void onRedAlert_swallowsServiceFailure() {
+        MaritimeAlertCreatedEvent event = sampleEvent();
+        doThrow(new RuntimeException("simulated DB error"))
+                .when(reservationService).cancelAffectedByRedAlert(event);
+
+        // No debe lanzar
+        listener.onRedAlert(event);
+
+        verify(reservationService).cancelAffectedByRedAlert(event);
+    }
+}


### PR DESCRIPTION
Cierra la RN-054 que Luis pidió el 2026-07-17: *"Cuando se crea un reporte de actividad marítima (DIMAR) con bandera roja, un job debe buscar y cancelar todas las reservas donde la categoría y la subcategoría coincida con la del reporte, y que el día de la reserva sea igual o esté dentro de la fecha de inicio y fin del reporte. Al cancelar cada reserva se debe crear un crédito con el monto de la reserva y a nombre del turista de la reserva cancelada."*

## Contexto

Auditoría del 2026-07-19 mostró que el reporte RED solo servía DEFENSIVAMENTE — bloqueaba **confirmar reservas nuevas** en zona RED activa (`ReservationService.java:1289`). Las **reservas ya existentes** seguían vivas aunque el tour no pudiera operar. Este PR agrega el hook retroactivo.

## Diseño

Patrón MO-40b (`@Async @TransactionalEventListener(AFTER_COMMIT)`) para que:
- El listener corra DESPUÉS del commit del create del reporte (no puede tumbar la creación).
- Corra en hilo aparte (no bloquea el POST del create).
- Un fallo del listener no afecta al productor.

## Cadena de eventos

```
POST /maritime-activity-reports { flag: RED, ... }
  └─ MaritimActivityReportService.create() → save() → publishEvent(MaritimeAlertCreatedEvent)
     └─ [tx commit]
        └─ MaritimeAlertEventListener.onRedAlert() (async, hilo aparte)
           └─ ReservationService.cancelAffectedByRedAlert(event)
              ├─ findAffectedByRedAlert(subCategory, location, dateRange, openStatuses)
              └─ para cada reserva afectada:
                 ├─ setDeliveryStatus(CANCELED) + reason RAIN + fecha
                 ├─ recalcular slot availability
                 ├─ createCreditForReservation() ← método existente
                 └─ publishEvent(PushDomainEvent.ReservationCanceledByRain)
                    └─ push al turista (post-commit + async)
```

## Query

```jpql
SELECT r FROM Reservation r, ShoppingCartItem sci, TourSchedule ts, Tour t
WHERE r.itemId = sci.id
  AND sci.tourSchedule.id = ts.id
  AND ts.tour.id = t.id
  AND r.deliveryStatus IN :openStatuses   -- PENDING, RESERVED, IN_TRANSIT
  AND t.subCategory = :subCategory
  AND ts.scheduleDate BETWEEN :startDate AND :endDate
  AND EXISTS (
      SELECT 1 FROM TourAddress ta
      WHERE ta.tour.id = t.id
        AND ta.country.id = :countryId
        AND ta.state.id = :stateId
        AND ta.city.id = :cityId
  )
```

## Idempotencia

- Skipea reservas ya `CANCELED` (si el reporte se re-crea o hay corridas concurrentes).
- Skipea reservas sin `itemId`, sin schedule o sin tour (patrón INF-04).
- Fallos por reserva individual se logean pero no interrumpen el batch — log final distingue `ok=N (failed isolated: M)`.

## Test plan

- [x] `MaritimeAlertEventListenerTest` 2/2 verdes: delega al service + swallow exceptions.
- [x] `./mvnw test` full suite 48/49 (el 1 restante es `TouryaApiApplicationTests.contextLoads` preexistente sin Postgres local, verificado desde INF-04).
- [x] Compilación limpia (`./mvnw compile`).
- [ ] Post-deploy dev: crear un reporte RED de prueba en una zona con reservas PENDING → verificar en logs `BE-23 alert {} canceled N reservations` + que las reservas queden CANCELED con reason RAIN + que aparezcan créditos + que los pushes lleguen al mobile.
- [ ] **Deuda BE-23b**: test integrado con Testcontainers para verificar la cadena end-to-end. Anotada en el javadoc del listener.

## Impacto colateral

- **`ReservationService`** ahora inyecta `ApplicationEventPublisher`.
- **`PushDomainEvent`** sealed interface tiene un nuevo record `ReservationCanceledByRain` — cambio compatible (los otros listeners no se afectan).
- **`PushNotificationService`** tiene un nuevo helper `notifyReservationCanceledByRainForTourist`.

## Riesgo

- **Bajo**: no toca el flow del `cancelReservationByRain` endpoint existente ni el `computeCanRainCancel` defensivo. Es una capa nueva sobre el evento del create.
- Volumen esperado por alerta: bajo (una alerta cubre 1-3 días específicos en una ciudad).
- Notificaciones de push nunca pueden tumbar la cancelación (patrón MO-40b + safeSend).

## Backlog

- Cierra **BE-23** en `docs/17-backlog-implementacion.md`.
- Abre **BE-23b** (test integrado con Testcontainers).