### PR TITLE
fix(be-27): recalculate en jobs de expiracion + backfill drift acumulado

### DIFF
--- a/database/migrations/080_be27_backfill_slot_bookings_drift.sql
+++ b/database/migrations/080_be27_backfill_slot_bookings_drift.sql
@@ -1,0 +1,41 @@
+-- Migration 080: BE-27 — backfill de slot.bookings / slot.availability
+-- Date: 2026-07-22
+-- Description:
+--   El TemporalReservationExpiryJob y el PendingReservationNoShowJob marcaban
+--   reservas como CANCELED/NO_SHOW sin llamar a recalculate. El campo denormalizado
+--   `tour_schedule_config_slot.bookings` quedaba inflado, acumulando drift sobre el tiempo.
+--
+--   Antes de este PR, dev tenia 33 slots con drift (drift total = 54 unidades, max = 20).
+--
+--   El fix del codigo (esta misma rama) evita drift futuro. Esta migracion limpia el
+--   drift acumulado recalculando `bookings` y `availability` como la suma de unidades
+--   de reservas activas (TEMPORAL/PENDING/DELIVERED), respetando priceType:
+--     - grupo: 1 unidad por reserva
+--     - individual: suma de pax (shopping_cart_item_detail.quantity)
+--
+--   Idempotente: correr varias veces produce el mismo resultado.
+
+UPDATE public.tour_schedule_config_slot s
+SET bookings = COALESCE((
+    SELECT SUM(
+        CASE
+            WHEN t.price_type = 'grupo' THEN 1
+            ELSE COALESCE((
+                SELECT SUM(d.quantity)
+                FROM shopping_cart_item_detail d
+                WHERE d.shopping_cart_item_id = i.id
+            ), 0)
+        END
+    )
+    FROM reservation r
+    JOIN shopping_cart_item i ON i.id = r.item_id
+    JOIN tour_schedule ts ON ts.id = i.tour_schedule_id
+    JOIN tour t ON t.id = ts.tour_id
+    WHERE i.slot_id = s.id
+      AND r.delivery_status IN ('TEMPORAL', 'PENDING', 'DELIVERED')
+), 0)::int
+WHERE s.bookings IS NOT NULL;
+
+UPDATE public.tour_schedule_config_slot
+SET availability = GREATEST(0, COALESCE(capacity, 0) - COALESCE(bookings, 0))
+WHERE capacity IS NOT NULL;

--- a/src/main/java/com/tourya/api/jobs/PendingReservationNoShowJob.java
+++ b/src/main/java/com/tourya/api/jobs/PendingReservationNoShowJob.java
@@ -2,7 +2,10 @@ package com.tourya.api.jobs;
 
 import com.tourya.api.constans.enums.DeliveryStatusEnum;
 import com.tourya.api.models.Reservation;
+import com.tourya.api.models.ShoppingCartItem;
 import com.tourya.api.repository.ReservationRepository;
+import com.tourya.api.repository.ShoppingCartItemRepository;
+import com.tourya.api.services.TourScheduleSlotAvailabilityService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -21,9 +24,13 @@ public class PendingReservationNoShowJob {
     private static final ZoneId CO_ZONE = ZoneId.of("America/Bogota");
 
     private final ReservationRepository reservationRepository;
+    private final ShoppingCartItemRepository shoppingCartItemRepository;
+    private final TourScheduleSlotAvailabilityService tourScheduleSlotAvailabilityService;
 
     /**
      * Diario 7am (hora Colombia): marca como NO_SHOW las reservas PENDING cuyo scheduleDate ya pasó.
+     * BE-27: por cada NO_SHOW llama {@code recalculate(slotId)} para que {@code slot.bookings}
+     * refleje la liberacion del cupo (antes quedaba inflado con el drift acumulandose).
      */
     @Scheduled(cron = "0 0 7 * * *", zone = "America/Bogota")
     @Transactional
@@ -35,16 +42,38 @@ public class PendingReservationNoShowJob {
         );
         if (pendingPast.isEmpty()) return;
 
+        java.util.Set<Integer> slotIdsToRecalc = new java.util.HashSet<>();
         for (Reservation r : pendingPast) {
             try {
                 r.setDeliveryStatus(DeliveryStatusEnum.NO_SHOW);
                 reservationRepository.save(r);
+                // BE-27: acumular slotIds afectados para recalcular al final (una vez por slot).
+                if (r.getItemId() != null) {
+                    ShoppingCartItem item = shoppingCartItemRepository.findById(r.getItemId()).orElse(null);
+                    if (item != null && item.getSlot() != null && item.getSlot().getId() != null) {
+                        slotIdsToRecalc.add(item.getSlot().getId());
+                    }
+                }
             } catch (Exception e) {
                 log.warn("No se pudo marcar NO_SHOW la reserva {}: {}", r.getReservationId(), e.getMessage());
             }
         }
 
-        log.info("Marcadas {} reservas como NO_SHOW (scheduleDate < {})", pendingPast.size(), today);
+        // BE-27: recalcular disponibilidad de cada slot afectado una sola vez.
+        int recalcOk = 0;
+        int recalcFailed = 0;
+        for (Integer slotId : slotIdsToRecalc) {
+            try {
+                tourScheduleSlotAvailabilityService.recalculate(slotId);
+                recalcOk++;
+            } catch (Exception e) {
+                recalcFailed++;
+                log.warn("BE-27: recalculate fallo para slot {} tras marcar NO_SHOW: {}", slotId, e.getMessage());
+            }
+        }
+
+        log.info("Marcadas {} reservas como NO_SHOW (scheduleDate < {}). Recalculados {} slots (fallidos: {}).",
+                pendingPast.size(), today, recalcOk, recalcFailed);
     }
 }
 

