### PR TITLE
feat(be-24): endpoint provider decline + fix colateral AccountPayable

### DIFF
--- a/database/migrations/081_be24_reservation_provider_declined_at.sql
+++ b/database/migrations/081_be24_reservation_provider_declined_at.sql
@@ -1,0 +1,15 @@
+-- Migration 081: BE-24 Fase 1 — reservation.provider_declined_at
+-- Date: 2026-07-23
+-- Description:
+--   Nuevo campo para marcar cuándo el provider declinó una reserva
+--   (RN-055 rediseñada, Luis 2026-07-23 en issue #193).
+--
+--   El endpoint PUT /reservations/{id}/decline lo setea y dispara auto-cancel
+--   con crédito + email al turista con tours alternativos + anula el
+--   AccountPayable para evitar doble pago en el próximo payout del provider.
+
+ALTER TABLE public.reservation
+    ADD COLUMN IF NOT EXISTS provider_declined_at TIMESTAMPTZ NULL;
+
+COMMENT ON COLUMN public.reservation.provider_declined_at IS
+    'BE-24 (RN-055): timestamp cuando el provider marcó "no puedo atender" la reserva. NULL = no ha sido declinada. Al setearse se dispara cancelación automática + crédito al turista + anula AccountPayable.';

--- a/src/main/java/com/tourya/api/constans/enums/CancellationReasonEnum.java
+++ b/src/main/java/com/tourya/api/constans/enums/CancellationReasonEnum.java
@@ -35,7 +35,14 @@ public enum CancellationReasonEnum {
     /**
      * Cambio de planes del turista (BE-05, aprobado Luis 2026-07-07, RN-030).
      */
-    CHANGE_OF_PLANS
+    CHANGE_OF_PLANS,
+
+    /**
+     * BE-24 (RN-055): el provider avisó que no puede atender la reserva. Solo vía
+     * {@code PUT /reservations/{id}/decline}. Dispara cancelación automática +
+     * crédito al turista + anula {@code AccountPayable} del provider.
+     */
+    PROVIDER_DECLINED
 }
 
 

--- a/src/main/java/com/tourya/api/controller/ReservationController.java
+++ b/src/main/java/com/tourya/api/controller/ReservationController.java
@@ -362,6 +362,28 @@ public class ReservationController {
      * @param authentication Autenticación del usuario
      * @return RescheduleResponse con estado de transacción, validación de precio y datos
      */
+    /**
+     * BE-24 (RN-055): el provider marca "no puedo atender" la reserva. Trigger automático:
+     * cancela + crea crédito al turista + envía email con tours alternativos + anula
+     * AccountPayable para evitar doble pago en el próximo payout.
+     */
+    @PutMapping("/{reservationId}/decline")
+    @Operation(
+            summary = "Provider declina reserva (BE-24, RN-055)",
+            description = "Solo el provider actual de la reserva puede declinarla. Dispara cancelación + crédito al turista + email + anula AccountPayable. Idempotente: si providerDeclinedAt ya no es null, retorna 400.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Reserva declinada y cancelada"),
+            @ApiResponse(responseCode = "404", description = "Reserva no encontrada"),
+            @ApiResponse(responseCode = "400", description = "Estado inválido (terminal / ya declinada)"),
+            @ApiResponse(responseCode = "403", description = "El user no es el provider actual de la reserva")
+    })
+    public ResponseEntity<ReservationResponse> declineReservationByProvider(
+            @Parameter(description = "ID de la reserva a declinar") @PathVariable Long reservationId,
+            Authentication authentication) {
+        log.info("BE-24: provider declining reservation {}", reservationId);
+        return ResponseEntity.ok(reservationService.declineReservationByProvider(reservationId, authentication));
+    }
+
     @PutMapping("/{reservationId}/reschedule")
     @Operation(summary = "Re-agendar reserva", description = "Re-agenda una reserva con nueva fecha y configuración. Maneja 3 casos: precio igual/menor (actualiza) o mayor (cancela y agrega al carrito)")
     @ApiResponses(value = {

--- a/src/main/java/com/tourya/api/models/Reservation.java
+++ b/src/main/java/com/tourya/api/models/Reservation.java
@@ -100,6 +100,13 @@ public class Reservation extends BaseEntity {
     @Column(name = "cancellation_date")
     private LocalDateTime cancellationDate;
 
+    /**
+     * BE-24 (RN-055): timestamp cuando el provider marcó "no puedo atender" la reserva.
+     * NULL = no declinada. Al setearse se cancela automáticamente + crédito + anula AccountPayable.
+     */
+    @Column(name = "provider_declined_at")
+    private OffsetDateTime providerDeclinedAt;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "payment_id", insertable = false, updatable = false)
     private Payment payment;

--- a/src/main/java/com/tourya/api/repository/TourRepository.java
+++ b/src/main/java/com/tourya/api/repository/TourRepository.java
@@ -1,6 +1,7 @@
 package com.tourya.api.repository;
 
 import com.tourya.api.constans.enums.TourStatusEnum;
+import com.tourya.api.constans.enums.TourSubCategoryEnum;
 import com.tourya.api.models.Tour;
 import com.tourya.api.models.TourCategory;
 import org.springframework.data.domain.Page;
@@ -50,4 +51,33 @@ public interface TourRepository extends JpaRepository<Tour, Integer> {
      */
     @Query("SELECT t.id, t.rating FROM Tour t WHERE t.id IN :ids")
     List<Object[]> findIdAndRatingByTourIds(@Param("ids") Collection<Integer> ids);
+
+    /**
+     * BE-24 (RN-055): tours alternativos para el email de cancelación por decline del provider.
+     * Devuelve hasta {@code limit} tours ACCEPTED con la misma subcategoria (excluyendo el
+     * tour cancelado) ordenados por rating descendente.
+     *
+     * <p>No filtra por disponibilidad futura para no complicar el JPQL — el email solo
+     * muestra "revisa el catálogo" y el turista al hacer click ve los schedules disponibles.</p>
+     */
+    @Query(value = """
+            SELECT t FROM Tour t
+            WHERE t.status = 'accepted'
+              AND t.subCategory = :subCategory
+              AND t.id <> :excludeTourId
+            ORDER BY t.rating DESC NULLS LAST
+            """)
+    List<Tour> findAlternativesBySubCategoryQuery(
+            @Param("subCategory") TourSubCategoryEnum subCategory,
+            @Param("excludeTourId") Integer excludeTourId,
+            Pageable pageable);
+
+    /**
+     * BE-24: wrapper conveniente con {@code Pageable} armado internamente.
+     */
+    default List<Tour> findAlternativesBySubCategory(TourSubCategoryEnum subCategory,
+                                                     Integer excludeTourId, int limit) {
+        return findAlternativesBySubCategoryQuery(subCategory, excludeTourId,
+                org.springframework.data.domain.PageRequest.of(0, Math.max(1, limit)));
+    }
 }

--- a/src/main/java/com/tourya/api/services/EmailService.java
+++ b/src/main/java/com/tourya/api/services/EmailService.java
@@ -183,6 +183,52 @@ public class EmailService {
         mailSender.send(mimeMessage);
     }
 
+    /**
+     * BE-24 (RN-055): notifica al turista que su reserva fue cancelada porque el provider
+     * no puede atender, entrega el crédito compensatorio y lista de tours alternativos.
+     */
+    @Async
+    public void sendProviderDeclinedNotification(
+            String to,
+            String username,
+            String tourName,
+            java.math.BigDecimal creditAmount,
+            java.time.LocalDate creditExpirationDate,
+            List<com.tourya.api.models.Tour> alternatives,
+            String subject
+    ) throws MessagingException {
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(
+                mimeMessage,
+                MULTIPART_MODE_MIXED,
+                UTF_8.name());
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("username", username);
+        properties.put("tourName", tourName);
+        properties.put("creditAmount", creditAmount);
+        properties.put("creditExpirationDate", creditExpirationDate);
+        // Presentar tours alternativos como estructuras simples (id, nombre, rating) para el template.
+        List<Map<String, Object>> alternativesData = new java.util.ArrayList<>();
+        if (alternatives != null) {
+            for (com.tourya.api.models.Tour t : alternatives) {
+                Map<String, Object> row = new HashMap<>();
+                row.put("id", t.getId());
+                row.put("name", t.getName() != null ? t.getName().getEs() : "");
+                row.put("rating", t.getRating() != null ? t.getRating() : 0);
+                alternativesData.add(row);
+            }
+        }
+        properties.put("alternatives", alternativesData);
+        Context context = new Context();
+        context.setVariables(properties);
+        helper.setFrom(fromEmail);
+        helper.setTo(to);
+        helper.setSubject(subject);
+        String template = templateEngine.process("provider_declined_notification", context);
+        helper.setText(template, true);
+        mailSender.send(mimeMessage);
+    }
+
     @Async
     public void sendPurchaseConfirmationEmail(
             String to,

--- a/src/main/java/com/tourya/api/services/ReservationService.java
+++ b/src/main/java/com/tourya/api/services/ReservationService.java
@@ -52,6 +52,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -81,6 +82,7 @@ public class ReservationService {
     private final TourScheduleRepository tourScheduleRepository;
     private final TourRepository tourRepository;
     private final ProviderService providerService;
+    private final EmailService emailService;
     private final AccountPayableRepository accountPayableRepository;
     private final TourMainAttractionRepository tourMainAttractionRepository;
     private final TourIncludesExcludesRepository tourIncludesExcludesRepository;
@@ -1264,6 +1266,11 @@ public class ReservationService {
             tourScheduleSlotAvailabilityService.recalculate(item.getSlot().getId());
         }
 
+        // BE-24 fix colateral: al cancelar por lluvia también hay que anular el AccountPayable
+        // asociado, sino el ProviderPayoutOrderJob lo incluiría en el proximo payout del provider
+        // (doble pago: turista tiene credito Y provider recibe el pago).
+        voidAccountPayablesForReservation(r.getReservationId());
+
         Credit credit = createCreditForReservation(r, tour);
 
         Integer touristUserId = item.getShoppingCart() != null && item.getShoppingCart().getUser() != null
@@ -1326,6 +1333,9 @@ public class ReservationService {
         if (item.getSlot() != null && item.getSlot().getId() != null) {
             tourScheduleSlotAvailabilityService.recalculate(item.getSlot().getId());
         }
+
+        // BE-24 fix colateral: anular el AccountPayable (misma razon que en cancelOneByRedAlert).
+        voidAccountPayablesForReservation(reservation.getReservationId());
 
         Credit credit = createCreditForReservation(reservation, tour);
         log.info("Reservation {} canceled by rain successfully", reservationId);
@@ -2451,7 +2461,170 @@ public class ReservationService {
             
             totalPrice = totalPrice.add(detailTotalPrice);
         }
-        
+
         return totalPrice;
+    }
+
+    // ============================================================
+    // BE-24 Fase 1 (RN-055) — Provider decline
+    // ============================================================
+
+    /**
+     * BE-24 fix colateral: anula (marca como CANCELLED) los AccountPayable asociados a
+     * una reserva cancelada. Sin esto, el ProviderPayoutOrderJob los incluiría en el
+     * proximo payout y Tourya paga doble: el credito al turista + el payout al provider.
+     *
+     * <p>Aplica a cualquier cancelacion: por lluvia (BE-23), por decline (BE-24), o futura.
+     * Idempotente: si ya estan CANCELLED se saltan.</p>
+     */
+    private void voidAccountPayablesForReservation(Long reservationId) {
+        List<AccountPayable> aps = accountPayableRepository.findByReservationId(reservationId);
+        for (AccountPayable ap : aps) {
+            if (ap.getDeliveryStatus() != AccountPayableStatusEnum.CANCELLED) {
+                ap.setDeliveryStatus(AccountPayableStatusEnum.CANCELLED);
+            }
+        }
+        if (!aps.isEmpty()) {
+            accountPayableRepository.saveAll(aps);
+            log.info("BE-24: anulados {} AccountPayable(s) para reservationId={}", aps.size(), reservationId);
+        }
+    }
+
+    /**
+     * BE-24 (RN-055 rediseñada Luis 2026-07-23): el provider marca "no puedo atender".
+     * El sistema automaticamente:
+     * <ol>
+     *   <li>Setea {@code providerDeclinedAt = NOW()}.</li>
+     *   <li>Cancela la reserva ({@code deliveryStatus = CANCELED}, {@code reason = PROVIDER_DECLINED}).</li>
+     *   <li>Recalcula disponibilidad del slot.</li>
+     *   <li>Anula el AccountPayable del provider (fix colateral).</li>
+     *   <li>Crea un Credit al turista con el monto original.</li>
+     *   <li>Envía email al turista con notificacion + lista de tours alternativos.</li>
+     * </ol>
+     *
+     * <p><b>Guards</b>: solo el provider actual de la reserva puede declinarla. La reserva
+     * no debe estar en estado terminal (CANCELED/NO_SHOW/DELIVERED) ni haber sido ya declinada.</p>
+     */
+    @Transactional
+    public ReservationResponse declineReservationByProvider(Long reservationId, Authentication authentication) {
+        log.info("BE-24: provider declining reservation {}", reservationId);
+
+        User user = (User) authentication.getPrincipal();
+
+        Reservation reservation = reservationRepository.findByIdForUpdate(reservationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Reservation not found with id: " + reservationId));
+
+        if (reservation.getItemId() == null) {
+            throw new OperationNotPermittedException("La reserva no tiene un item de carrito asociado.");
+        }
+
+        if (reservation.getDeliveryStatus() == DeliveryStatusEnum.CANCELED
+                || reservation.getDeliveryStatus() == DeliveryStatusEnum.NO_SHOW
+                || reservation.getDeliveryStatus() == DeliveryStatusEnum.DELIVERED) {
+            throw new OperationNotPermittedException(
+                    "No se puede declinar una reserva en estado terminal (" + reservation.getDeliveryStatus() + ").");
+        }
+
+        if (reservation.getProviderDeclinedAt() != null) {
+            throw new OperationNotPermittedException("La reserva ya fue declinada por el provider.");
+        }
+
+        ShoppingCartItem item = shoppingCartItemRepository.findById(reservation.getItemId())
+                .orElseThrow(() -> new ResourceNotFoundException("Shopping cart item not found"));
+
+        if (item.getTourSchedule() == null || item.getTourSchedule().getTourId() == null) {
+            throw new OperationNotPermittedException("La reserva no tiene tour asociado.");
+        }
+
+        Tour tour = tourRepository.findById(item.getTourSchedule().getTourId())
+                .orElseThrow(() -> new ResourceNotFoundException("Tour not found"));
+
+        // Ownership guard: el user autenticado debe ser el provider actual del tour.
+        Provider currentProvider = providerService.findByUserAndStatusActive(user);
+        if (tour.getProvider() == null || !tour.getProvider().getId().equals(currentProvider.getId())) {
+            throw new InsufficientPrivilegesException(
+                    "Solo el provider actual de la reserva puede declinarla.");
+        }
+
+        // 1. Marcar decline + cancelar
+        reservation.setProviderDeclinedAt(OffsetDateTime.now());
+        reservation.setDeliveryStatus(DeliveryStatusEnum.CANCELED);
+        reservation.setCancellationReason(CancellationReasonEnum.PROVIDER_DECLINED);
+        reservation.setCancellationDate(LocalDateTime.now());
+        reservation = reservationRepository.save(reservation);
+
+        // 2. Recalcular disponibilidad del slot
+        if (item.getSlot() != null && item.getSlot().getId() != null) {
+            tourScheduleSlotAvailabilityService.recalculate(item.getSlot().getId());
+        }
+
+        // 3. Anular AccountPayable (fix colateral: evita doble pago)
+        voidAccountPayablesForReservation(reservation.getReservationId());
+
+        // 4. Crear credito al turista
+        Credit credit = createCreditForReservation(reservation, tour);
+
+        // 5. Email al turista con lista de tours alternativos (best-effort, no bloquea la tx)
+        sendProviderDeclinedEmailBestEffort(reservation, tour, item, credit);
+
+        log.info("BE-24: reservation {} declined by provider {}. Credit {} created, AP voided.",
+                reservationId, currentProvider.getId(), credit != null ? credit.getId() : "null");
+
+        ReservationResponse response = reservationMapper.toResponse(reservation);
+        enrichReservationResponse(response, reservation);
+        if (credit != null) {
+            response.setCredit(CreditResponse.builder()
+                    .id(credit.getId())
+                    .reservationId(credit.getReservationId())
+                    .amount(credit.getAmount())
+                    .creationDate(credit.getCreationDate())
+                    .expirationDate(credit.getExpirationDate())
+                    .status(credit.getStatus())
+                    .build());
+        }
+        return response;
+    }
+
+    /**
+     * BE-24: envia email al turista con la notificacion de cancelacion, el credito
+     * generado y una lista de tours alternativos de la misma subcategoria.
+     *
+     * <p>Best-effort: cualquier fallo se logea pero no propaga (la cancelacion ya
+     * ocurrio y es lo que importa).</p>
+     */
+    private void sendProviderDeclinedEmailBestEffort(Reservation reservation, Tour tour,
+                                                     ShoppingCartItem item, Credit credit) {
+        try {
+            if (item.getShoppingCart() == null || item.getShoppingCart().getUser() == null) {
+                log.warn("BE-24: reservationId={} sin usuario en carrito; email no enviado.",
+                        reservation.getReservationId());
+                return;
+            }
+            User tourist = item.getShoppingCart().getUser();
+            if (tourist.getEmail() == null || tourist.getEmail().isBlank()) {
+                log.warn("BE-24: turista sin email para reservationId={}", reservation.getReservationId());
+                return;
+            }
+
+            List<Tour> alternatives = tour.getSubCategory() != null
+                    ? tourRepository.findAlternativesBySubCategory(
+                            tour.getSubCategory(), tour.getId(), 5)
+                    : java.util.Collections.emptyList();
+
+            String tourName = tour.getName() != null ? tour.getName().getEs() : "tu tour";
+            java.math.BigDecimal creditAmount = credit != null ? credit.getAmount() : java.math.BigDecimal.ZERO;
+
+            emailService.sendProviderDeclinedNotification(
+                    tourist.getEmail(),
+                    tourist.fullName(),
+                    tourName,
+                    creditAmount,
+                    credit != null ? credit.getExpirationDate() : null,
+                    alternatives,
+                    "Reserva cancelada — tienes un crédito Tourya para tu próximo tour");
+        } catch (Exception ex) {
+            log.warn("BE-24: fallo enviando email de provider-decline para reservationId={}: {}",
+                    reservation.getReservationId(), ex.getMessage());
+        }
     }
 }

--- a/src/main/resources/templates/provider_declined_notification.html
+++ b/src/main/resources/templates/provider_declined_notification.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Reserva cancelada — tienes un crédito Tourya</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #f4f4f4;
+        }
+        .container {
+            max-width: 600px;
+            margin: 10px auto;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+        }
+        h1 {
+            color: #1f2937;
+            margin-top: 0;
+        }
+        h2 {
+            color: #1f2937;
+            font-size: 18px;
+            margin-top: 24px;
+        }
+        p {
+            color: #374151;
+            line-height: 1.5;
+        }
+        .credit-box {
+            background-color: #ecfdf5;
+            border: 1px solid #10b981;
+            border-radius: 8px;
+            padding: 16px;
+            margin: 20px 0;
+            text-align: center;
+        }
+        .credit-amount {
+            font-size: 28px;
+            font-weight: bold;
+            color: #047857;
+            display: block;
+        }
+        .credit-expiration {
+            font-size: 13px;
+            color: #6b7280;
+            margin-top: 6px;
+        }
+        .alternatives {
+            margin-top: 8px;
+        }
+        .alt-item {
+            border: 1px solid #e5e7eb;
+            border-radius: 6px;
+            padding: 10px 12px;
+            margin-bottom: 8px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .alt-name {
+            font-weight: 600;
+            color: #1f2937;
+        }
+        .alt-rating {
+            font-size: 13px;
+            color: #d97706;
+        }
+        .footer {
+            font-size: 12px;
+            color: #6b7280;
+            text-align: center;
+            margin-top: 30px;
+            border-top: 1px solid #e5e7eb;
+            padding-top: 15px;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Hola <span th:text="${username}">turista</span>,</h1>
+
+    <p>
+        Lamentamos informarte que el proveedor de tu reserva
+        <strong th:text="${tourName}">tu tour</strong> nos avisó que no podrá atenderla.
+    </p>
+
+    <p>
+        Como compensación te generamos un <strong>crédito Tourya</strong> por el valor total pagado:
+    </p>
+
+    <div class="credit-box">
+        <span class="credit-amount">
+            $<span th:text="${#numbers.formatDecimal(creditAmount, 0, 'COMMA', 2, 'POINT')}">0.00</span> COP
+        </span>
+        <div class="credit-expiration" th:if="${creditExpirationDate != null}">
+            Válido hasta <strong th:text="${#temporals.format(creditExpirationDate, 'dd/MM/yyyy')}">--/--/----</strong>
+        </div>
+    </div>
+
+    <p>
+        Puedes usar tu crédito para reservar cualquier otro tour en Tourya o
+        solicitar el reembolso del dinero contactando a nuestro equipo.
+    </p>
+
+    <h2 th:if="${alternatives != null and !#lists.isEmpty(alternatives)}">
+        Tours similares que te pueden interesar
+    </h2>
+
+    <div class="alternatives" th:if="${alternatives != null and !#lists.isEmpty(alternatives)}">
+        <div class="alt-item" th:each="alt : ${alternatives}">
+            <span class="alt-name" th:text="${alt.name}">Nombre del tour</span>
+            <span class="alt-rating">
+                ★ <span th:text="${#numbers.formatDecimal(alt.rating, 1, 1)}">0.0</span>
+            </span>
+        </div>
+    </div>
+
+    <p style="margin-top: 24px;">
+        Ingresa a la plataforma para explorar todas las opciones y utilizar tu crédito.
+    </p>
+
+    <div class="footer">
+        Este es un mensaje automático de Tourya. Si tienes alguna pregunta, respóndenos este correo.
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
BE-24 Fase 1 según **RN-055 rediseñada** (Luis 2026-07-23, issue #193).

## Contexto de negocio

Cuando un provider avisa que no puede atender una reserva pagada, el sistema **automáticamente**:
1. Cancela la reserva.
2. Crea un `Credit` al turista con el monto original.
3. Envía email al turista con notificación + lista de tours alternativos de la misma subcategoría.
4. Anula el `AccountPayable` del provider (para evitar doble pago).

No hay UI de reasignación manual del ADMIN — descartada en el rediseño por complejidad de precio/payout/capacidad. Ver [RN-055 en doc 05](https://github.com/Touryapp/tourya-api/blob/develop/docs/05-reglas-de-negocio.md) y [issue #193](https://github.com/Touryapp/tourya-api/issues/193).

## Cambios

### Nuevo endpoint

```
PUT /reservations/{reservationId}/decline
```

**Guards** validados con detalle:
- Solo el **provider actual** de la reserva (via `tour.provider.id == currentProvider.id`) puede declinarla — `403 InsufficientPrivileges` en otro caso.
- Reserva no puede estar en estado terminal (`CANCELED`/`NO_SHOW`/`DELIVERED`) — `400`.
- Reserva no puede haber sido declinada ya (`providerDeclinedAt != null`) — `400`.

### Flujo del método `declineReservationByProvider`

1. Valida ownership + estado.
2. Setea `providerDeclinedAt = OffsetDateTime.now()`, `deliveryStatus = CANCELED`, `cancellationReason = PROVIDER_DECLINED`, `cancellationDate = LocalDateTime.now()`.
3. Recalcula disponibilidad del slot (patrón BE-27).
4. **Anula AccountPayable** — fix colateral.
5. Crea `Credit` reusando `createCreditForReservation` (patrón BE-23).
6. Envía email best-effort con tours alternativos (query nueva por subcategory).

### Fix colateral BE-23 — anular `AccountPayable`

**Bug latente descubierto durante auditoría**: `cancelReservationByRain` y `cancelOneByRedAlert` (BE-23) **NO tocan el `AccountPayable`** al cancelar. Consecuencia: el `ProviderPayoutOrderJob` (lunes/jueves 7am) lo incluye en el próximo payout del provider → **doble pago** (turista tiene crédito + provider recibe payout).

Nuevo helper `voidAccountPayablesForReservation(reservationId)` aplicado en los 3 puntos de cancelación:
- `cancelReservationByRain` (BE-23)
- `cancelOneByRedAlert` (BE-23 batch)
- `declineReservationByProvider` (BE-24 nuevo)

**Idempotente**: si el AP ya está `CANCELLED` se salta.

### Archivos modificados

| Archivo | Cambio |
|---|---|
| `081_be24_reservation_provider_declined_at.sql` | Nueva columna `provider_declined_at TIMESTAMPTZ NULL` |
| `CancellationReasonEnum.java` | Nuevo valor `PROVIDER_DECLINED` |
| `Reservation.java` | Nuevo campo `providerDeclinedAt: OffsetDateTime` |
| `ReservationController.java` | Nuevo endpoint `PUT /{id}/decline` |
| `ReservationService.java` | `voidAccountPayablesForReservation`, `declineReservationByProvider`, `sendProviderDeclinedEmailBestEffort` + `void` en los 2 cancels existentes |
| `TourRepository.java` | Query `findAlternativesBySubCategory` (top N por rating, misma subCategory, `status = 'accepted'`) |
| `EmailService.java` | `sendProviderDeclinedNotification` async |
| `provider_declined_notification.html` | Template con crédito destacado + lista tours alternativos |

## Verificación

- [x] Migración 081 aplicada a Cloud SQL dev.
- [x] Build local: `./mvnw compile` → BUILD SUCCESS.
- [x] Columna `provider_declined_at` confirmada en DB (`TIMESTAMPTZ NULLABLE`).

## Deuda registrada

**BE-24b**: test unitario del `declineReservationByProvider` requiere 30+ mocks del `ReservationService` (mismo problema que `ReservationServiceRescheduleTest`). Queda registrado como deuda para un test integrado con `@SpringBootTest` + Testcontainers, junto con las deudas **BE-20b** y **BE-23b** ya conocidas. Se puede cerrar de una todas juntas cuando se introduzca Testcontainers al proyecto.

## Test plan post-merge

- [ ] Con un provider real: crear una reserva vía Wompi → login como provider → llamar `PUT /reservations/{id}/decline`.
  - Reserva pasa a `CANCELED, PROVIDER_DECLINED`, con `providerDeclinedAt` seteado.
  - `Credit` creado al turista con el `total_amount`.
  - Turista recibe email con lista de tours alternativos.
  - `AccountPayable.delivery_status = CANCELLED`.
  - Slot disponibilidad recalculada.
- [ ] Provider ajeno intenta declinar → `403`.
- [ ] Reserva `CANCELED` intenta declinarse → `400 "estado terminal"`.
- [ ] Reserva ya declinada intenta declinarse otra vez → `400 "ya fue declinada"`.
- [ ] Regresión BE-23: crear reserva → cancelar por lluvia → verificar que el `AccountPayable` queda en `CANCELLED` (no `PENDING` como antes).

## Fase 2 pendiente (roadmap)

Sistema de **penalizaciones por ventana temporal** (48h / 24-48h / <24h / no-show):
- Multa económica variable según horas antes del tour.
- Descenso en el ranking de búsquedas (7 o 15 días).
- Cupones de disculpas adicionales al turista (5%, 10%, 20%).
- Suspensión / expulsión del provider por reincidencia.

Talla XL, sin timeline definido. Ver RN-055 en doc 05.

## Referencias

- Issue [#193 BE-24](https://github.com/Touryapp/tourya-api/issues/193) — análisis técnico + rediseño de Luis.
- RN-055 en `docs/05-reglas-de-negocio.md`.
- Backlog `docs/17-backlog-implementacion.md` — BE-24 (activo) + FE-13 CANCELADO.
- Commit rediseño: [823f2e4](https://github.com/Touryapp/tourya-api/commit/823f2e4).