### PR TITLE
feat(admin): CRUD backend BACKOFFICE_OPERATION users (FE-15d)

### DIFF
--- a/src/main/java/com/tourya/api/controller/BackofficeUserController.java
+++ b/src/main/java/com/tourya/api/controller/BackofficeUserController.java
@@ -1,0 +1,90 @@
+package com.tourya.api.controller;
+
+import com.tourya.api.models.request.CreateBackofficeUserRequest;
+import com.tourya.api.models.request.ResetBackofficeUserPasswordRequest;
+import com.tourya.api.models.request.UpdateBackofficeUserRequest;
+import com.tourya.api.models.responses.BackofficeUserResponse;
+import com.tourya.api.services.BackofficeUserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * FE-15d: gestión de usuarios con rol {@code BACKOFFICE_OPERATION}. Solo ADMIN.
+ */
+@RestController
+@RequestMapping("admin/backoffice-users")
+@RequiredArgsConstructor
+@Tag(name = "Backoffice Users")
+public class BackofficeUserController {
+
+    private final BackofficeUserService backofficeUserService;
+
+    @GetMapping
+    @Operation(summary = "Listar usuarios BACKOFFICE_OPERATION")
+    public ResponseEntity<List<BackofficeUserResponse>> list(Authentication connectedUser) {
+        return ResponseEntity.ok(backofficeUserService.list(connectedUser));
+    }
+
+    @PostMapping
+    @Operation(summary = "Crear usuario BACKOFFICE_OPERATION",
+            description = "El ADMIN define una contraseña temporal. El usuario debe cambiarla en el primer login.")
+    public ResponseEntity<BackofficeUserResponse> create(
+            @Valid @RequestBody CreateBackofficeUserRequest request,
+            Authentication connectedUser) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(backofficeUserService.create(request, connectedUser));
+    }
+
+    @PutMapping("/{userId}")
+    @Operation(summary = "Actualizar datos personales del usuario BACKOFFICE_OPERATION")
+    public ResponseEntity<BackofficeUserResponse> update(
+            @PathVariable Integer userId,
+            @Valid @RequestBody UpdateBackofficeUserRequest request,
+            Authentication connectedUser) {
+        return ResponseEntity.ok(backofficeUserService.update(userId, request, connectedUser));
+    }
+
+    @PutMapping("/{userId}/reset-password")
+    @Operation(summary = "Resetear contraseña temporal del usuario BACKOFFICE_OPERATION")
+    public ResponseEntity<Map<String, String>> resetPassword(
+            @PathVariable Integer userId,
+            @Valid @RequestBody ResetBackofficeUserPasswordRequest request,
+            Authentication connectedUser) {
+        backofficeUserService.resetTemporaryPassword(userId, request, connectedUser);
+        return ResponseEntity.ok(Map.of("message", "Temporary password updated"));
+    }
+
+    @DeleteMapping("/{userId}")
+    @Operation(summary = "Deshabilitar usuario BACKOFFICE_OPERATION (no lo elimina, lo desactiva)")
+    public ResponseEntity<Map<String, String>> disable(
+            @PathVariable Integer userId,
+            Authentication connectedUser) {
+        backofficeUserService.toggleEnabled(userId, false, connectedUser);
+        return ResponseEntity.ok(Map.of("message", "User disabled"));
+    }
+
+    @PutMapping("/{userId}/enable")
+    @Operation(summary = "Reactivar usuario BACKOFFICE_OPERATION")
+    public ResponseEntity<Map<String, String>> enable(
+            @PathVariable Integer userId,
+            Authentication connectedUser) {
+        backofficeUserService.toggleEnabled(userId, true, connectedUser);
+        return ResponseEntity.ok(Map.of("message", "User enabled"));
+    }
+}

--- a/src/main/java/com/tourya/api/models/request/CreateBackofficeUserRequest.java
+++ b/src/main/java/com/tourya/api/models/request/CreateBackofficeUserRequest.java
@@ -1,0 +1,33 @@
+package com.tourya.api.models.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * FE-15d: request para crear un usuario con rol {@code BACKOFFICE_OPERATION}.
+ * Solo lo puede llamar un usuario ADMIN. El usuario creado debe cambiar la
+ * contraseña temporal en el primer acceso ({@code mustChangePassword = true}).
+ */
+@Data
+public class CreateBackofficeUserRequest {
+
+    @NotBlank
+    private String firstname;
+
+    private String lastname;
+
+    @NotBlank
+    @Email
+    private String email;
+
+    /** Opcional. Sirve para contacto interno. */
+    @Size(max = 20)
+    private String phone;
+
+    /** Contraseña temporal que el ADMIN comunica al operador; debe cambiarla en el primer acceso. */
+    @NotBlank
+    @Size(min = 8, message = "temporaryPassword should be 8 characters long minimum")
+    private String temporaryPassword;
+}

