### PR TITLE
fix(tc-004): bookings/availability por (slot, fecha) en runtime

### DIFF
--- a/database/migrations/078_tc004_bookings_per_day_sps.sql
+++ b/database/migrations/078_tc004_bookings_per_day_sps.sql
@@ -1,0 +1,533 @@
+-- Migration 078: TC-004 — bookings por día en SPs (sp_get_tour_schedule_json + sp_count_tour_schedule_json)
+-- Date: 2026-07-22
+-- Description:
+--   El contador `tour_schedule_config_slot.bookings` es a nivel de config-slot (plantilla),
+--   NO por fecha. Como el mismo slot config se aplica a múltiples fechas, las reservas de
+--   cualquier día "pintaban" a todos los demás días con la misma disponibilidad reducida.
+--
+--   Fix: los SPs ahora cuentan bookings por (slot_id, schedule_id) en runtime usando la
+--   nueva función helper `fn_slot_booked_units_on_schedule`. El campo denormalizado
+--   `slot.bookings` queda intacto en la BD pero deja de ser fuente de verdad (los endpoints
+--   Java tampoco lo leen — ver TourScheduleConfigGeneralService.mapSlotToResponse).
+--
+--   Comportamiento:
+--   - Para tours "grupo": suma 1 unidad por reserva activa.
+--   - Para tours "individual": suma pax (shopping_cart_item_detail.quantity).
+--   - Estados considerados activos: TEMPORAL, PENDING, DELIVERED.
+--
+--   Impacto: cuando un cliente compra el 24-jul, el 23-jul, 25-jul, etc. siguen mostrando
+--   la capacidad completa. El bug reportado por Luis 2026-07-21 queda resuelto.
+
+-- 1) Helper: cuenta unidades reservadas para un slot en un tour_schedule específico.
+CREATE OR REPLACE FUNCTION public.fn_slot_booked_units_on_schedule(p_slot_id int, p_schedule_id int)
+RETURNS int
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT COALESCE(SUM(
+    CASE
+      WHEN t.price_type = 'grupo' THEN 1
+      ELSE COALESCE((
+        SELECT SUM(d.quantity)
+        FROM shopping_cart_item_detail d
+        WHERE d.shopping_cart_item_id = i.id
+      ), 0)
+    END
+  ), 0)::int
+  FROM reservation r
+  JOIN shopping_cart_item i ON i.id = r.item_id
+  JOIN tour_schedule ts ON ts.id = i.tour_schedule_id
+  JOIN tour t ON t.id = ts.tour_id
+  WHERE i.slot_id = p_slot_id
+    AND ts.id = p_schedule_id
+    AND r.delivery_status IN ('TEMPORAL', 'PENDING', 'DELIVERED');
+$$;
+
+COMMENT ON FUNCTION public.fn_slot_booked_units_on_schedule(int, int) IS
+  'TC-004: Cuenta unidades reservadas activas (TEMPORAL/PENDING/DELIVERED) para un slot en un tour_schedule específico. Respeta priceType: grupo cuenta 1 unidad por reserva, individual suma pax.';
+
+-- 2) sp_get_tour_schedule_json — usa el helper en vez de sl.bookings global.
+DROP FUNCTION IF EXISTS public.sp_get_tour_schedule_json(jsonb);
+
+CREATE OR REPLACE FUNCTION public.sp_get_tour_schedule_json(filters jsonb)
+ RETURNS TABLE(result jsonb)
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  v_page int := COALESCE((filters->>'page')::int, 0);
+  v_size int := COALESCE((filters->>'size')::int, 10);
+
+  v_start_date date := COALESCE((filters->>'start_date')::date, (filters->>'startDate')::date);
+  v_end_date   date := COALESCE((filters->>'end_date')::date,   (filters->>'endDate')::date);
+
+  v_state_txt text := NULLIF(COALESCE(filters->>'state', filters->>'stateId'), '');
+  v_city_txt  text := NULLIF(COALESCE(filters->>'city',  filters->>'cityId'),  '');
+
+  v_provider_state_txt text := NULLIF(filters->>'providerStateId', '');
+  v_provider_city_txt  text := NULLIF(filters->>'providerCityId',  '');
+
+  v_duration_txt      text := NULLIF(filters->>'duration','');
+  v_category_txt      text := NULLIF(COALESCE(filters->>'category', filters->>'categoryId'), '');
+  v_duration_type_txt text := NULLIF(COALESCE(filters->>'duration_type', filters->>'durationType'), '');
+  v_age_type_txt      text := UPPER(NULLIF(COALESCE(filters->>'age_type', filters->>'ageType'), ''));
+  v_category_ids int[] := CASE
+    WHEN filters ? 'categoryIds' AND jsonb_typeof(filters->'categoryIds') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'categoryIds')::int)
+    WHEN NULLIF(COALESCE(filters->>'category', filters->>'categoryId'), '') IS NOT NULL THEN
+      ARRAY[COALESCE(filters->>'category', filters->>'categoryId')::int]
+    ELSE NULL
+  END;
+
+  v_sub_category_txt  text := NULLIF(COALESCE(filters->>'subCategory', filters->>'sub_category'), '');
+  v_duration_enum_txt text := NULLIF(COALESCE(filters->>'durationEnum', filters->>'duration_enum'), '');
+  v_time_of_day_txt   text := NULLIF(COALESCE(filters->>'timeOfDay', filters->>'time_of_day'), '');
+  v_sub_categories text[] := CASE
+    WHEN filters ? 'subCategories' AND jsonb_typeof(filters->'subCategories') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'subCategories'))
+    WHEN NULLIF(COALESCE(filters->>'subCategory', filters->>'sub_category'), '') IS NOT NULL THEN
+      ARRAY[COALESCE(filters->>'subCategory', filters->>'sub_category')]
+    ELSE NULL
+  END;
+  v_duration_enums text[] := CASE
+    WHEN filters ? 'durationEnums' AND jsonb_typeof(filters->'durationEnums') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'durationEnums'))
+    WHEN NULLIF(COALESCE(filters->>'durationEnum', filters->>'duration_enum'), '') IS NOT NULL THEN
+      ARRAY[COALESCE(filters->>'durationEnum', filters->>'duration_enum')]
+    ELSE NULL
+  END;
+  v_time_of_day_arr text[] := CASE
+    WHEN filters ? 'timeOfDay' AND jsonb_typeof(filters->'timeOfDay') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'timeOfDay'))
+    WHEN filters ? 'time_of_day' AND jsonb_typeof(filters->'time_of_day') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'time_of_day'))
+    WHEN NULLIF(COALESCE(filters->>'timeOfDay', filters->>'time_of_day'), '') IS NOT NULL THEN
+      ARRAY[COALESCE(filters->>'timeOfDay', filters->>'time_of_day')]
+    ELSE NULL
+  END;
+
+  v_min_price numeric := COALESCE(NULLIF(filters->>'min_price','')::numeric,
+                                   NULLIF(filters->>'minPrice','')::numeric);
+  v_max_price numeric := COALESCE(NULLIF(filters->>'max_price','')::numeric,
+                                   NULLIF(filters->>'maxPrice','')::numeric);
+
+  v_tag text := NULLIF(COALESCE(filters->>'tag', filters->>'tags'), '');
+  v_tag_ids int[] := CASE
+    WHEN filters ? 'tagIds' AND jsonb_typeof(filters->'tagIds') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'tagIds')::int)
+    ELSE NULL
+  END;
+  v_tag_names text[] := CASE
+    WHEN filters ? 'tags' AND jsonb_typeof(filters->'tags') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'tags'))
+    WHEN NULLIF(COALESCE(filters->>'tag', filters->>'tags'), '') IS NOT NULL THEN
+      ARRAY[COALESCE(filters->>'tag', filters->>'tags')]
+    ELSE NULL
+  END;
+  v_text_search text := NULLIF(filters->>'textSearch','');
+
+  v_tour_id int := (filters->>'tourId')::int;
+  v_tour_ids int[] := CASE
+    WHEN filters ? 'tourIds' AND jsonb_typeof(filters->'tourIds') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'tourIds')::int)
+    ELSE NULL
+  END;
+  v_requested_units int := COALESCE(
+    NULLIF(COALESCE(filters->>'requestedUnits', filters->>'participants', filters->>'quantity'), '')::int,
+    NULL
+  );
+  v_language text := COALESCE(NULLIF(filters->>'language', ''), 'es');
+BEGIN
+  RETURN QUERY
+  SELECT jsonb_build_object(
+    'tour', jsonb_build_object(
+      'id', t.id,
+      'name', t.name,
+      'description', t.description,
+      'categoryId', t.category_id,
+      'categoryName', tc.name,
+      'duration', t.duration,
+      'durationType', t.duration_type,
+      'rating', t.rating,
+      'status', t.status,
+      'priceType', t.price_type,
+      'maxPeople', t.max_people,
+      'isUnlimitedCapacity', t.is_unlimited_capacity,
+      'subCategory', t.sub_category,
+      'subCategoryName', tscm.display_name,
+      'durationEnum', t.duration_enum,
+      'timeOfDay', t.time_of_day,
+      'tags', COALESCE((
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'id', tg.id,
+            'name', tg.nombre,
+            'category', td.nombre
+          )
+        )
+        FROM tour_tags tt
+        JOIN tags tg ON tg.id = tt.tag_id
+        JOIN tag_dimensions td ON td.id = tg.dimension_id
+        WHERE tt.tour_id = t.id
+      ), '[]'::jsonb),
+      'address', jsonb_build_object(
+        'country', a.country_id,
+        'state', a.state_id,
+        'city', a.city_id,
+        'address', a.address,
+        'latitude', a.latitude,
+        'longitude', a.longitude
+      ),
+      'gallery', COALESCE((
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'id', g.id,
+            'imageUrl', g.image_url,
+            'description', g.description,
+            'order', g.order_index
+          )
+        )
+        FROM tour_gallery g
+        WHERE g.tour_id = t.id
+      ), '[]'::jsonb)
+    ),
+    'schedules', COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', s.id,
+          'scheduleDate', s.schedule_date,
+          'status', s.status,
+          'config', jsonb_build_object(
+            'id', sc.id,
+            'slots', COALESCE((
+              SELECT jsonb_agg(
+                jsonb_build_object(
+                  'slotId', sl.id,
+                  'startTime', sl.start_time,
+                  'endTime', sl.end_time,
+                  'capacity', sl.capacity,
+                  -- TC-004: bookings/availability por (slot_id, schedule_id) en runtime.
+                  'bookings', public.fn_slot_booked_units_on_schedule(sl.id, s.id),
+                  'availability', GREATEST(0, COALESCE(sl.capacity, 0) - public.fn_slot_booked_units_on_schedule(sl.id, s.id)),
+                  'minCapacityCalc', sl.min_capacity_calc,
+                  'checkAvailability', sl.check_availability,
+                  'prices', COALESCE((
+                    SELECT jsonb_agg(
+                      jsonb_build_object(
+                        'ageType', p.age_type,
+                        'minAge', arc.min_age,
+                        'maxAge', arc.max_age,
+                        'price', p.price,
+                        'providerPrice', p.provider_price
+                      )
+                    )
+                    FROM tour_schedule_config_price p
+                    LEFT JOIN public.age_range_config arc ON arc.age_type = CAST(p.age_type AS character varying)
+                    WHERE p.slot_id = sl.id
+                      AND (v_age_type_txt IS NULL OR CAST(p.age_type AS character varying) = v_age_type_txt)
+                      AND (v_min_price IS NULL OR p.price >= v_min_price)
+                      AND (v_max_price IS NULL OR p.price <= v_max_price)
+                  ), '[]'::jsonb)
+                )
+                ORDER BY sl.start_time
+              )
+              FROM tour_schedule_config_slot sl
+              WHERE sl.config_id = sc.id
+                AND (
+                  v_requested_units IS NULL
+                  OR COALESCE(t.is_unlimited_capacity, false) = true
+                  -- TC-004: filtro por capacidad usa conteo por-fecha.
+                  OR GREATEST(0, COALESCE(sl.capacity, 0) - public.fn_slot_booked_units_on_schedule(sl.id, s.id)) >= v_requested_units
+                )
+            ), '[]'::jsonb)
+          )
+        )
+        ORDER BY s.schedule_date ASC
+      )
+      FROM tour_schedule s
+      LEFT JOIN tour_schedule_config sc ON sc.id = s.config_id
+      WHERE s.tour_id = t.id
+        AND (v_start_date IS NULL OR s.schedule_date >= v_start_date)
+        AND (v_end_date IS NULL OR s.schedule_date <= v_end_date)
+        AND (
+          v_requested_units IS NULL
+          OR COALESCE(t.is_unlimited_capacity, false) = true
+          OR EXISTS (
+            SELECT 1
+            FROM tour_schedule_config_slot sl_filter
+            WHERE sl_filter.config_id = sc.id
+              -- TC-004: filtro por capacidad del schedule usa conteo por-fecha.
+              AND GREATEST(0, COALESCE(sl_filter.capacity, 0) - public.fn_slot_booked_units_on_schedule(sl_filter.id, s.id)) >= v_requested_units
+          )
+        )
+    ), '[]'::jsonb)
+  ) AS result
+  FROM tour t
+  JOIN tour_category tc ON tc.id = t.category_id
+  JOIN tour_address a ON a.tour_id = t.id
+  JOIN provider pr ON pr.id = t.provider_id
+  LEFT JOIN tour_business_subcategory_mapping tscm ON tscm.subcategory_code = t.sub_category::text
+  WHERE
+    t.status = 'accepted'
+    AND (v_tour_id IS NULL OR t.id = v_tour_id)
+    AND (v_tour_ids IS NULL OR t.id = ANY(v_tour_ids))
+    AND (v_state_txt IS NULL OR a.state_id::text = v_state_txt)
+    AND (v_city_txt IS NULL OR a.city_id::text = v_city_txt)
+    AND (v_provider_state_txt IS NULL OR pr.state_id::text = v_provider_state_txt)
+    AND (v_provider_city_txt IS NULL OR pr.city_id::text = v_provider_city_txt)
+    AND (v_duration_txt IS NULL OR t.duration::text = v_duration_txt)
+    AND (v_duration_type_txt IS NULL OR t.duration_type::text = v_duration_type_txt)
+    AND (v_category_ids IS NULL OR t.category_id = ANY(v_category_ids))
+    AND (v_sub_categories IS NULL OR t.sub_category::text = ANY(v_sub_categories))
+    AND (v_duration_enums IS NULL OR t.duration_enum::text = ANY(v_duration_enums))
+    AND (
+      v_time_of_day_arr IS NULL
+      OR (
+        t.time_of_day IS NOT NULL
+        AND EXISTS (
+          SELECT 1
+          FROM unnest(t.time_of_day::text[]) AS tod(value)
+          WHERE tod.value = ANY(v_time_of_day_arr)
+        )
+      )
+    )
+    AND (
+      (v_tag_ids IS NULL AND v_tag_names IS NULL) OR EXISTS (
+        SELECT 1
+        FROM tour_tags tt2
+        JOIN tags tg2 ON tg2.id = tt2.tag_id
+        WHERE tt2.tour_id = t.id
+          AND (
+            (v_tag_ids IS NOT NULL AND tg2.id = ANY(v_tag_ids))
+            OR (v_tag_names IS NOT NULL AND tg2.nombre = ANY(v_tag_names))
+          )
+      )
+    )
+    AND (
+      v_text_search IS NULL OR
+      (t.name->>v_language) ILIKE '%' || v_text_search || '%' OR
+      (t.description->>v_language) ILIKE '%' || v_text_search || '%'
+    )
+    AND (
+      (v_start_date IS NULL AND v_end_date IS NULL)
+      OR EXISTS (
+        SELECT 1 FROM tour_schedule sx
+        LEFT JOIN tour_schedule_config scx ON scx.id = sx.config_id
+        WHERE sx.tour_id = t.id
+          AND (v_start_date IS NULL OR sx.schedule_date >= v_start_date)
+          AND (v_end_date IS NULL OR sx.schedule_date <= v_end_date)
+          AND (
+            v_requested_units IS NULL
+            OR COALESCE(t.is_unlimited_capacity, false) = true
+            OR EXISTS (
+              SELECT 1
+              FROM tour_schedule_config_slot slx
+              WHERE slx.config_id = scx.id
+                -- TC-004: pre-filtro EXISTS ahora también usa conteo por-fecha.
+                AND GREATEST(0, COALESCE(slx.capacity, 0) - public.fn_slot_booked_units_on_schedule(slx.id, sx.id)) >= v_requested_units
+            )
+          )
+      )
+    )
+    AND (
+      v_min_price IS NULL
+      OR EXISTS (
+        SELECT 1
+        FROM tour_schedule s2
+        JOIN tour_schedule_config sc2 ON sc2.id = s2.config_id
+        JOIN tour_schedule_config_slot sl2 ON sl2.config_id = sc2.id
+        JOIN tour_schedule_config_price p2 ON p2.slot_id = sl2.id
+        WHERE s2.tour_id = t.id
+          AND (v_start_date IS NULL OR s2.schedule_date >= v_start_date)
+          AND (v_end_date IS NULL OR s2.schedule_date <= v_end_date)
+          AND CAST(p2.age_type AS character varying) = 'ADULT'
+          AND p2.price >= v_min_price
+      )
+    )
+    AND (
+      v_max_price IS NULL
+      OR EXISTS (
+        SELECT 1
+        FROM tour_schedule s3
+        JOIN tour_schedule_config sc3 ON sc3.id = s3.config_id
+        JOIN tour_schedule_config_slot sl3 ON sl3.config_id = sc3.id
+        JOIN tour_schedule_config_price p3 ON p3.slot_id = sl3.id
+        WHERE s3.tour_id = t.id
+          AND (v_start_date IS NULL OR s3.schedule_date >= v_start_date)
+          AND (v_end_date IS NULL OR s3.schedule_date <= v_end_date)
+          AND CAST(p3.age_type AS character varying) = 'ADULT'
+          AND p3.price <= v_max_price
+      )
+    )
+  GROUP BY t.id, tc.id, a.id, pr.id, tscm.subcategory_code, tscm.display_name
+  ORDER BY t.id ASC
+  LIMIT v_size
+  OFFSET v_page * v_size;
+END;
+$function$;
+
+-- 3) sp_count_tour_schedule_json — mismo fix en el filtro EXISTS.
+CREATE OR REPLACE FUNCTION public.sp_count_tour_schedule_json(filters jsonb)
+ RETURNS bigint
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  v_start_date date := COALESCE((filters->>'start_date')::date, (filters->>'startDate')::date);
+  v_end_date   date := COALESCE((filters->>'end_date')::date,   (filters->>'endDate')::date);
+  v_state_txt text := NULLIF(COALESCE(filters->>'state', filters->>'stateId'), '');
+  v_city_txt  text := NULLIF(COALESCE(filters->>'city',  filters->>'cityId'),  '');
+  v_provider_state_txt text := NULLIF(filters->>'providerStateId', '');
+  v_provider_city_txt  text := NULLIF(filters->>'providerCityId',  '');
+  v_duration_txt      text := NULLIF(filters->>'duration','');
+  v_category_ids int[] := CASE
+    WHEN filters ? 'categoryIds' AND jsonb_typeof(filters->'categoryIds') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'categoryIds')::int)
+    WHEN NULLIF(COALESCE(filters->>'category', filters->>'categoryId'), '') IS NOT NULL THEN
+      ARRAY[COALESCE(filters->>'category', filters->>'categoryId')::int]
+    ELSE NULL
+  END;
+  v_sub_categories text[] := CASE
+    WHEN filters ? 'subCategories' AND jsonb_typeof(filters->'subCategories') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'subCategories'))
+    WHEN NULLIF(COALESCE(filters->>'subCategory', filters->>'sub_category'), '') IS NOT NULL THEN
+      ARRAY[COALESCE(filters->>'subCategory', filters->>'sub_category')]
+    ELSE NULL
+  END;
+  v_duration_enums text[] := CASE
+    WHEN filters ? 'durationEnums' AND jsonb_typeof(filters->'durationEnums') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'durationEnums'))
+    WHEN NULLIF(COALESCE(filters->>'durationEnum', filters->>'duration_enum'), '') IS NOT NULL THEN
+      ARRAY[COALESCE(filters->>'durationEnum', filters->>'duration_enum')]
+    ELSE NULL
+  END;
+  v_time_of_day_arr text[] := CASE
+    WHEN filters ? 'timeOfDay' AND jsonb_typeof(filters->'timeOfDay') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'timeOfDay'))
+    WHEN filters ? 'time_of_day' AND jsonb_typeof(filters->'time_of_day') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'time_of_day'))
+    WHEN NULLIF(COALESCE(filters->>'timeOfDay', filters->>'time_of_day'), '') IS NOT NULL THEN
+      ARRAY[COALESCE(filters->>'timeOfDay', filters->>'time_of_day')]
+    ELSE NULL
+  END;
+  v_min_price numeric := COALESCE(NULLIF(filters->>'min_price','')::numeric,
+                                   NULLIF(filters->>'minPrice','')::numeric);
+  v_max_price numeric := COALESCE(NULLIF(filters->>'max_price','')::numeric,
+                                   NULLIF(filters->>'maxPrice','')::numeric);
+  v_tag_ids int[] := CASE
+    WHEN filters ? 'tagIds' AND jsonb_typeof(filters->'tagIds') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'tagIds')::int)
+    ELSE NULL
+  END;
+  v_tag_names text[] := CASE
+    WHEN filters ? 'tags' AND jsonb_typeof(filters->'tags') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'tags'))
+    WHEN NULLIF(COALESCE(filters->>'tag', filters->>'tags'), '') IS NOT NULL THEN
+      ARRAY[COALESCE(filters->>'tag', filters->>'tags')]
+    ELSE NULL
+  END;
+  v_text_search text := NULLIF(filters->>'textSearch','');
+  v_tour_id int := (filters->>'tourId')::int;
+  v_tour_ids int[] := CASE
+    WHEN filters ? 'tourIds' AND jsonb_typeof(filters->'tourIds') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'tourIds')::int)
+    ELSE NULL
+  END;
+  v_requested_units int := COALESCE(
+    NULLIF(COALESCE(filters->>'requestedUnits', filters->>'participants', filters->>'quantity'), '')::int,
+    NULL
+  );
+  v_language text := COALESCE(NULLIF(filters->>'language', ''), 'es');
+  v_total bigint;
+BEGIN
+  SELECT COUNT(DISTINCT t.id) INTO v_total
+  FROM tour t
+  JOIN tour_address a ON a.tour_id = t.id
+  JOIN provider pr ON pr.id = t.provider_id
+  WHERE
+    t.status = 'accepted'
+    AND (v_tour_id IS NULL OR t.id = v_tour_id)
+    AND (v_tour_ids IS NULL OR t.id = ANY(v_tour_ids))
+    AND (v_state_txt IS NULL OR a.state_id::text = v_state_txt)
+    AND (v_city_txt IS NULL OR a.city_id::text = v_city_txt)
+    AND (v_provider_state_txt IS NULL OR pr.state_id::text = v_provider_state_txt)
+    AND (v_provider_city_txt IS NULL OR pr.city_id::text = v_provider_city_txt)
+    AND (v_duration_txt IS NULL OR t.duration::text = v_duration_txt)
+    AND (v_category_ids IS NULL OR t.category_id = ANY(v_category_ids))
+    AND (v_sub_categories IS NULL OR t.sub_category::text = ANY(v_sub_categories))
+    AND (v_duration_enums IS NULL OR t.duration_enum::text = ANY(v_duration_enums))
+    AND (
+      v_time_of_day_arr IS NULL
+      OR (
+        t.time_of_day IS NOT NULL
+        AND EXISTS (
+          SELECT 1 FROM unnest(t.time_of_day::text[]) AS tod(value)
+          WHERE tod.value = ANY(v_time_of_day_arr)
+        )
+      )
+    )
+    AND (
+      (v_tag_ids IS NULL AND v_tag_names IS NULL) OR EXISTS (
+        SELECT 1 FROM tour_tags tt2
+        JOIN tags tg2 ON tg2.id = tt2.tag_id
+        WHERE tt2.tour_id = t.id
+          AND (
+            (v_tag_ids IS NOT NULL AND tg2.id = ANY(v_tag_ids))
+            OR (v_tag_names IS NOT NULL AND tg2.nombre = ANY(v_tag_names))
+          )
+      )
+    )
+    AND (
+      v_text_search IS NULL OR
+      (t.name->>v_language) ILIKE '%' || v_text_search || '%' OR
+      (t.description->>v_language) ILIKE '%' || v_text_search || '%'
+    )
+    AND (
+      (v_start_date IS NULL AND v_end_date IS NULL)
+      OR EXISTS (
+        SELECT 1 FROM tour_schedule sx
+        LEFT JOIN tour_schedule_config scx ON scx.id = sx.config_id
+        WHERE sx.tour_id = t.id
+          AND (v_start_date IS NULL OR sx.schedule_date >= v_start_date)
+          AND (v_end_date IS NULL OR sx.schedule_date <= v_end_date)
+          AND (
+            v_requested_units IS NULL
+            OR COALESCE(t.is_unlimited_capacity, false) = true
+            OR EXISTS (
+              SELECT 1 FROM tour_schedule_config_slot slx
+              WHERE slx.config_id = scx.id
+                -- TC-004: filtro por capacidad usa conteo por-fecha.
+                AND GREATEST(0, COALESCE(slx.capacity, 0) - public.fn_slot_booked_units_on_schedule(slx.id, sx.id)) >= v_requested_units
+            )
+          )
+      )
+    )
+    AND (
+      v_min_price IS NULL
+      OR EXISTS (
+        SELECT 1 FROM tour_schedule s2
+        JOIN tour_schedule_config sc2 ON sc2.id = s2.config_id
+        JOIN tour_schedule_config_slot sl2 ON sl2.config_id = sc2.id
+        JOIN tour_schedule_config_price p2 ON p2.slot_id = sl2.id
+        WHERE s2.tour_id = t.id
+          AND (v_start_date IS NULL OR s2.schedule_date >= v_start_date)
+          AND (v_end_date IS NULL OR s2.schedule_date <= v_end_date)
+          AND CAST(p2.age_type AS character varying) = 'ADULT'
+          AND p2.price >= v_min_price
+      )
+    )
+    AND (
+      v_max_price IS NULL
+      OR EXISTS (
+        SELECT 1 FROM tour_schedule s3
+        JOIN tour_schedule_config sc3 ON sc3.id = s3.config_id
+        JOIN tour_schedule_config_slot sl3 ON sl3.config_id = sc3.id
+        JOIN tour_schedule_config_price p3 ON p3.slot_id = sl3.id
+        WHERE s3.tour_id = t.id
+          AND (v_start_date IS NULL OR s3.schedule_date >= v_start_date)
+          AND (v_end_date IS NULL OR s3.schedule_date <= v_end_date)
+          AND CAST(p3.age_type AS character varying) = 'ADULT'
+          AND p3.price <= v_max_price
+      )
+    );
+  RETURN COALESCE(v_total, 0);
+END;
+$function$;

