### PR TITLE
feat(providers): BE-22c + BE-22d — endpoint operadores por tour + phone en User

### DIFF
--- a/database/migrations/077_user_phone.sql
+++ b/database/migrations/077_user_phone.sql
@@ -1,0 +1,16 @@
+-- Migration 077 — BE-22d
+-- Agrega columna phone al _user para permitir que sub-usuarios (PROVIDER_OPERATOR
+-- y futuros roles) tengan su propio numero de contacto.
+--
+-- Hoy `TourPrincipalOperatorService.fromOperatorLink()` usa `provider.phone`
+-- como fallback del phone del operador — con este campo, el operador principal
+-- de un tour muestra su propio numero (RN-026 de Luis 2026-07-19).
+--
+-- Aditiva, nullable, sin backfill: usuarios existentes quedan NULL y el
+-- servicio hace fallback al provider.phone (retrocompatible).
+
+ALTER TABLE public._user
+    ADD COLUMN IF NOT EXISTS phone VARCHAR(20) NULL;
+
+COMMENT ON COLUMN public._user.phone IS
+    'BE-22d: telefono de contacto del usuario. Usado por PROVIDER_OPERATOR como contacto principal del tour (RN-026). NULL cuando no se ha cargado — el fallback en TourPrincipalOperatorService toma provider.phone.';

--- a/src/main/java/com/tourya/api/controller/ProviderUserController.java
+++ b/src/main/java/com/tourya/api/controller/ProviderUserController.java
@@ -67,6 +67,14 @@ public class ProviderUserController {
                 providerUserService.updatePrincipalTour(providerUserId, tourId, connectedUser));
     }
 
+    @GetMapping("/tour/{tourId}")
+    @Operation(summary = "BE-22c: Listar operadores asignados a un tour del PROVIDER autenticado. Cada operador incluye flag isPrincipal.")
+    public ResponseEntity<List<ProviderOperatorResponse>> listOperatorsByTour(
+            @PathVariable Integer tourId,
+            Authentication connectedUser) {
+        return ResponseEntity.ok(providerUserService.listOperatorsByTour(tourId, connectedUser));
+    }
+
     @PutMapping("/{providerUserId}/reset-password")
     @Operation(summary = "Restablecer contraseña temporal",
             description = "El proveedor asigna una nueva contraseña temporal; el operador deberá cambiarla en el próximo login.")