--- a/src/main/java/com/tourya/api/models/request/ResetBackofficeUserPasswordRequest.java
+++ b/src/main/java/com/tourya/api/models/request/ResetBackofficeUserPasswordRequest.java
@@ -1,0 +1,17 @@
+package com.tourya.api.models.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * FE-15d: request para resetear la contraseña de un usuario
+ * {@code BACKOFFICE_OPERATION}. El usuario deberá cambiarla en el próximo login.
+ */
+@Data
+public class ResetBackofficeUserPasswordRequest {
+
+    @NotBlank
+    @Size(min = 8, message = "temporaryPassword should be 8 characters long minimum")
+    private String temporaryPassword;
+}

--- a/src/main/java/com/tourya/api/models/request/UpdateBackofficeUserRequest.java
+++ b/src/main/java/com/tourya/api/models/request/UpdateBackofficeUserRequest.java
@@ -1,0 +1,19 @@
+package com.tourya.api.models.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * FE-15d: request para actualizar datos personales de un usuario
+ * {@code BACKOFFICE_OPERATION}. El cambio de contraseña va por endpoint aparte.
+ */
+@Data
+public class UpdateBackofficeUserRequest {
+
+    private String firstname;
+
+    private String lastname;
+
+    @Size(max = 20)
+    private String phone;
+}

--- a/src/main/java/com/tourya/api/models/responses/BackofficeUserResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/BackofficeUserResponse.java
@@ -1,0 +1,20 @@
+package com.tourya.api.models.responses;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * FE-15d: DTO de respuesta para usuarios con rol {@code BACKOFFICE_OPERATION}.
+ */
+@Data
+@Builder
+public class BackofficeUserResponse {
+    private Integer userId;
+    private String email;
+    private String fullName;
+    private String phone;
+    private Boolean accountEnabled;
+    @Schema(description = "true hasta que el operador cambie la contraseña temporal")
+    private Boolean mustChangePassword;
+}