--- a/src/main/java/com/tourya/api/repository/ReservationRepository.java
+++ b/src/main/java/com/tourya/api/repository/ReservationRepository.java
@@ -217,6 +217,37 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             Pageable pageable
     );
 
-
-
+    /**
+     * TC-004: cuenta unidades reservadas para un slot en una fecha específica.
+     *
+     * Suma unidades activas (TEMPORAL/PENDING/DELIVERED) respetando priceType:
+     *  - grupo: 1 unidad por reserva
+     *  - individual: suma de pax (shopping_cart_item_detail.quantity)
+     *
+     * Se cuenta por (shopping_cart_item.slot_id, tour_schedule.schedule_date) para
+     * evitar el bug del contador global slot.bookings (ver TC-004).
+     */
+    @Query(value = """
+        SELECT COALESCE(SUM(
+          CASE
+            WHEN t.price_type = 'grupo' THEN 1
+            ELSE COALESCE((
+              SELECT SUM(d.quantity)
+              FROM shopping_cart_item_detail d
+              WHERE d.shopping_cart_item_id = i.id
+            ), 0)
+          END
+        ), 0)
+        FROM reservation r
+        JOIN shopping_cart_item i ON i.id = r.item_id
+        JOIN tour_schedule ts ON ts.id = i.tour_schedule_id
+        JOIN tour t ON t.id = ts.tour_id
+        WHERE i.slot_id = :slotId
+          AND ts.schedule_date = :scheduleDate
+          AND r.delivery_status IN ('TEMPORAL', 'PENDING', 'DELIVERED')
+        """,
+        nativeQuery = true)
+    Integer countActiveBookingUnitsForSlotOnDate(
+            @Param("slotId") Integer slotId,
+            @Param("scheduleDate") LocalDate scheduleDate);
 }