--- a/src/main/java/com/tourya/api/jobs/TemporalReservationExpiryJob.java
+++ b/src/main/java/com/tourya/api/jobs/TemporalReservationExpiryJob.java
@@ -8,6 +8,7 @@ import com.tourya.api.models.ShoppingCartItem;
 import com.tourya.api.repository.CreditRepository;
 import com.tourya.api.repository.ReservationRepository;
 import com.tourya.api.repository.ShoppingCartItemRepository;
+import com.tourya.api.services.TourScheduleSlotAvailabilityService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -25,15 +26,18 @@ public class TemporalReservationExpiryJob {
     private final ReservationRepository reservationRepository;
     private final ShoppingCartItemRepository shoppingCartItemRepository;
     private final CreditRepository creditRepository;
+    private final TourScheduleSlotAvailabilityService tourScheduleSlotAvailabilityService;
     private final TransactionTemplate perReservationTx;
 
     public TemporalReservationExpiryJob(ReservationRepository reservationRepository,
                                         ShoppingCartItemRepository shoppingCartItemRepository,
                                         CreditRepository creditRepository,
+                                        TourScheduleSlotAvailabilityService tourScheduleSlotAvailabilityService,
                                         PlatformTransactionManager transactionManager) {
         this.reservationRepository = reservationRepository;
         this.shoppingCartItemRepository = shoppingCartItemRepository;
         this.creditRepository = creditRepository;
+        this.tourScheduleSlotAvailabilityService = tourScheduleSlotAvailabilityService;
         // Hotfix #179b: cada reserva se procesa en su propia tx REQUIRES_NEW para
         // que un fallo aislado no marque rollback-only la tx del batch y arrastre
         // al resto (el job entraba en loop de UnexpectedRollbackException).
@@ -43,7 +47,9 @@ public class TemporalReservationExpiryJob {
 
     /**
      * Expira holds temporales vencidos. Cada reserva corre en su propia transaccion.
-     * Nota: liberacion de disponibilidad se recalcula al proximo hold/payment/cancel; aqui solo marca CANCELED.
+     * BE-27: al final de {@link #expireOne} se llama {@code recalculate(slotId)} para que
+     * {@code slot.bookings/availability} reflejen la liberacion del cupo (antes se dejaba
+     * inflado hasta el proximo hold, causando drift acumulado sobre el tiempo).
      */
     @Scheduled(fixedDelayString = "${tourya.temporalReservationExpiry.fixedDelayMs:60000}")
     public void expireTemporalReservations() {
@@ -81,7 +87,11 @@ public class TemporalReservationExpiryJob {
         }
 
         ShoppingCartItem item = shoppingCartItemRepository.findById(itemId).orElse(null);
+        Integer slotIdForRecalc = null;
         if (item != null) {
+            if (item.getSlot() != null && item.getSlot().getId() != null) {
+                slotIdForRecalc = item.getSlot().getId();
+            }
             // mantener el item en el carrito pero quitar la reserva temporal para permitir reintento
             item.setReservationId(null);
             shoppingCartItemRepository.save(item);
@@ -98,6 +108,17 @@ public class TemporalReservationExpiryJob {
         }
         if (!reservedCredits.isEmpty()) {
             creditRepository.saveAll(reservedCredits);
+        }
+
+        // BE-27: recalcular slot.bookings/availability para que reflejen que este hold libero cupo.
+        if (slotIdForRecalc != null) {
+            try {
+                tourScheduleSlotAvailabilityService.recalculate(slotIdForRecalc);
+            } catch (Exception e) {
+                // No propagar: el hold ya se cancelo. El drift se corrige al proximo touch del slot.
+                log.warn("BE-27: recalculate fallo para slot {} tras expirar reserva {}: {}",
+                        slotIdForRecalc, r.getReservationId(), e.getMessage());
+            }
         }
     }
 }

--- a/src/test/java/com/tourya/api/jobs/TemporalReservationExpiryJobTest.java
+++ b/src/test/java/com/tourya/api/jobs/TemporalReservationExpiryJobTest.java
@@ -5,9 +5,11 @@ import com.tourya.api.constans.enums.DeliveryStatusEnum;
 import com.tourya.api.models.Credit;
 import com.tourya.api.models.Reservation;
 import com.tourya.api.models.ShoppingCartItem;
+import com.tourya.api.models.TourScheduleConfigSlot;
 import com.tourya.api.repository.CreditRepository;
 import com.tourya.api.repository.ReservationRepository;
 import com.tourya.api.repository.ShoppingCartItemRepository;
+import com.tourya.api.services.TourScheduleSlotAvailabilityService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,6 +50,7 @@ class TemporalReservationExpiryJobTest {
     @Mock private ReservationRepository reservationRepository;
     @Mock private ShoppingCartItemRepository shoppingCartItemRepository;
     @Mock private CreditRepository creditRepository;
+    @Mock private TourScheduleSlotAvailabilityService tourScheduleSlotAvailabilityService;
     @Mock private PlatformTransactionManager transactionManager;
 
     private TemporalReservationExpiryJob job;
@@ -58,7 +61,8 @@ class TemporalReservationExpiryJobTest {
         // ejecute el callback en cada iteracion.
         when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
         job = new TemporalReservationExpiryJob(
-                reservationRepository, shoppingCartItemRepository, creditRepository, transactionManager);
+                reservationRepository, shoppingCartItemRepository, creditRepository,
+                tourScheduleSlotAvailabilityService, transactionManager);
     }
 
     @Test
@@ -140,6 +144,57 @@ class TemporalReservationExpiryJobTest {
         verify(reservationRepository).save(ok1);
         verify(reservationRepository).save(boom);
         verify(reservationRepository).save(ok2);
+    }
+
+    @Test
+    @DisplayName("BE-27: reserva con item.slot → llama recalculate(slotId) tras cancelar")
+    void expiredWithItemAndSlot_callsRecalculate() {
+        Reservation r = temporalReservation(600L, 700L);
+        ShoppingCartItem item = new ShoppingCartItem();
+        item.setId(700L);
+        TourScheduleConfigSlot slot = new TourScheduleConfigSlot();
+        slot.setId(1030);
+        item.setSlot(slot);
+
+        when(reservationRepository.findExpiredTemporalReservations(any())).thenReturn(List.of(r));
+        when(shoppingCartItemRepository.findById(700L)).thenReturn(Optional.of(item));
+
+        job.expireTemporalReservations();
+
+        verify(tourScheduleSlotAvailabilityService).recalculate(1030);
+    }
+
+    @Test
+    @DisplayName("BE-27: reserva con itemId=NULL NO llama recalculate (no hay slot que ajustar)")
+    void expiredNullItemId_skipsRecalculate() {
+        Reservation r = temporalReservation(601L, null);
+        when(reservationRepository.findExpiredTemporalReservations(any())).thenReturn(List.of(r));
+
+        job.expireTemporalReservations();
+
+        verify(tourScheduleSlotAvailabilityService, never()).recalculate(any());
+    }
+
+    @Test
+    @DisplayName("BE-27: si recalculate falla NO propaga — la reserva ya quedo cancelada")
+    void expiredRecalculateFails_stillCancelsReservation() {
+        Reservation r = temporalReservation(602L, 701L);
+        ShoppingCartItem item = new ShoppingCartItem();
+        item.setId(701L);
+        TourScheduleConfigSlot slot = new TourScheduleConfigSlot();
+        slot.setId(1031);
+        item.setSlot(slot);
+
+        when(reservationRepository.findExpiredTemporalReservations(any())).thenReturn(List.of(r));
+        when(shoppingCartItemRepository.findById(701L)).thenReturn(Optional.of(item));
+        org.mockito.Mockito.doThrow(new RuntimeException("recalculate boom"))
+                .when(tourScheduleSlotAvailabilityService).recalculate(1031);
+
+        // No debe lanzar — la cancelacion es exitosa aunque el recalculate falle.
+        job.expireTemporalReservations();
+
+        verify(reservationRepository).save(r);
+        assertThat(r.getDeliveryStatus()).isEqualTo(DeliveryStatusEnum.CANCELED);
     }
 
     private Reservation temporalReservation(Long id, Long itemId) {


### PR DESCRIPTION
Fix deuda técnica encontrada durante la auditoría de TC-004.

## Contexto

`TemporalReservationExpiryJob` (cada 60s) y `PendingReservationNoShowJob` (diario 7am Bogotá) marcaban reservas como `CANCELED`/`NO_SHOW` **sin llamar a `recalculate`**. El campo `tour_schedule_config_slot.bookings` se inflaba y acumulaba drift.

**Estado en dev al momento del análisis**: 33 slots con drift, drift total = 54 unidades, máximo = 20 (slot 509 — aparecía "lleno" cuando en realidad estaba vacío).

**Post TC-004** el impacto para el usuario es mínimo (los endpoints principales calculan bookings en runtime), pero:
- La vista de edición del schedule config del provider aún lee `slot.bookings`.
- Las escrituras defensivas (`setBookings(0)` en `TourScheduleConfigGeneralService`) y la validación de "no bajes capacity debajo del bookings" al editar config también leen el campo.
- Cualquier caller futuro que asuma `slot.bookings` como real verá números inflados.

## Cambios

### 1. `TemporalReservationExpiryJob.expireOne`

Obtiene el `slotId` del item **antes** de nullear `reservationId`, y al final del método llama `tourScheduleSlotAvailabilityService.recalculate(slotId)`.

Falla aislada — si `recalculate` revienta la cancelación ya quedó guardada (loguea WARN, no propaga).

### 2. `PendingReservationNoShowJob.markNoShows`

Acumula los `slotIds` afectados en un `Set` durante el loop y al final ejecuta `recalculate` **una vez por slot** (dedupe). Log separa ok/failed.

### 3. Migración `080_be27_backfill_slot_bookings_drift.sql`

Backfill SQL que recalcula `bookings` y `availability` de todos los slots como `SUM` de unidades activas (`TEMPORAL`/`PENDING`/`DELIVERED`) respetando `priceType`:
- grupo → 1 unidad por reserva.
- individual → suma de pax (`shopping_cart_item_detail.quantity`).

Idempotente — correr varias veces produce el mismo resultado.

## Verificación en Cloud SQL dev

**ANTES**: 33 slots con drift, drift total = 54.
**Migración aplicada**: UPDATE 790 (bookings) + UPDATE 402 (availability).
**DESPUÉS**: 0 slots con drift ✅.
**Slot 509** (el peor): pasó de `bookings=20, availability=0` a `bookings=0, availability=20` (correcto — capacity=20, 0 reservas activas reales).

## Tests

**7 tests verdes en `TemporalReservationExpiryJobTest`** (4 originales + 3 nuevos):
- `expiredWithItemAndSlot_callsRecalculate` — verifica que `recalculate(slotId)` se llama con el ID correcto.
- `expiredNullItemId_skipsRecalculate` — reservas huérfanas no llaman recalculate.
- `expiredRecalculateFails_stillCancelsReservation` — si recalculate falla no propaga, la cancelación queda persistida.

```
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
```

## Alcance del cambio

- **1 archivo SQL** — migración 080 (idempotente).
- **2 archivos Java** — jobs.
- **1 archivo test** — 3 tests nuevos.
- **Cero cambios en API pública** ni en endpoints.

## Riesgo

**Bajo**. `recalculate` ya se llama desde otros 7 lugares del código (creación de hold, cancelación, reschedule) — es un método idempotente y probado. Este PR solo lo agrega en 2 puntos más donde faltaba.

## Test plan post-merge

- [x] Migración aplicada a Cloud SQL dev, drift = 0 confirmado.
- [x] Tests unitarios verdes.
- [ ] **Post-deploy dev**: crear un hold TEMPORAL, esperar los 15 min de expiración, verificar que `slot.bookings` **baja** correctamente cuando el job corre.
- [ ] **Post-deploy dev**: verificar que la vista de edición del schedule config del provider ya no muestra bookings inflado en los slots viejos.

## Referencia

Este PR complementa TC-004 (PR #190). Con esto y con TC-004, `slot.bookings` queda consistente para todos los flujos actuales y futuros — dejamos de acumular deuda silenciosamente.