--- a/src/main/java/com/tourya/api/models/User.java
+++ b/src/main/java/com/tourya/api/models/User.java
@@ -59,6 +59,13 @@ public class User implements UserDetails, Principal {
     private String uuidSocial;
 
     /**
+     * BE-22d: telefono de contacto del usuario. Usado por PROVIDER_OPERATOR
+     * como contacto principal del tour (RN-026). Nullable — hasta que el usuario
+     * lo cargue, el TourPrincipalOperatorService cae al provider.phone.
+     */
+    private String phone;
+
+    /**
      * Contador de intentos de login fallidos desde el ultimo login exitoso.
      * Se resetea a 0 en cada success. Usado por SEC-10 para lockout automatico.
      */

--- a/src/main/java/com/tourya/api/models/request/CreateProviderOperatorRequest.java
+++ b/src/main/java/com/tourya/api/models/request/CreateProviderOperatorRequest.java
@@ -20,6 +20,10 @@ public class CreateProviderOperatorRequest {
     @Email
     private String email;
 
+    /** BE-22d: telefono de contacto del operador. Opcional. Usado como contacto principal del tour (RN-026). */
+    @Size(max = 20)
+    private String phone;
+
     /** Contraseña temporal que el proveedor comunica al operador; debe cambiarla en el primer acceso. */
     @NotBlank
     @Size(min = 8, message = "temporaryPassword should be 8 characters long minimum")

--- a/src/main/java/com/tourya/api/models/request/UpdateProviderOperatorRequest.java
+++ b/src/main/java/com/tourya/api/models/request/UpdateProviderOperatorRequest.java
@@ -10,6 +10,9 @@ public class UpdateProviderOperatorRequest {
     private String firstname;
     private String lastname;
 
+    /** BE-22d: telefono de contacto del operador. Se actualiza si viene no-null. */
+    private String phone;
+
     /** Si se envía, reemplaza la asignación de tours del operador (no puede estar vacío). */
     private List<Integer> tourIds;
 

--- a/src/main/java/com/tourya/api/models/responses/ProviderOperatorResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/ProviderOperatorResponse.java
@@ -14,6 +14,8 @@ public class ProviderOperatorResponse {
     private Integer userId;
     private String email;
     private String fullName;
+    /** BE-22d: telefono del operador. Nullable hasta que lo carguen. */
+    private String phone;
     private Boolean isPrimary;
     private Boolean accountEnabled;
     /** true hasta que el operador cambie la contraseña temporal (PATCH /users). */

--- a/src/main/java/com/tourya/api/repository/ProviderUserTourRepository.java
+++ b/src/main/java/com/tourya/api/repository/ProviderUserTourRepository.java
@@ -31,6 +31,20 @@ public interface ProviderUserTourRepository extends JpaRepository<ProviderUserTo
             """)
     Optional<ProviderUserTour> findPrincipalByTourId(@Param("tourId") Integer tourId);
 
+    /**
+     * BE-22c: todos los operadores asignados a un tour, con user + provider
+     * eager para poblar la UI del modal "contacto principal" del card del tour.
+     */
+    @Query("""
+            SELECT put FROM ProviderUserTour put
+            JOIN FETCH put.providerUser pu
+            JOIN FETCH pu.user
+            JOIN FETCH pu.provider
+            WHERE put.tour.id = :tourId
+            ORDER BY put.isPrincipal DESC, pu.id ASC
+            """)
+    List<ProviderUserTour> findByTourIdWithProviderUserAndUser(@Param("tourId") Integer tourId);
+
     @Modifying
     @Query("""
             UPDATE ProviderUserTour put

--- a/src/main/java/com/tourya/api/services/ProviderUserService.java
+++ b/src/main/java/com/tourya/api/services/ProviderUserService.java
@@ -154,6 +154,8 @@ public class ProviderUserService {
 
                 .email(email)
 
+                .phone(request.getPhone() != null ? request.getPhone().trim() : null)
+
                 .password(passwordEncoder.encode(request.getTemporaryPassword()))
 
                 .enabled(true)
@@ -227,6 +229,12 @@ public class ProviderUserService {
         if (request.getLastname() != null) {
 
             user.setLastname(request.getLastname().trim());
+
+        }
+
+        if (request.getPhone() != null) {
+
+            user.setPhone(request.getPhone().trim().isEmpty() ? null : request.getPhone().trim());
 
         }
 
@@ -458,6 +466,8 @@ public class ProviderUserService {
 
                 .fullName(user.fullName())
 
+                .phone(user.getPhone())
+
                 .isPrimary(providerUser.getIsPrimary())
 
                 .accountEnabled(user.isEnabled())
@@ -468,6 +478,43 @@ public class ProviderUserService {
 
                 .build();
 
+    }
+
+    /**
+     * BE-22c: lista todos los operadores asignados a un tour, con flag `isPrincipal`
+     * marcando cuál es el contacto principal (a lo sumo uno). Valida que el tour
+     * pertenezca al provider autenticado (o al backoffice si se implementa después).
+     * Uso: alimenta el modal "Contacto principal" en el card del tour (BE-22b).
+     */
+    @Transactional(readOnly = true)
+    public List<ProviderOperatorResponse> listOperatorsByTour(Integer tourId, Authentication connectedUser) {
+        Provider provider = requireProviderOwner(connectedUser);
+        Tour tour = tourRepository.findTourByIdAndProviderId(tourId, provider.getId());
+        if (tour == null) {
+            throw new ResourceNotFoundException("Tour not found for provider. tourId=" + tourId);
+        }
+
+        return providerUserTourRepository.findByTourIdWithProviderUserAndUser(tourId).stream()
+                .map(link -> {
+                    ProviderUser pu = link.getProviderUser();
+                    User u = pu.getUser();
+                    return ProviderOperatorResponse.builder()
+                            .providerUserId(pu.getId())
+                            .userId(u.getId())
+                            .email(u.getEmail())
+                            .fullName(u.fullName())
+                            .phone(u.getPhone())
+                            .isPrimary(pu.getIsPrimary())
+                            .accountEnabled(u.isEnabled())
+                            .mustChangePassword(u.isMustChangePassword())
+                            .tours(List.of(ProviderOperatorTourResponse.builder()
+                                    .tourId(tourId)
+                                    .tourName(tour.getName() != null ? tour.getName().getEs() : null)
+                                    .isPrincipal(link.getIsPrincipal())
+                                    .build()))
+                            .build();
+                })
+                .toList();
     }
 
 }

--- a/src/main/java/com/tourya/api/services/TourPrincipalOperatorService.java
+++ b/src/main/java/com/tourya/api/services/TourPrincipalOperatorService.java
@@ -40,11 +40,16 @@ public class TourPrincipalOperatorService {
     private TourOperatorResponse fromOperatorLink(ProviderUserTour link) {
         User user = link.getProviderUser().getUser();
         Provider provider = link.getProviderUser().getProvider();
+        // BE-22d: preferir el phone del operador (user); si no esta cargado
+        // (backfill vacío en migración 077), caer al del provider — retrocompatible.
+        String phoneSource = user != null && user.getPhone() != null && !user.getPhone().isBlank()
+                ? user.getPhone()
+                : (provider != null ? provider.getPhone() : null);
         return TourOperatorResponse.builder()
                 .providerUserId(link.getProviderUser().getId())
                 .name(user != null ? user.fullName() : null)
                 .email(user != null ? user.getEmail() : null)
-                .phone(parsePhoneDigits(provider != null ? provider.getPhone() : null))
+                .phone(parsePhoneDigits(phoneSource))
                 .build();
     }
 


### PR DESCRIPTION
## Contexto

Respuesta a Luis 2026-07-19 (WhatsApp):
- **P1**: "podría ser un botón en el card del tour que despliegue la lista de PROVIDER_OPERATOR y se marca el principal ✅"
- Complemento P1: *"en la creación del PROVIDER_OPERATOR puedes agregarle un campo (teléfono), actualmente no lo tiene"*
- RN-026 doc 05: *"al momento en que se genera la reserva, debe aparecer la información (nombre, teléfono y correo electrónico) del contacto principal del tour"*

Este PR es el **backend**. El frontend (BE-22b modal + phone input) va en PR separado sobre `tourya-front` una vez este mergeado.

## Cambios

### BE-22c — `GET /provider/users/tour/{tourId}`
- Nuevo query `ProviderUserTourRepository.findByTourIdWithProviderUserAndUser` con `JOIN FETCH` de `providerUser.user + provider`.
- `ProviderUserService.listOperatorsByTour` con validación de ownership (tour del PROVIDER autenticado).
- Endpoint en `ProviderUserController`.
- Reusa `ProviderOperatorResponse` (ya existe).

### BE-22d — Campo `phone` en `_user`
- Migración `077_user_phone.sql` (aditiva, nullable, sin backfill).
- `User.phone` en JPA entity.
- `CreateProviderOperatorRequest.phone` (opcional, `@Size(max = 20)`).
- `UpdateProviderOperatorRequest.phone` (nullable, actualiza si viene).
- `ProviderOperatorResponse.phone` expuesto.
- `ProviderUserService.createOperator/updateOperator/toResponse` — leen/setean phone del user.

### Cambio de comportamiento a nivel de reserva ⚠️

`TourPrincipalOperatorService.fromOperatorLink()` cambia el orden del fallback del phone del operador principal:

- **Antes**: `provider.phone` (sí, el phone de la empresa, no del operador humano — probablemente un bug de UX antiguo).
- **Ahora**: `user.phone ?? provider.phone` (retrocompatible: operadores existentes sin phone cargado siguen mostrando el del provider).

Este flujo alimenta `TourOperatorResponse` → `ReservationResponse` → mobile/web del provider en la vista de detalle de reserva. Cambio esperado por RN-026.

## Test plan

- [x] `./mvnw compile` limpio.
- [x] `./mvnw test` — 48/49 verdes (el 1 restante es `TouryaApiApplicationTests.contextLoads` preexistente sin Postgres local, verificado desde INF-04).
- [ ] Post-merge: **aplicar migración `077` manualmente a Cloud SQL dev** (patrón conocido 074/075/076 mientras INF-05 esté abierto).
- [ ] Post-merge dev: `POST /provider/users` con nuevo campo phone → response incluye `phone`. Modificar operador existente para agregarle phone → response.
- [ ] Post-merge dev: crear un reporte + verificar que la reserva devuelve `tourOperator.phone` con el del user si está cargado, sino con el del provider.

## Riesgo

- **Medio** por la migración manual (sigue siendo el patrón #179 si no se aplica).
- **Bajo** en código: cambio aditivo + fallback retrocompatible + endpoint nuevo con ownership check.

## Backlog

- Cierra **BE-22c** y **BE-22d backend** en `docs/17-backlog-implementacion.md`.
- Habilita **BE-22b** (frontend modal desde card del tour) que va en PR separado sobre `tourya-front`.
- Sigue pendiente **BE-22d mobile** (paridad opcional para operarios MAUI) — se puede hacer después.