### PR TITLE
fix(tc-005): providerprice sin multiplicar por pax en tours grupo

### DIFF
--- a/database/migrations/079_tc005_sp_provider_reservations_grupo.sql
+++ b/database/migrations/079_tc005_sp_provider_reservations_grupo.sql
@@ -1,0 +1,138 @@
+-- Migration 079: TC-005 — providerprice correcto para tours GRUPO en sp_get_provider_reservations
+-- Date: 2026-07-22
+-- Description:
+--   El SP calculaba providerprice como SUM(provider_unit_price × quantity) sin distinguir tipo.
+--   Para tours GRUPO el precio es fijo por reserva (no por pax), por lo que el cálculo actual
+--   inflaba providerprice de RES-317 (grupo, 2 pax): 300,000 × 2 = 600,000, y de RES-316
+--   (grupo, 4 pax): 300,000 × 4 = 1,200,000.
+--
+--   Efecto visible: la LISTA de reservas del rol PROVIDER (mapProviderReservationToBooking en
+--   Angular usa `reservation.providerPrice` como precio mostrado) exponía los valores inflados.
+--   El resto del sistema no depende de esta columna del SP.
+--
+--   Fix: agregar CASE por t.price_type — GRUPO cuenta 1 unidad, INDIVIDUAL mantiene × quantity.
+--   Único cambio vs mig 061; el resto del SP queda idéntico.
+
+DROP FUNCTION IF EXISTS public.sp_get_provider_reservations(int4, int4, int8, varchar, varchar);
+
+CREATE OR REPLACE FUNCTION public.sp_get_provider_reservations(
+    p_provider_id integer DEFAULT NULL,
+    p_customer_user_id integer DEFAULT NULL,
+    p_reservation_id bigint DEFAULT NULL,
+    p_delivery_status character varying DEFAULT NULL,
+    p_sub_category character varying DEFAULT NULL
+)
+RETURNS TABLE(
+    reservationid bigint,
+    reservationdate timestamp without time zone,
+    reservationdeliverystatus character varying,
+    reservationcreateddate timestamp without time zone,
+    paymentid bigint,
+    paymenttransactionid character varying,
+    payername character varying,
+    payeremail character varying,
+    payerphone character varying,
+    payerdocumenttype character varying,
+    payerdocumentnumber character varying,
+    shoppingitemid integer,
+    shoppingtotalprice numeric,
+    shoppingunitprice numeric,
+    providerprice numeric,
+    shoppingquantity integer,
+    producttype character varying,
+    productid integer,
+    totaltourists bigint,
+    tourid integer,
+    tourname jsonb,
+    tourcategoryid integer,
+    tourproviderid integer,
+    toursubcategory character varying,
+    tourscheduleid integer,
+    scheduledate date,
+    slotid integer,
+    slottime_start time without time zone,
+    slottime_end time without time zone,
+    service_responsible_name character varying,
+    service_responsible_email character varying,
+    service_responsible_phone character varying,
+    max_cancellation_date date,
+    max_rescheduling_date date,
+    cancellation_reason character varying,
+    cancellation_date timestamp without time zone
+)
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+    RETURN QUERY
+    SELECT
+        r.reservation_id,
+        r.reservation_date,
+        r.delivery_status,
+        r.created_date,
+        p.payment_id,
+        p.transaction_id,
+        p.payer_name,
+        p.payer_email,
+        p.payer_phone,
+        p.payer_document_type,
+        p.payer_document_number,
+        sci.id AS shoppingItemId,
+        sci.total_price,
+        sci.unit_price,
+        -- TC-005: para tours GRUPO el precio del proveedor no depende de pax (multiplica × 1).
+        COALESCE((
+            SELECT SUM(
+                COALESCE(scid.provider_unit_price, 0) *
+                CASE WHEN t.price_type = 'grupo' THEN 1 ELSE COALESCE(scid.quantity, 0) END
+            )
+            FROM shopping_cart_item_detail scid
+            WHERE scid.shopping_cart_item_id = sci.id
+        ), 0)::numeric AS providerPrice,
+        sci.quantity,
+        sci.product_type,
+        sci.product_id,
+        COALESCE((
+            SELECT SUM(scid.quantity)
+            FROM shopping_cart_item_detail scid
+            WHERE scid.shopping_cart_item_id = sci.id
+        ), 0) AS totalTourists,
+        t.id AS tourId,
+        t.name AS tourName,
+        t.category_id,
+        t.provider_id,
+        t.sub_category::character varying AS tourSubcategory,
+        ts.id AS tourScheduleId,
+        sci.schedule_date,
+        tscs.id AS slotId,
+        tscs.start_time,
+        tscs.end_time,
+        r.service_responsible_name,
+        r.service_responsible_email,
+        r.service_responsible_phone,
+        r.max_cancellation_date,
+        r.max_rescheduling_date,
+        r.cancellation_reason,
+        r.cancellation_date
+    FROM reservation r
+    JOIN shopping_cart_item sci ON sci.id = r.item_id
+    JOIN shopping_cart sc ON sc.id = sci.shopping_cart_id
+    LEFT JOIN payment p ON p.payment_id = r.payment_id
+    LEFT JOIN tour_schedule ts ON ts.id = sci.tour_schedule_id
+    LEFT JOIN tour_schedule_config_slot tscs ON tscs.id = sci.slot_id
+    LEFT JOIN tour t ON t.id = sci.product_id
+    WHERE
+        (p_provider_id IS NULL OR t.provider_id = p_provider_id)
+        AND (p_customer_user_id IS NULL OR sc.user_id = p_customer_user_id)
+        AND (p_reservation_id IS NULL OR r.reservation_id = p_reservation_id)
+        AND (p_delivery_status IS NULL OR r.delivery_status = p_delivery_status)
+        AND (p_sub_category IS NULL OR t.sub_category::text = p_sub_category)
+    GROUP BY
+        r.reservation_id,
+        p.payment_id,
+        sci.id,
+        sc.id,
+        t.id,
+        ts.id,
+        tscs.id;
+END;
+$function$;


