### PR TITLE
feat(security): FE-15b backend + fix H2 (agujero DIMAR)

### DIFF
--- a/src/main/java/com/tourya/api/controller/MaritimActivityReportController.java
+++ b/src/main/java/com/tourya/api/controller/MaritimActivityReportController.java
@@ -67,14 +67,15 @@ public class MaritimActivityReportController {
     @Operation(summary = "Actualizar reporte")
     public ResponseEntity<MaritimActivityReportResponse> update(
             @PathVariable Long id,
-            @Valid @RequestBody MaritimActivityReportRequest request) {
-        return ResponseEntity.ok(maritimActivityReportService.update(id, request));
+            @Valid @RequestBody MaritimActivityReportRequest request,
+            Authentication authentication) {
+        return ResponseEntity.ok(maritimActivityReportService.update(id, request, authentication));
     }
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Eliminar reporte")
-    public ResponseEntity<Void> delete(@PathVariable Long id) {
-        maritimActivityReportService.delete(id);
+    public ResponseEntity<Void> delete(@PathVariable Long id, Authentication authentication) {
+        maritimActivityReportService.delete(id, authentication);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/tourya/api/services/MaritimActivityReportService.java
+++ b/src/main/java/com/tourya/api/services/MaritimActivityReportService.java
@@ -1,12 +1,15 @@
 package com.tourya.api.services;
 
 import com.tourya.api.common.PageResponse;
+import com.tourya.api.exceptions.InsufficientPrivilegesException;
 import com.tourya.api.exceptions.OperationNotPermittedException;
 import com.tourya.api.exceptions.ResourceNotFoundException;
+import com.tourya.api._utils.Utils;
 import com.tourya.api.models.City;
 import com.tourya.api.models.Country;
 import com.tourya.api.models.MaritimActivityReport;
 import com.tourya.api.models.State;
+import com.tourya.api.models.User;
 import com.tourya.api.models.request.MaritimActivityReportRequest;
 import com.tourya.api.models.responses.MaritimActivityReportResponse;
 import com.tourya.api.constans.enums.MaritimeFlagEnum;
@@ -49,6 +52,10 @@ public class MaritimActivityReportService {
 
     @Transactional
     public MaritimActivityReportResponse create(MaritimActivityReportRequest request, Authentication authentication) {
+        // FE-15b + H2: hasta ahora el endpoint POST /maritime-activity-reports
+        // solo pedia authenticated() en SecurityConfig — cualquier usuario podia
+        // crear reportes DIMAR. Restringido a ADMIN + BACKOFFICE_OPERATION (Luis P2 opción C).
+        requireBackoffice(authentication);
         validateReportDates(request.getReportStartDate(), request.getReportEndDate());
         LocationRefs location = resolveAndValidateLocation(request);
         validateCategoryAndSubcategory(request.getBusinessCategoryId(), request.getSubcategoryCode());
@@ -113,7 +120,9 @@ public class MaritimActivityReportService {
     }
 
     @Transactional
-    public MaritimActivityReportResponse update(Long id, MaritimActivityReportRequest request) {
+    public MaritimActivityReportResponse update(Long id, MaritimActivityReportRequest request, Authentication authentication) {
+        // FE-15b + H2: mismo guard que create.
+        requireBackoffice(authentication);
         MaritimActivityReport report = maritimActivityReportRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Maritime activity report not found with id: " + id));
 
@@ -134,11 +143,29 @@ public class MaritimActivityReportService {
     }
 
     @Transactional
-    public void delete(Long id) {
+    public void delete(Long id, Authentication authentication) {
+        // FE-15b + H2: mismo guard que create/update.
+        requireBackoffice(authentication);
         if (!maritimActivityReportRepository.existsById(id)) {
             throw new ResourceNotFoundException("Maritime activity report not found with id: " + id);
         }
         maritimActivityReportRepository.deleteById(id);
+    }
+
+    /**
+     * FE-15b + H2: cierra un agujero de seguridad preexistente. Hasta este cambio
+     * el endpoint POST/PUT/DELETE de reportes solo requeria autenticacion generica
+     * (SecurityConfig anyRequest().authenticated()). Ahora exige ADMIN o
+     * BACKOFFICE_OPERATION (subset P2 opción C de Luis: "gestionar reportes DIMAR").
+     */
+    private void requireBackoffice(Authentication authentication) {
+        if (authentication == null || !(authentication.getPrincipal() instanceof User user)) {
+            throw new InsufficientPrivilegesException("Autenticacion requerida.");
+        }
+        if (!Utils.isTouryaBackoffice(user.getRoles())) {
+            throw new InsufficientPrivilegesException(
+                    "Solo ADMIN o BACKOFFICE_OPERATION pueden gestionar reportes DIMAR.");
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/tourya/api/services/ProviderPayoutOrderService.java
+++ b/src/main/java/com/tourya/api/services/ProviderPayoutOrderService.java
@@ -90,7 +90,8 @@ public class ProviderPayoutOrderService {
             @Nullable LocalDate toDate) {
         User user = (User) connectedUser.getPrincipal();
         List<Role> roles = user.getRoles();
-        if (!Utils.isAdmin(roles)) {
+        // FE-15b: ADMIN + BACKOFFICE_OPERATION (subset P2 opción C — "subir pagos").
+        if (!Utils.isTouryaBackoffice(roles)) {
             throw new InsufficientPrivilegesException(NOT_PRIVILEGES);
         }
         return buildListPage(
@@ -169,7 +170,8 @@ public class ProviderPayoutOrderService {
     public ProviderPayoutOrderDetailsResponse getDetailsForAdmin(Long orderId, Authentication connectedUser) {
         User user = (User) connectedUser.getPrincipal();
         List<Role> roles = user.getRoles();
-        if (!Utils.isAdmin(roles)) {
+        // FE-15b: ADMIN + BACKOFFICE_OPERATION (subset P2 opción C — "subir pagos").
+        if (!Utils.isTouryaBackoffice(roles)) {
             throw new InsufficientPrivilegesException(NOT_PRIVILEGES);
         }
 
@@ -183,7 +185,8 @@ public class ProviderPayoutOrderService {
     public ProviderPayoutOrderDetailsResponse uploadAttachmentAndMarkPaid(Long orderId, MultipartFile file, Authentication connectedUser) throws IOException {
         User user = (User) connectedUser.getPrincipal();
         List<Role> roles = user.getRoles();
-        if (!Utils.isAdmin(roles)) {
+        // FE-15b: ADMIN + BACKOFFICE_OPERATION (subset P2 opción C — "subir pagos").
+        if (!Utils.isTouryaBackoffice(roles)) {
             throw new InsufficientPrivilegesException(NOT_PRIVILEGES);
         }
 


### PR DESCRIPTION
Habilita en backend el subset **BACKOFFICE_OPERATION** que Luis definió en P2 opción C (WhatsApp 2026-07-18): ver reservas, subir pagos, gestionar reportes DIMAR.

Y aprovecha para cerrar un agujero de seguridad preexistente (**H2**) descubierto durante la auditoría del 2026-07-21: los endpoints de `MaritimActivityReport` no validaban rol — cualquier usuario autenticado podía crear/borrar reportes DIMAR (Franklin aprobó cerrarlo en el mismo PR).

## Cambios

### FE-15b — Payouts admin
`ProviderPayoutOrderService` (3 métodos):
- `listForAdmin()` — `Utils.isAdmin(roles)` → `Utils.isTouryaBackoffice(roles)`.
- `getDetailsForAdmin()` — idem.
- `uploadAttachmentAndMarkPaid()` — idem.

### H2 — Guard DIMAR
`MaritimActivityReportService`:
- Nuevo helper `requireBackoffice(authentication)` que exige ADMIN o BACKOFFICE_OPERATION.
- `create()`, `update()`, `delete()` invocan el helper al inicio.

`MaritimActivityReportController`:
- `update()` y `delete()` cambian firma para recibir `Authentication` (antes no lo tenían).
- `create()` ya lo tenía.

Los `GET` (`findById`, `findAll`, `findActiveOnDate`, `findByLocation`) siguen autenticados sin restricción de rol — no manejan datos sensibles y se usan defensivamente en `ReservationService.java:1289`.

## Test plan

- [x] `./mvnw compile` limpio.
- [x] `./mvnw test`: 48/49 verdes (el 1 restante es `TouryaApiApplicationTests.contextLoads` preexistente sin Postgres local).
- [ ] Post-merge dev: probar como BACKOFFICE_OPERATION — puede listar/subir comprobante de payouts + crear/editar/borrar reportes DIMAR.
- [ ] Post-merge dev: probar como usuario CLIENT o PROVIDER autenticado — POST/PUT/DELETE /maritime-activity-reports responde 403.

## Impacto

**Cambio de comportamiento visible**:
- Antes: cualquier user autenticado podía crear reporte DIMAR. **Ahora sí valida rol.**
- Antes: solo ADMIN podía subir pagos. **Ahora también BACKOFFICE_OPERATION.**

Sin cambios en flujo del cliente/provider normal — la restricción solo aplica a endpoints administrativos.

## Frontend correspondiente

Va en PR aparte en `tourya-front` — nuevo `BackofficeGuard` + reemplazos `isAdmin()` → `isTouryaBackoffice()` en 5 componentes + `home-redirect.guard.ts` para BACKOFFICE.

## Backlog

- Cierra parte backend de **FE-15b** y **H2** (agujero DIMAR).