### PR TITLE
fix(reservation): backoffice ve reservas cross-provider aun con rol PROVIDER dual (#188)

### DIFF
--- a/src/main/java/com/tourya/api/services/ReservationService.java
+++ b/src/main/java/com/tourya/api/services/ReservationService.java
@@ -980,15 +980,19 @@ public class ReservationService {
         Integer finalProviderId = null;
         Integer customerUserId = null;
 
-        if (Utils.isProviderSide(roles)) {
+        // TC-005 Prueba 3 (fix #188 2026-07-23): chequear backoffice ANTES que providerSide.
+        // Usuarios ADMIN/BACKOFFICE_OPERATION que ademas tengan rol PROVIDER (dual role, caso
+        // real de Luis con user id=49) caian en la primera rama y forzaban filtro por
+        // providerId propio, ocultando la vista cross-provider. Ahora backoffice manda:
+        // requestedProviderId=null => SP no filtra => ve todo. Si backoffice pasa
+        // ?providerId=X explicito, se respeta.
+        if (Utils.isTouryaBackoffice(roles)) {
+            finalProviderId = requestedProviderId;
+        } else if (Utils.isProviderSide(roles)) {
             Provider provider = providerService.findByUserAndStatusActive(user);
             finalProviderId = provider.getId();
-        } else if (Utils.isTouryaBackoffice(roles)) {
-            finalProviderId = requestedProviderId;
-        } else if (!Utils.isTouryaBackoffice(roles) && !Utils.isProviderSide(roles)) {
-            customerUserId = user.getId();
         } else {
-            throw new InsufficientPrivilegesException("You have no privileges to perform this action.");
+            customerUserId = user.getId();
         }
 
         String status = (deliveryStatus != null) ? deliveryStatus.name() : null;


### PR DESCRIPTION
Hotfix del **TC-005 Prueba 3** (issue #188) tras que Luis reportó que el fix del PR front #74 no era suficiente.

## Bug reportado por Luis

Login como ADMIN en `/admin/bookings-management` — solo ve las reservas de UN provider (id=49), no todas cross-provider como debería.

## Root cause

`ReservationService.getProviderReservations:983-992` chequeaba `Utils.isProviderSide()` **antes que** `Utils.isTouryaBackoffice()`. El usuario ADMIN de Luis (id=49 en tabla `provider`) tiene también rol PROVIDER — caía en la primera rama y forzaba `finalProviderId = provider.getId() = 49` al SP, ocultando el resto.

**Evidencia** — logs Cloud Run `tourya-dev-api` después del deploy FE del PR #74:
```
22:31:05  providerId=49, size=5
22:32:06  providerId=49
23:12:34  providerId=49
```

**Frontend NUNCA manda `providerId`** (verificado en `reservation.service.ts:112-135`). El `providerId=49` lo inyectaba el backend en la primera rama del `if/else`.

**El fix del PR tourya-front #74** (mapear BACKOFFICE_OPERATION → 'ADMIN' y agregar rama `else-if 'PROVIDER || ADMIN'` en `loadProviderReservations`) era **necesario pero cosmético** — hacía que la vista se renderizara pero el backend seguía filtrando. Con este fix el backend hace lo suyo.

## Fix

Invertir el orden: chequear `isTouryaBackoffice` primero.

```java
// Antes:
if (Utils.isProviderSide(roles)) { ... provider.getId() ... }
else if (Utils.isTouryaBackoffice(roles)) { ... requestedProviderId ... }

// Ahora:
if (Utils.isTouryaBackoffice(roles)) { ... requestedProviderId ... }
else if (Utils.isProviderSide(roles)) { ... provider.getId() ... }
else { customerUserId = user.getId(); }
```

Con eso:
- Usuario con **rol dual** (ADMIN + PROVIDER, como Luis) → rama backoffice → `finalProviderId=null` → SP no filtra → ve todo cross-provider.
- Backoffice puro → mismo comportamiento.
- Provider puro → mismo comportamiento.
- Cliente puro → mismo comportamiento.
- Si backoffice pasa `?providerId=X` explícito en el query → se respeta.

Además simplifiqué el else final: el guard defensivo `!isTouryaBackoffice && !isProviderSide` era redundante porque ya cubierto por las 2 ramas anteriores.

## Verificación

- [x] `./mvnw compile` → BUILD SUCCESS.
- [x] Sin cambios en firma pública, ni en SP, ni en frontend.

## Test plan post-merge

- [ ] Login como ADMIN de Luis (dual role) en `/admin/bookings-management` → ver **todas** las reservas de todos los providers (RES-316, RES-317, RES-318, etc.).
- [ ] Login como ADMIN puro (sin rol PROVIDER) → mismo comportamiento, ve todo.
- [ ] Login como BACKOFFICE_OPERATION → aterriza en `/admin/bookings-management` → ve todo cross-provider.
- [ ] Regresión: login como PROVIDER puro → sigue viendo **solo** sus reservas (comportamiento anterior conservado).
- [ ] Regresión: ADMIN pasando `?providerId=49` explícito → ve solo las de ese provider (feature preservada).

## Referencias

- Issue [#188 TC-005](https://github.com/Touryapp/tourya-api/issues/188) — reporte de Luis + análisis del agent.
- PR tourya-front [#74](https://github.com/Touryapp/tourya-front/pull/74) — fix cosmético frontend (correcto pero insuficiente sin este backend fix).
- `Utils.isProviderSide` (`_utils/Utils.java:72`) — devuelve true si el user tiene PROVIDER o PROVIDER_OPERATOR.
- `Utils.isTouryaBackoffice` — devuelve true si el user tiene ADMIN o BACKOFFICE_OPERATION.

## Nota histórica

Este es el 4to bug del día en el mismo método `getProviderReservations`:
1. TC-005 Prueba 1 — providerprice sin multiplicar por pax en grupo (fix mig 079).
2. TC-005 Prueba 3 (frontend) — PR front #74 mapea BACKOFFICE→ADMIN.
3. TC-005 Prueba 3 (backend, este PR) — orden if/else del rol dual.
4. Bonus: `sp_get_provider_reservations` en general — la lógica del rol dual es un patrón que puede aparecer en otros métodos. Auditar candidatos queda como tarea futura.