--- a/src/main/java/com/tourya/api/services/ReservationService.java
+++ b/src/main/java/com/tourya/api/services/ReservationService.java
@@ -222,7 +222,9 @@ public class ReservationService {
                 .orElseThrow(() -> new ResourceNotFoundException("Slot not found"));
         int participantTotal = item.getDetails() == null ? 0
                 : item.getDetails().stream().mapToInt(ShoppingCartItemDetail::getQuantity).sum();
-        tourScheduleSlotAvailabilityService.ensureSlotHasCapacity(tour, slot, participantTotal);
+        // TC-004: capacity se valida contra el conteo (slot, fecha del schedule) — no el bookings global.
+        tourScheduleSlotAvailabilityService.ensureSlotHasCapacity(
+                tour, slot, item.getTourSchedule().getScheduleDate(), participantTotal);
     }
 
     /**
@@ -1779,7 +1781,9 @@ public class ReservationService {
         log.info("Validating slot capacity for reschedule - newScheduleId: {}, targetSlotId: {}, requestedParticipants: {}",
                 newSchedule.getId(), slotToUse.getId(), newTotalQuantity);
         if (!Boolean.TRUE.equals(tourForCap.getIsUnlimitedCapacity())) {
-            tourScheduleSlotAvailabilityService.ensureSlotHasCapacity(tourForCap, slotToUse, newTotalQuantity);
+            // TC-004: la validación se hace contra el conteo del nuevo día, no el bookings global del slot config.
+            tourScheduleSlotAvailabilityService.ensureSlotHasCapacity(
+                    tourForCap, slotToUse, newSchedule.getScheduleDate(), newTotalQuantity);
         }
         
         // Crear SlotRequest temporal con el slotId y la nueva configQuantity

--- a/src/main/java/com/tourya/api/services/ShoppingCartService.java
+++ b/src/main/java/com/tourya/api/services/ShoppingCartService.java
@@ -136,7 +136,9 @@ public class ShoppingCartService {
                 : 0;
         TourScheduleConfigSlot slot = tourScheduleConfigSlotRepository.findById(slotRequest.getId().intValue())
                 .orElseThrow(() -> new ResourceNotFoundException("Slot no encontrado"));
-        tourScheduleSlotAvailabilityService.ensureSlotHasCapacity(tour, slot, totalPax);
+        // TC-004: capacity se valida contra el conteo (slot, fecha del schedule) — no el bookings global.
+        tourScheduleSlotAvailabilityService.ensureSlotHasCapacity(
+                tour, slot, tourSchedule.getScheduleDate(), totalPax);
     }
 
     /**

--- a/src/main/java/com/tourya/api/services/TourScheduleConfigGeneralService.java
+++ b/src/main/java/com/tourya/api/services/TourScheduleConfigGeneralService.java
@@ -572,11 +572,23 @@ public class TourScheduleConfigGeneralService {
 
     private TourScheduleConfigResponse mapToTourScheduleConfigResponse(TourScheduleConfig config, List<Role> roleList,
             Map<AgePriceType, AgeRangeConfig> ageConfigMap) {
-        return mapToTourScheduleConfigResponse(config, roleList, ageConfigMap, true);
+        return mapToTourScheduleConfigResponse(config, roleList, ageConfigMap, true, null);
     }
 
     private TourScheduleConfigResponse mapToTourScheduleConfigResponse(TourScheduleConfig config, List<Role> roleList,
             Map<AgePriceType, AgeRangeConfig> ageConfigMap, boolean includeConfigSlotPercentage) {
+        return mapToTourScheduleConfigResponse(config, roleList, ageConfigMap, includeConfigSlotPercentage, null);
+    }
+
+    /**
+     * TC-004: {@code scheduleDate} opcional. Si se pasa, cada slot expone bookings/availability
+     * calculados por (slot_id, scheduleDate) en runtime. Si es null se mantiene el valor
+     * denormalizado del slot config (comportamiento pre-TC-004, apropiado para vistas de
+     * edición de la config donde no hay una fecha específica).
+     */
+    private TourScheduleConfigResponse mapToTourScheduleConfigResponse(TourScheduleConfig config, List<Role> roleList,
+            Map<AgePriceType, AgeRangeConfig> ageConfigMap, boolean includeConfigSlotPercentage,
+            LocalDate scheduleDate) {
         boolean showTouryaFields = roleList != null && Utils.isTouryaBackoffice(roleList);
 
         TourScheduleConfigResponse responseDto = new TourScheduleConfigResponse();
@@ -586,7 +598,7 @@ public class TourScheduleConfigGeneralService {
         responseDto.setDaysOfWeek(config.getDaysOfWeek());
 
         Set<TourScheduleSlotResponse> slotDtos = config.getSlots().stream()
-                .map(slot -> mapSlotToResponse(slot, ageConfigMap, showTouryaFields, includeConfigSlotPercentage))
+                .map(slot -> mapSlotToResponse(slot, ageConfigMap, showTouryaFields, includeConfigSlotPercentage, scheduleDate))
                 .collect(Collectors.toSet());
         responseDto.setSlots(slotDtos);
         return responseDto;
@@ -594,19 +606,30 @@ public class TourScheduleConfigGeneralService {
 
     private TourScheduleSlotResponse mapSlotToResponse(TourScheduleConfigSlot slot,
             Map<AgePriceType, AgeRangeConfig> ageConfigMap, boolean showTouryaFields) {
-        return mapSlotToResponse(slot, ageConfigMap, showTouryaFields, true);
+        return mapSlotToResponse(slot, ageConfigMap, showTouryaFields, true, null);
     }
 
     private TourScheduleSlotResponse mapSlotToResponse(TourScheduleConfigSlot slot,
             Map<AgePriceType, AgeRangeConfig> ageConfigMap, boolean showTouryaFields,
-            boolean includeConfigSlotPercentage) {
+            boolean includeConfigSlotPercentage,
+            LocalDate scheduleDate) {
         TourScheduleSlotResponse slotDto = new TourScheduleSlotResponse();
         slotDto.setId(slot.getId());
         slotDto.setStartTime(slot.getStartTime());
         slotDto.setEndTime(slot.getEndTime());
         slotDto.setCapacity(slot.getCapacity());
-        slotDto.setBookings(slot.getBookings());
-        slotDto.setAvailability(slot.getAvailability());
+        // TC-004: si viene fecha, contar (slot_id, scheduleDate) en runtime. Si no, mantener denormalizado.
+        if (scheduleDate != null && slot.getId() != null) {
+            int bookings = tourScheduleSlotAvailabilityService.countBookingsForSlotOnDate(slot.getId(), scheduleDate);
+            int availability = slot.getCapacity() != null
+                    ? Math.max(0, slot.getCapacity() - bookings)
+                    : 0;
+            slotDto.setBookings(bookings);
+            slotDto.setAvailability(availability);
+        } else {
+            slotDto.setBookings(slot.getBookings());
+            slotDto.setAvailability(slot.getAvailability());
+        }
         slotDto.setMinCapacityCalc(slot.getMinCapacityCalc());
         slotDto.setCheckAvailability(slot.getCheckAvailability());
         if (showTouryaFields && includeConfigSlotPercentage) {
@@ -696,8 +719,9 @@ public class TourScheduleConfigGeneralService {
                     if (schedule.getConfigId() != null) {
                         TourScheduleConfig config = configById.get(schedule.getConfigId());
                         if (config != null) {
+                            // TC-004: pasar la fecha del schedule para que los slots reporten bookings/availability por-día.
                             TourScheduleConfigResponse configResponse =
-                                    mapToTourScheduleConfigResponse(config, roleList, ageConfigMap, false);
+                                    mapToTourScheduleConfigResponse(config, roleList, ageConfigMap, false, schedule.getScheduleDate());
                             tourScheduleOverrideService.applyToConfigResponse(
                                     schedule.getId(),
                                     configResponse,

--- a/src/main/java/com/tourya/api/services/TourScheduleSlotAvailabilityService.java
+++ b/src/main/java/com/tourya/api/services/TourScheduleSlotAvailabilityService.java
@@ -13,14 +13,21 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Bookings y availability viven en {@link TourScheduleConfigSlot}.
- * Bookings = suma de unidades de {@link Reservation} activas (TEMPORAL/PENDING/DELIVERED) por slot.
+ * TC-004: bookings/availability se calculan por (slot_id, schedule_date) en runtime.
+ *
+ * Las columnas denormalizadas {@code tour_schedule_config_slot.bookings} y {@code availability}
+ * quedan preservadas por compatibilidad pero ya no son la fuente de verdad — se contaba a nivel
+ * de config-slot y esa cifra se replicaba en todas las fechas del calendario mensual (bug reportado
+ * en el issue TC-004 el 2026-07-21).
+ *
+ * Nueva fuente de verdad: {@link ReservationRepository#countActiveBookingUnitsForSlotOnDate}.
  */
 @Service
 @RequiredArgsConstructor
@@ -59,9 +66,28 @@ public class TourScheduleSlotAvailabilityService {
     }
 
     /**
-     * Valida cupos en el slot usando capacity − bookings (no solo la columna availability).
+     * TC-004: cuenta unidades reservadas para un slot en una fecha específica
+     * respetando priceType (grupo=1 unidad por reserva, individual=suma de pax).
+     *
+     * @param slotId       id del {@link TourScheduleConfigSlot}
+     * @param scheduleDate fecha del schedule (no la del recalculate del slot config)
+     * @return unidades reservadas activas (TEMPORAL/PENDING/DELIVERED), 0 si no hay ninguna
      */
-    public void ensureSlotHasCapacity(Tour tour, TourScheduleConfigSlot slot, int participantTotal) {
+    public int countBookingsForSlotOnDate(Integer slotId, LocalDate scheduleDate) {
+        if (slotId == null || scheduleDate == null) {
+            return 0;
+        }
+        Integer count = reservationRepository.countActiveBookingUnitsForSlotOnDate(slotId, scheduleDate);
+        return count != null ? count : 0;
+    }
+
+    /**
+     * Valida cupos en el slot para una fecha específica (TC-004).
+     *
+     * @param scheduleDate fecha real del schedule que se está reservando; obligatoria para
+     *                     evitar el bug del bookings global (ver TC-004).
+     */
+    public void ensureSlotHasCapacity(Tour tour, TourScheduleConfigSlot slot, LocalDate scheduleDate, int participantTotal) {
         if (Boolean.TRUE.equals(tour.getIsUnlimitedCapacity())) {
             return;
         }
@@ -74,7 +100,7 @@ public class TourScheduleSlotAvailabilityService {
                     "El grupo supera el máximo de personas por reserva del tour (" + tour.getMaxPeople() + ")");
         }
         int slotUnits = isGrupo ? 1 : participantTotal;
-        int booked = slot.getBookings() != null ? slot.getBookings() : 0;
+        int booked = countBookingsForSlotOnDate(slot.getId(), scheduleDate);
         int available = Math.max(0, slot.getCapacity() - booked);
         if (slotUnits > available) {
             String unitLabel = isGrupo ? "cupos de grupo" : "plazas";

--- a/src/test/java/com/tourya/api/services/TourScheduleSlotAvailabilityServiceTest.java
+++ b/src/test/java/com/tourya/api/services/TourScheduleSlotAvailabilityServiceTest.java
@@ -1,0 +1,235 @@
+package com.tourya.api.services;
+
+import com.tourya.api.constans.enums.PriceTypeEnum;
+import com.tourya.api.exceptions.OperationNotPermittedException;
+import com.tourya.api.models.Tour;
+import com.tourya.api.models.TourScheduleConfigSlot;
+import com.tourya.api.repository.ReservationRepository;
+import com.tourya.api.repository.ShoppingCartItemRepository;
+import com.tourya.api.repository.TourRepository;
+import com.tourya.api.repository.TourScheduleConfigRepository;
+import com.tourya.api.repository.TourScheduleConfigSlotRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * TC-004: bookings/availability se cuentan por (slot_id, schedule_date) en runtime,
+ * NO desde el campo denormalizado `slot.bookings`.
+ *
+ * Estos tests protegen el fix del bug reportado por Luis 2026-07-21 donde el mismo
+ * `slot.bookings` aparecía en TODAS las fechas del calendario mensual del tour.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("TourScheduleSlotAvailabilityService — TC-004 bookings por día")
+class TourScheduleSlotAvailabilityServiceTest {
+
+    private static final LocalDate DATE_24_JUL = LocalDate.of(2026, 7, 24);
+    private static final LocalDate DATE_25_JUL = LocalDate.of(2026, 7, 25);
+    private static final Integer SLOT_ID = 1030;
+
+    @Mock private TourScheduleConfigSlotRepository slotRepository;
+    @Mock private ShoppingCartItemRepository shoppingCartItemRepository;
+    @Mock private ReservationRepository reservationRepository;
+    @Mock private TourRepository tourRepository;
+    @Mock private TourScheduleConfigRepository configRepository;
+
+    private TourScheduleSlotAvailabilityService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TourScheduleSlotAvailabilityService(
+                slotRepository, shoppingCartItemRepository, reservationRepository,
+                tourRepository, configRepository);
+    }
+
+    // ---------------- countBookingsForSlotOnDate ----------------
+
+    @Test
+    @DisplayName("countBookingsForSlotOnDate: devuelve 0 si slotId es null")
+    void countBookings_nullSlot_returnsZero() {
+        int result = service.countBookingsForSlotOnDate(null, DATE_24_JUL);
+
+        assertThat(result).isZero();
+        verifyNoInteractions(reservationRepository);
+    }
+
+    @Test
+    @DisplayName("countBookingsForSlotOnDate: devuelve 0 si scheduleDate es null")
+    void countBookings_nullDate_returnsZero() {
+        int result = service.countBookingsForSlotOnDate(SLOT_ID, null);
+
+        assertThat(result).isZero();
+        verifyNoInteractions(reservationRepository);
+    }
+
+    @Test
+    @DisplayName("countBookingsForSlotOnDate: devuelve valor del repository")
+    void countBookings_happyPath_returnsRepositoryValue() {
+        when(reservationRepository.countActiveBookingUnitsForSlotOnDate(SLOT_ID, DATE_24_JUL))
+                .thenReturn(2);
+
+        int result = service.countBookingsForSlotOnDate(SLOT_ID, DATE_24_JUL);
+
+        assertThat(result).isEqualTo(2);
+        verify(reservationRepository).countActiveBookingUnitsForSlotOnDate(SLOT_ID, DATE_24_JUL);
+    }
+
+    @Test
+    @DisplayName("countBookingsForSlotOnDate: repository null se trata como 0")
+    void countBookings_repoReturnsNull_returnsZero() {
+        when(reservationRepository.countActiveBookingUnitsForSlotOnDate(SLOT_ID, DATE_24_JUL))
+                .thenReturn(null);
+
+        int result = service.countBookingsForSlotOnDate(SLOT_ID, DATE_24_JUL);
+
+        assertThat(result).isZero();
+    }
+
+    // ---------------- ensureSlotHasCapacity ----------------
+
+    @Test
+    @DisplayName("ensureSlotHasCapacity: tour unlimited pasa sin consultar reservas")
+    void ensureCapacity_unlimited_shortCircuits() {
+        Tour tour = new Tour();
+        tour.setIsUnlimitedCapacity(true);
+        TourScheduleConfigSlot slot = slot(SLOT_ID, 5);
+
+        service.ensureSlotHasCapacity(tour, slot, DATE_24_JUL, 100);
+
+        verifyNoInteractions(reservationRepository);
+    }
+
+    @Test
+    @DisplayName("ensureSlotHasCapacity: individual — pasa cuando hay capacidad en la fecha")
+    void ensureCapacity_individual_passesWhenAvailable() {
+        Tour tour = individualTour();
+        TourScheduleConfigSlot slot = slot(SLOT_ID, 5);
+        when(reservationRepository.countActiveBookingUnitsForSlotOnDate(SLOT_ID, DATE_24_JUL))
+                .thenReturn(2);
+
+        // 5 capacity - 2 booked en 24-jul = 3 available, pido 3
+        service.ensureSlotHasCapacity(tour, slot, DATE_24_JUL, 3);
+    }
+
+    @Test
+    @DisplayName("ensureSlotHasCapacity: individual — falla cuando no hay capacidad")
+    void ensureCapacity_individual_failsWhenFull() {
+        Tour tour = individualTour();
+        TourScheduleConfigSlot slot = slot(SLOT_ID, 5);
+        when(reservationRepository.countActiveBookingUnitsForSlotOnDate(SLOT_ID, DATE_24_JUL))
+                .thenReturn(4);
+
+        // 5 - 4 = 1 disponible, pido 2 → falla
+        assertThatThrownBy(() -> service.ensureSlotHasCapacity(tour, slot, DATE_24_JUL, 2))
+                .isInstanceOf(OperationNotPermittedException.class)
+                .hasMessageContaining("Disponible: 1");
+    }
+
+    @Test
+    @DisplayName("TC-004 REGRESIÓN: usa conteo por-fecha, NO el campo slot.bookings global")
+    void ensureCapacity_ignoresGlobalSlotBookings() {
+        Tour tour = individualTour();
+        // slot.bookings=99 (contador global desactualizado del bug histórico) pero solo 1 reserva real hoy
+        TourScheduleConfigSlot slot = slot(SLOT_ID, 5);
+        slot.setBookings(99);
+        when(reservationRepository.countActiveBookingUnitsForSlotOnDate(SLOT_ID, DATE_25_JUL))
+                .thenReturn(1);
+
+        // Si leyera slot.bookings=99 con capacity=5, siempre fallaría. Con conteo por-fecha=1, pasa.
+        service.ensureSlotHasCapacity(tour, slot, DATE_25_JUL, 4);
+    }
+
+    @Test
+    @DisplayName("TC-004 REGRESIÓN: fechas distintas del mismo slot no comparten bookings")
+    void ensureCapacity_differentDates_independentCounts() {
+        Tour tour = individualTour();
+        TourScheduleConfigSlot slot = slot(SLOT_ID, 5);
+        // 24-jul lleno (5), 25-jul vacío (0)
+        when(reservationRepository.countActiveBookingUnitsForSlotOnDate(SLOT_ID, DATE_24_JUL))
+                .thenReturn(5);
+        when(reservationRepository.countActiveBookingUnitsForSlotOnDate(SLOT_ID, DATE_25_JUL))
+                .thenReturn(0);
+
+        // 24-jul rechaza
+        assertThatThrownBy(() -> service.ensureSlotHasCapacity(tour, slot, DATE_24_JUL, 1))
+                .isInstanceOf(OperationNotPermittedException.class);
+
+        // 25-jul acepta el mismo pedido
+        service.ensureSlotHasCapacity(tour, slot, DATE_25_JUL, 5);
+    }
+
+    @Test
+    @DisplayName("ensureSlotHasCapacity: grupo — usa 1 unidad (no pax) al medir capacidad")
+    void ensureCapacity_grupo_countsAsOneUnit() {
+        Tour tour = grupoTour(10);
+        TourScheduleConfigSlot slot = slot(SLOT_ID, 3);
+        when(reservationRepository.countActiveBookingUnitsForSlotOnDate(SLOT_ID, DATE_24_JUL))
+                .thenReturn(2);
+
+        // capacity=3 grupos, booked=2 → 1 grupo disponible. Pido 8 pax (1 grupo, dentro del maxPeople=10)
+        service.ensureSlotHasCapacity(tour, slot, DATE_24_JUL, 8);
+    }
+
+    @Test
+    @DisplayName("ensureSlotHasCapacity: grupo — falla si pax excede maxPeople del tour")
+    void ensureCapacity_grupo_failsWhenExceedsMaxPeople() {
+        Tour tour = grupoTour(4);
+        TourScheduleConfigSlot slot = slot(SLOT_ID, 10);
+
+        assertThatThrownBy(() -> service.ensureSlotHasCapacity(tour, slot, DATE_24_JUL, 5))
+                .isInstanceOf(OperationNotPermittedException.class)
+                .hasMessageContaining("máximo de personas");
+    }
+
+    @Test
+    @DisplayName("ensureSlotHasCapacity: falla si capacity del slot es null")
+    void ensureCapacity_nullCapacity_fails() {
+        Tour tour = individualTour();
+        TourScheduleConfigSlot slot = new TourScheduleConfigSlot();
+        slot.setId(SLOT_ID);
+        slot.setCapacity(null);
+
+        assertThatThrownBy(() -> service.ensureSlotHasCapacity(tour, slot, DATE_24_JUL, 1))
+                .isInstanceOf(OperationNotPermittedException.class)
+                .hasMessageContaining("no tiene capacity configurada");
+    }
+
+    // ---------------- helpers ----------------
+
+    private Tour individualTour() {
+        Tour tour = new Tour();
+        tour.setIsUnlimitedCapacity(false);
+        tour.setPriceType(PriceTypeEnum.INDIVIDUAL);
+        return tour;
+    }
+
+    private Tour grupoTour(int maxPeople) {
+        Tour tour = new Tour();
+        tour.setIsUnlimitedCapacity(false);
+        tour.setPriceType(PriceTypeEnum.GRUPO);
+        tour.setMaxPeople(maxPeople);
+        return tour;
+    }
+
+    private TourScheduleConfigSlot slot(Integer id, int capacity) {
+        TourScheduleConfigSlot slot = new TourScheduleConfigSlot();
+        slot.setId(id);
+        slot.setCapacity(capacity);
+        return slot;
+    }
+}


### PR DESCRIPTION
Cierra el bug reportado por Luis en #187 (TC-004).

## Resumen

- El campo `tour_schedule_config_slot.bookings` es un contador a nivel de config-slot (plantilla), NO por fecha.
- Como el mismo slot config se aplica a múltiples fechas, las 2 reservas del 24-jul en el tour 72 aparecían en TODOS los 16 días del calendario mensual con `availability=3` cuando deberían ser 5.
- Confirmado por Donnaly Giménez vía WhatsApp 21-jul: *"Si la regla de negocio es cupo por día, hoy el backend no lo hace así. Haría falta contar por slotId + scheduleDate"*.

## Fix

### Java

- `ReservationRepository.countActiveBookingUnitsForSlotOnDate` — query nativa que cuenta unidades activas (TEMPORAL/PENDING/DELIVERED) respetando `priceType` (grupo=1 unidad por reserva, individual=suma pax).
- `TourScheduleSlotAvailabilityService.countBookingsForSlotOnDate` — helper público.
- `TourScheduleSlotAvailabilityService.ensureSlotHasCapacity` — **cambio de firma**: ahora requiere `LocalDate scheduleDate`. Los 3 callers (`ReservationService.validateSlotAvailabilityForItem`, reschedule, `ShoppingCartService.validateTourCapacityForCartRequest`) propagan la fecha desde `tourSchedule.getScheduleDate()`.
- `TourScheduleConfigGeneralService.mapSlotToResponse` — acepta `LocalDate scheduleDate` opcional. Cuando viene poblada (via `findAllByTourId`), `bookings`/`availability` se calculan en runtime por-fecha. Otros callers de la config (creación/edición) pasan `null` y mantienen comportamiento previo.
- El campo `slot.bookings` en BD queda intacto por compatibilidad pero **deja de ser fuente de verdad** para el endpoint que Luis reportaba (`/tour-schedules/tours/{tourId}`) y para los SPs públicos.

### SQL — migración 078

- **Nueva función helper** `fn_slot_booked_units_on_schedule(slot_id, schedule_id)` (STABLE) que hace el mismo cálculo que la query nativa Java.
- `sp_get_tour_schedule_json` — reemplaza `sl.bookings` por el helper en (a) el JSON output de cada slot y (b) el filtro `requestedUnits`.
- `sp_count_tour_schedule_json` — mismo fix en el filtro EXISTS.
- Ambos SPs afectan el flujo público del turista (`/public/tours/schedule/search`).

## Verificación en dev

Migración 078 aplicada a Cloud SQL `tourya-dev-db`. Tour 72 slot 1030:

| Fecha | bookings antes | bookings después | availability antes | availability después |
|---|:---:|:---:|:---:|:---:|
| 22-jul | 2 ❌ | **0** ✅ | 3 ❌ | **5** ✅ |
| 23-jul | 2 ❌ | **0** ✅ | 3 ❌ | **5** ✅ |
| **24-jul** | 2 ✅ | 2 ✅ | 3 ✅ | 3 ✅ |
| 25-jul | 2 ❌ | **0** ✅ | 3 ❌ | **5** ✅ |
| 26-jul | 2 ❌ | **0** ✅ | 3 ❌ | **5** ✅ |
| ... | ... | ... | ... | ... |

## Tests

**12 tests unitarios nuevos** en `TourScheduleSlotAvailabilityServiceTest.java`:

- Guards null (slotId, scheduleDate, repo devuelve null).
- Individual: pasa con disponibilidad / falla lleno / usa capacity correcta.
- Grupo: cuenta como 1 unidad / falla si pax > maxPeople.
- **Regresión explícita del bug**:
  - `ensureCapacity_ignoresGlobalSlotBookings`: aunque `slot.bookings=99` (drift del bug histórico), el conteo por-fecha se impone.
  - `ensureCapacity_differentDates_independentCounts`: 24-jul lleno rechaza / 25-jul vacío acepta el mismo pedido.

```
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
```

## Consideraciones de performance

- El helper `fn_slot_booked_units_on_schedule` está marcado `STABLE` para que PostgreSQL cachee dentro de la transacción.
- En un tour con 30 días × 5 slots = 150 llamadas. Cada llamada es 3 JOINs indexados. Aceptable para el volumen actual; si se vuelve issue en el futuro, evolucionar a `LEFT JOIN LATERAL` batch (deuda registrada aquí).

## Test plan

- [x] Build local (`./mvnw compile`)
- [x] Tests unitarios (`./mvnw test -Dtest=TourScheduleSlotAvailabilityServiceTest`)
- [x] Migración 078 aplicada a Cloud SQL dev
- [x] Verificación SQL directa: `fn_slot_booked_units_on_schedule` devuelve valores correctos
- [x] Verificación SQL: `sp_get_tour_schedule_json` devuelve `bookings=0` en días sin reservas y `bookings=2` solo el 24-jul
- [ ] **Post-merge**: verificar en UI de `/providers/tours/72/tour-schedule` que el calendario mensual muestra disponibilidad correcta por día
- [ ] **Post-merge**: crear reserva de prueba en 25-jul y confirmar que solo ese día baja disponibilidad
- [ ] **Post-merge**: verificar búsqueda pública turista (`/clients/list-tours`) con `requestedUnits` filtra correctamente

## Impacto en TC-005 / TC-006

Este fix también resuelve automáticamente el **sub-bug 1 de TC-006** (disponibilidad=3 en todos los días de la vista turista). TC-005 y los otros sub-bugs de TC-006 se abordan en PRs separados.

## Follow-up separado

Bug latente encontrado durante la investigación: `TemporalReservationExpiryJob` y transiciones a `NO_SHOW` no llaman `recalculate` — dejan `slot.bookings` inflado. **Este PR lo hace irrelevante** para los endpoints principales (ya no leen `slot.bookings`), pero conviene limpieza aparte para mantener consistencia si algún futuro caller lo consulta.