### PR TITLE
fix(reservation): status guard + 500->400 en consumeReservation (#194)

### DIFF
--- a/src/main/java/com/tourya/api/services/ReservationService.java
+++ b/src/main/java/com/tourya/api/services/ReservationService.java
@@ -857,32 +857,28 @@ public class ReservationService {
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Reservation not found with id: " + reservationId));
 
-        // Validar que la reserva esté en un estado válido para consumir
+        // TC-007 fix (#194): usar OperationNotPermittedException (mapeada a 400) en vez de
+        // IllegalStateException (que cae en el fallback 500 del GlobalExceptionHandler).
+        // Mensajes en español para exposicion directa al cliente.
         if (reservation.getDeliveryStatus() == DeliveryStatusEnum.DELIVERED) {
-            throw new IllegalStateException("Reservation is already consumed (DELIVERED)");
+            throw new OperationNotPermittedException("Esta reserva ya fue consumida.");
         }
-        
-        // Validar que la reserva no esté cancelada
         if (reservation.getDeliveryStatus() == DeliveryStatusEnum.CANCELED) {
-            throw new IllegalStateException("Cannot consume a canceled reservation");
+            throw new OperationNotPermittedException("No es posible confirmar una reserva cancelada.");
         }
-        
         if (reservation.getDeliveryStatus() == DeliveryStatusEnum.NO_SHOW) {
-            throw new IllegalStateException("Cannot consume a no-show reservation");
+            throw new OperationNotPermittedException("No es posible confirmar una reserva marcada como No Show.");
         }
 
         // TC-007 (RN-056): solo se puede confirmar el mismo día del tour, en zona Colombia.
-        // Antes de este guard el PROVIDER podía adelantar la confirmación cualquier día que
-        // la reserva estuviera en PENDING, lo que hacía inconsistente el ciclo NO_SHOW.
         if (reservation.getReservationDate() == null) {
-            throw new IllegalStateException("Reservation does not have a reservationDate");
+            throw new OperationNotPermittedException("La reserva no tiene fecha asignada.");
         }
         LocalDate tourDate = reservation.getReservationDate().toLocalDate();
         LocalDate todayInBogota = LocalDate.now(BOGOTA);
         if (!tourDate.isEqual(todayInBogota)) {
-            throw new IllegalStateException(
-                    "Only can confirm reservation on the tour day (tourDate=" + tourDate
-                            + ", today=" + todayInBogota + ")");
+            throw new OperationNotPermittedException(
+                    "La reserva solo puede confirmarse el día del tour (" + tourDate + ").");
         }
 
         // 2. Obtener el shopping cart item relacionado
@@ -1041,7 +1037,8 @@ public class ReservationService {
                 reservation.setCanRainCancel(false);
             }
 
-            reservation.setCanConfirmReservation(computeCanConfirmReservation(reservation.getScheduleDate()));
+            reservation.setCanConfirmReservation(computeCanConfirmReservation(
+                    reservation.getScheduleDate(), reservation.getReservationDeliveryStatus()));
             reservation.setTourOperator(tourPrincipalOperatorService.resolveForTourId(reservation.getTourId()));
         }
 
@@ -1385,7 +1382,16 @@ public class ReservationService {
      * en zona Colombia. Antes usaba {@code LocalDate.now()} sin zona — bug latente
      * en el borde del día cuando el server está en UTC.
      */
-    private boolean computeCanConfirmReservation(String scheduleDate) {
+    /**
+     * TC-007 fix (#194): el requerimiento original de Luis es "solo si status=PENDING Y
+     * today=reservationDate". Antes solo validabamos la fecha, por eso el flag salia true
+     * para reservas CANCELED del dia y el frontend pintaba el boton "Confirmar" (bug
+     * reportado por Luis 2026-07-25 con RES-316 declined).
+     */
+    private boolean computeCanConfirmReservation(String scheduleDate, String reservationDeliveryStatus) {
+        if (!"PENDING".equalsIgnoreCase(reservationDeliveryStatus)) {
+            return false;
+        }
         if (scheduleDate == null || scheduleDate.isBlank()) {
             return false;
         }


### PR DESCRIPTION
Cierra la re-apertura de **#194** por Luis (25-jul 01:51 UTC).

## 2 bugs reportados

**Bug 1 — botón Confirmar visible en RES-316 CANCELED**
Requerimiento original del body: "solo si estado='Pendiente' AND today==reservationDate". Yo solo implementé la parte de today en PR #200 — falto validar status.

**Bug 2 — 500 en vez de 400 al llamar consume con fecha distinta**
`IllegalStateException` no tiene handler en `GlobalExceptionHandler` → fallback genérico 500 con mensaje "Internal error, please contact the admin".

## Fix (1 archivo)

**`ReservationService.java`**:

1. **`computeCanConfirmReservation`** — extendido con `reservationDeliveryStatus`. Retorna `false` si no es `PENDING` (case insensitive).
2. **Caller (línea 1040)** — pasa `reservation.getReservationDeliveryStatus()`.
3. **`consumeReservation`** — 5 `throw IllegalStateException` → `OperationNotPermittedException` (mapeada a 400) con mensajes amigables en español:
   - "Esta reserva ya fue consumida." (DELIVERED)
   - "No es posible confirmar una reserva cancelada." (CANCELED)
   - "No es posible confirmar una reserva marcada como No Show."
   - "La reserva no tiene fecha asignada."
   - "La reserva solo puede confirmarse el día del tour (X)."

## Verificación

- `./mvnw compile` BUILD SUCCESS.
- Frontend sin cambios: los 3 mappers ya propagaban `canConfirmReservation` desde PR #76.

## Referencias

- Issue [#194](https://github.com/Touryapp/tourya-api/issues/194) reabierto por Luis.
- PR previo [#200](https://github.com/Touryapp/tourya-api/pull/200) — cubrió solo today, no status.