### PR DESCRIPTION
Cierra parcialmente #188 (TC-005 backend). El frontend queda para PR aparte.

## Resumen

El SP `sp_get_provider_reservations` calculaba `providerprice` como `SUM(provider_unit_price × quantity)` **sin distinguir el tipo del tour**. Para tours GRUPO el precio del proveedor es fijo por reserva (no por pax), pero el cálculo multiplicaba por la cantidad de viajeros — inflando el valor.

## Reproducción confirmada en BD (antes del fix)

| Reserva | Tipo | pax | provider_unit_price | providerprice (bug) | Esperado |
|:---:|:---:|:---:|:---:|:---:|:---:|
| RES-316 | grupo | 4 | 300,000 | **1,200,000** ❌ | 300,000 |
| RES-317 | grupo | 2 | 300,000 | **600,000** ❌ | 300,000 |

Efecto visible: la LISTA de "Mis Reservas" para el rol PROVIDER en Angular usaba `reservation.providerPrice` como precio mostrado (`mapProviderReservationToBooking` línea 615 de `provider-tour-management.component.ts`) → exhibía los valores inflados.

## Fix

Migración `079_tc005_sp_provider_reservations_grupo.sql` con `CASE WHEN t.price_type = 'grupo' THEN 1 ELSE quantity END` en el cálculo del `providerprice`:

```sql
COALESCE((
    SELECT SUM(
        COALESCE(scid.provider_unit_price, 0) *
        CASE WHEN t.price_type = 'grupo' THEN 1 ELSE COALESCE(scid.quantity, 0) END
    )
    FROM shopping_cart_item_detail scid
    WHERE scid.shopping_cart_item_id = sci.id
), 0)::numeric AS providerPrice
```

Único cambio vs `061_sp_get_provider_reservations_cleanup_overloads.sql`. El resto del SP queda idéntico (mismo tipo de retorno, mismos parámetros, mismos joins).

## Validado en Cloud SQL dev (después del fix)

| Reserva | cliente_paga (shoppingtotalprice) | proveedor_recibe (providerprice) | pax |
|:---:|:---:|:---:|:---:|
| RES-316 | 345,000 ✅ | **300,000** ✅ | 4 |
| RES-317 | 345,000 ✅ | **300,000** ✅ | 2 |

## Alcance del cambio (scope quirúrgico)

- **Backend Java**: cero — el mapper `ReservationDetailsMapper.java:68` sigue leyendo `providerprice` del SP como siempre. No se toca código Java.
- **Frontend**: cero en este PR. La LISTA del rol PROVIDER (`mapProviderReservationToBooking`) automáticamente mostrará el valor correcto ($300,000) sin cambio.
- **Modal detalle**: queda para PR frontend separado — hoy siempre muestra `shoppingTotalPrice`, hay que condicionar al rol.

## Verificación de que no rompe otros consumers

- SP `sp_get_provider_reservations` solo se usa en `ReservationNativeRepositoryImpl` + `ReservationRepository` (verificado con grep).
- Campo `providerPrice` del `ReservationDetailsResponse` solo se lee en el mapper (verificado con grep).
- Frontend: `reservation.providerPrice` solo se usa en `mapProviderReservationToBooking` línea 615 (verificado con grep).

## Preexistencia

Bug de la migración `061` (Donnaly Gimenez, ~jun 2026). Ningún commit reciente de nuestro equipo tocó este SP.

## Test plan

- [x] Migración aplicada a Cloud SQL dev
- [x] Verificación SQL directa: RES-316 y RES-317 devuelven providerprice=300,000
- [x] Verificación SQL: shoppingtotalprice sigue en 345,000 (sin regresión al lado cliente)
- [ ] **Post-merge**: verificar en UI que la LISTA de "Mis Reservas" del rol PROVIDER muestra $300,000 para RES-316/RES-317
- [ ] **Post-merge (siguiente PR)**: implementar el bug 5b (modal detalle condicional al rol) en `tourya-front`

## Continuación

Bug 5b (modal detalle muestra el precio-cliente para el rol PROVIDER en vez del precio-proveedor) se aborda en `tourya-front` PR aparte una vez este PR mergeado.