--- a/src/main/java/com/tourya/api/repository/UserRepository.java
+++ b/src/main/java/com/tourya/api/repository/UserRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Integer> {
@@ -17,7 +18,19 @@ public interface UserRepository extends JpaRepository<User, Integer> {
     @Query("""
             SELECT user
             FROM User user
-            Where ( (:firstName IS NULL ) OR ( lower(  cast(user.firstname as string) ) like  lower(  cast(concat('%', :firstName,'%') as string)  )  )) 
+            Where ( (:firstName IS NULL ) OR ( lower(  cast(user.firstname as string) ) like  lower(  cast(concat('%', :firstName,'%') as string)  )  ))
             """)
     Page<User> findAllUser(@Param("firstName") String firstName, Pageable pageable);
+
+    /**
+     * FE-15d: usuarios que tienen asignado un rol especifico. Se usa para listar
+     * BACKOFFICE_OPERATION en el panel admin. Ordena por id ASC.
+     */
+    @Query("""
+            SELECT DISTINCT u FROM User u
+            JOIN u.roles r
+            WHERE r.name = :roleName
+            ORDER BY u.id ASC
+            """)
+    List<User> findByRoleName(@Param("roleName") String roleName);
 }

--- a/src/main/java/com/tourya/api/services/BackofficeUserService.java
+++ b/src/main/java/com/tourya/api/services/BackofficeUserService.java
@@ -1,0 +1,151 @@
+package com.tourya.api.services;
+
+import com.tourya.api._utils.Utils;
+import com.tourya.api.exceptions.InsufficientPrivilegesException;
+import com.tourya.api.exceptions.OperationNotPermittedException;
+import com.tourya.api.exceptions.ResourceNotFoundException;
+import com.tourya.api.models.Role;
+import com.tourya.api.models.User;
+import com.tourya.api.models.request.CreateBackofficeUserRequest;
+import com.tourya.api.models.request.ResetBackofficeUserPasswordRequest;
+import com.tourya.api.models.request.UpdateBackofficeUserRequest;
+import com.tourya.api.models.responses.BackofficeUserResponse;
+import com.tourya.api.repository.RoleRepository;
+import com.tourya.api.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * FE-15d: CRUD de usuarios con rol {@code BACKOFFICE_OPERATION}. Solo ADMIN puede
+ * gestionarlos. Reusa el patron de {@link ProviderUserService#createOperator} pero
+ * sin la relacion provider/tour (los BACKOFFICE_OPERATION son staff Tourya).
+ */
+@Service
+@RequiredArgsConstructor
+public class BackofficeUserService {
+
+    private static final String ROLE_NAME = "BACKOFFICE_OPERATION";
+    private static final String NOT_PRIVILEGES =
+            "You have no privileges to perform this action.";
+
+    private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional(readOnly = true)
+    public List<BackofficeUserResponse> list(Authentication connectedUser) {
+        requireAdmin(connectedUser);
+        return userRepository.findByRoleName(ROLE_NAME).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional
+    public BackofficeUserResponse create(CreateBackofficeUserRequest request,
+                                         Authentication connectedUser) {
+        requireAdmin(connectedUser);
+
+        String email = request.getEmail().trim().toLowerCase();
+        if (!Utils.isValidEmail(email)) {
+            throw new OperationNotPermittedException("Invalid email format.");
+        }
+        if (userRepository.existsByEmail(email)) {
+            throw new OperationNotPermittedException("Email already registered.");
+        }
+
+        Role backofficeRole = roleRepository.findByName(ROLE_NAME)
+                .orElseThrow(() -> new IllegalStateException(
+                        "ROLE " + ROLE_NAME + " was not initiated"));
+
+        User user = User.builder()
+                .firstname(request.getFirstname())
+                .lastname(request.getLastname())
+                .email(email)
+                .phone(request.getPhone() != null ? request.getPhone().trim() : null)
+                .password(passwordEncoder.encode(request.getTemporaryPassword()))
+                .enabled(true)
+                .mustChangePassword(true)
+                .accountLocked(false)
+                .roles(new ArrayList<>(List.of(backofficeRole)))
+                .build();
+        user = userRepository.save(user);
+        return toResponse(user);
+    }
+
+    @Transactional
+    public BackofficeUserResponse update(Integer userId,
+                                         UpdateBackofficeUserRequest request,
+                                         Authentication connectedUser) {
+        requireAdmin(connectedUser);
+        User user = requireBackofficeUser(userId);
+
+        if (request.getFirstname() != null) {
+            user.setFirstname(request.getFirstname());
+        }
+        if (request.getLastname() != null) {
+            user.setLastname(request.getLastname());
+        }
+        if (request.getPhone() != null) {
+            user.setPhone(request.getPhone().trim());
+        }
+        user = userRepository.save(user);
+        return toResponse(user);
+    }
+
+    @Transactional
+    public void resetTemporaryPassword(Integer userId,
+                                       ResetBackofficeUserPasswordRequest request,
+                                       Authentication connectedUser) {
+        requireAdmin(connectedUser);
+        User user = requireBackofficeUser(userId);
+        user.setPassword(passwordEncoder.encode(request.getTemporaryPassword()));
+        user.setMustChangePassword(true);
+        userRepository.save(user);
+    }
+
+    @Transactional
+    public void toggleEnabled(Integer userId, boolean enabled,
+                              Authentication connectedUser) {
+        requireAdmin(connectedUser);
+        User user = requireBackofficeUser(userId);
+        user.setEnabled(enabled);
+        userRepository.save(user);
+    }
+
+    private User requireBackofficeUser(Integer userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "User not found with id: " + userId));
+        boolean isBackoffice = user.getRoles() != null && user.getRoles().stream()
+                .anyMatch(r -> ROLE_NAME.equalsIgnoreCase(r.getName()));
+        if (!isBackoffice) {
+            throw new OperationNotPermittedException(
+                    "User with id " + userId + " is not a BACKOFFICE_OPERATION.");
+        }
+        return user;
+    }
+
+    private void requireAdmin(Authentication connectedUser) {
+        User user = (User) connectedUser.getPrincipal();
+        if (!Utils.isAdmin(user.getRoles())) {
+            throw new InsufficientPrivilegesException(NOT_PRIVILEGES);
+        }
+    }
+
+    private BackofficeUserResponse toResponse(User user) {
+        return BackofficeUserResponse.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .fullName(user.fullName())
+                .phone(user.getPhone())
+                .accountEnabled(user.isEnabled())
+                .mustChangePassword(user.isMustChangePassword())
+                .build();
+    }
+}


### PR DESCRIPTION
Backend de **FE-15d**. Desbloquea la Prueba 3 pendiente de #195 TC-008 — Luis no podía crear un usuario `BACKOFFICE_OPERATION` para validar la vista diferenciada porque no había UI ni endpoint.

## Nuevo módulo `/admin/backoffice-users` (guard ADMIN)

| Método | Path | Descripción |
|---|---|---|
| GET | `/admin/backoffice-users` | Listar todos los BACKOFFICE_OPERATION |
| POST | `/admin/backoffice-users` | Crear usuario |
| PUT | `/admin/backoffice-users/{id}` | Actualizar datos personales |
| PUT | `/admin/backoffice-users/{id}/reset-password` | Reset password temporal |
| PUT | `/admin/backoffice-users/{id}/enable` | Reactivar |
| DELETE | `/admin/backoffice-users/{id}` | Deshabilitar (soft, no borra) |

## Archivos

- `BackofficeUserController` — endpoints REST con `@Tag(""Backoffice Users"")`.
- `BackofficeUserService` — CRUD + toggleEnabled. Reusa el patrón de `ProviderUserService.createOperator` pero sin la relación provider/tour (BACKOFFICE_OPERATION es staff Tourya, no tiene provider asociado).
- `CreateBackofficeUserRequest`, `UpdateBackofficeUserRequest`, `ResetBackofficeUserPasswordRequest` — DTOs de entrada con Bean Validation.
- `BackofficeUserResponse` — DTO de salida.
- `UserRepository.findByRoleName(roleName)` — helper query nuevo con `JOIN u.roles r + DISTINCT` para evitar duplicados, ordenado por `id ASC`.

## Guards

- `requireAdmin(connectedUser)` con `Utils.isAdmin(roles)` al inicio de cada operación. Rol BACKOFFICE_OPERATION **no puede** gestionar otros BACKOFFICE_OPERATION (según matriz doc 03 — solo ADMIN gestiona users).
- `requireBackofficeUser(id)` valida que el user existe **y** tiene el rol BACKOFFICE_OPERATION antes de update/reset/toggle. Previene que el endpoint se use para modificar ADMINs u otros users por accidente.

## Contract del usuario creado

- `enabled = true`, `mustChangePassword = true`, `accountLocked = false`.
- Password bcrypt encoded desde `passwordEncoder`.
- Rol asignado desde `roleRepository.findByName(""BACKOFFICE_OPERATION"")` (id 35 en dev según memoria del proyecto).

## Verificación

- [x] `./mvnw compile` → BUILD SUCCESS.
- [x] `SecurityConfig` no requiere cambios — `/admin/**` cae en la política default (JWT required + rol validado en el service).

## Frontend (PR separado)

Trabajo restante en **tourya-front**:
- Nuevo componente `admin/backoffice-users` basado en el patrón `provider-users` (list + create modal + edit modal + reset password + toggle enabled).
- Nuevo `backoffice-user.service.ts` que consume estos 6 endpoints.
- Registrar ruta `/admin/backoffice-users` en `admin-routing.module.ts` con `AdminGuard`.
- Enlace desde el dashboard admin.
- i18n es/en/pt.

## Test plan post-merge

- [ ] Login como ADMIN → llamar `POST /admin/backoffice-users` con body válido → **201** y user creado con rol BACKOFFICE_OPERATION.
- [ ] Verificar en DB: `_user.enabled = true`, `_user.must_change_password = true`, password hasheado.
- [ ] Con el usuario creado, hacer login → debe forzar cambio de password.
- [ ] Después del cambio, verificar que puede acceder a `/admin/bookings-management` (subset FE-15b).
- [ ] Guards: login como PROVIDER intentar `POST /admin/backoffice-users` → **403 InsufficientPrivileges**.
- [ ] Guards: `PUT /admin/backoffice-users/{id}` con `id` de un ADMIN → **400 not a BACKOFFICE_OPERATION**.

## Referencias

- Issue [#195 TC-008](https://github.com/Touryapp/tourya-api/issues/195) — Prueba 3 pendiente.
- Comentario Luis 24-jul en #188 confirmando OK al scope de FE-15d.
- Patrón fuente: `ProviderUserService.createOperator` (líneas 117-195).