### PR TITLE
fix(reservation): comparar scheduleDate del cartItem, no reservationDate (#194)

### DIFF
--- a/src/main/java/com/tourya/api/services/ReservationService.java
+++ b/src/main/java/com/tourya/api/services/ReservationService.java
@@ -870,22 +870,24 @@ public class ReservationService {
             throw new OperationNotPermittedException("No es posible confirmar una reserva marcada como No Show.");
         }
 
-        // TC-007 (RN-056): solo se puede confirmar el mismo día del tour, en zona Colombia.
-        if (reservation.getReservationDate() == null) {
-            throw new OperationNotPermittedException("La reserva no tiene fecha asignada.");
-        }
-        LocalDate tourDate = reservation.getReservationDate().toLocalDate();
-        LocalDate todayInBogota = LocalDate.now(BOGOTA);
-        if (!tourDate.isEqual(todayInBogota)) {
-            throw new OperationNotPermittedException(
-                    "La reserva solo puede confirmarse el día del tour (" + tourDate + ").");
-        }
-
-        // 2. Obtener el shopping cart item relacionado
+        // 2. Obtener el shopping cart item relacionado (movido arriba para validar scheduleDate)
         final Long itemId = reservation.getItemId();
         ShoppingCartItem cartItem = shoppingCartItemRepository.findById(itemId)
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Shopping cart item not found with id: " + itemId));
+
+        // TC-007 (RN-056) — corregido 2026-07-25 por Luis: comparar contra scheduleDate del
+        // ShoppingCartItem (fecha del tour_schedule), NO reservationDate. Antes usaba
+        // reservation.getReservationDate() por error de comunicacion inicial.
+        LocalDate scheduleDate = cartItem.getScheduleDate();
+        if (scheduleDate == null) {
+            throw new OperationNotPermittedException("La reserva no tiene fecha de agenda.");
+        }
+        LocalDate todayInBogota = LocalDate.now(BOGOTA);
+        if (!scheduleDate.isEqual(todayInBogota)) {
+            throw new OperationNotPermittedException(
+                    "La reserva solo puede confirmarse el día del tour (" + scheduleDate + ").");
+        }
 
         // 3. Obtener el tour schedule
         TourSchedule tourSchedule = cartItem.getTourSchedule();


### PR DESCRIPTION
Cierra la corrección de especificación de Luis en **#194** (25-jul 20:40 UTC):
> "revise las indicaciones que te venia dando y hay un error de mi parte. te había dado la indicación de comparar con el **reservationDate** y es con **scheduleDate**".

## Root cause de mi implementación previa

PR #205 usaba `reservation.getReservationDate().toLocalDate()`. Cuando Luis definió el requisito original, la especificación decía "reservationDate" — pero Luis se refería semánticamente al scheduleDate del tour. Ahora lo corrigió.

- `reservationDate`: fecha de creación/pago de la reserva.
- `scheduleDate`: fecha real del tour agendado. Vive en `ShoppingCartItem.schedule_date`.

## Fix (1 archivo, 1 método)

**`ReservationService.consumeReservation`**:

1. Reordenar: cargar `cartItem` **primero** (ya se cargaba después en línea 886, ahora al inicio del guard temporal — evita doble query).
2. Usar `cartItem.getScheduleDate()` en lugar de `reservation.getReservationDate().toLocalDate()`.

**Helper `computeCanConfirmReservation` NO requiere cambios**: ya recibe `scheduleDate` como String desde el SP `sp_get_provider_reservations` (columna `scheduledate` que ya viene de la tabla correcta desde el mapper).

## Verificación

- `./mvnw compile` BUILD SUCCESS.
- Cero cambio en frontend: los 3 mappers propagan `canConfirmReservation` correctamente (PR #76).

## Test plan post-merge

- [ ] Login como PROVIDER con reserva PENDING cuyo tour es hoy → botón visible → click → **200 OK**.
- [ ] Login como PROVIDER con reserva PENDING cuyo tour es distinto a hoy → botón oculto.
- [ ] Si por curl/Postman se llama en día distinto → **400** con "La reserva solo puede confirmarse el día del tour ($scheduleDate)".

## Referencias

- Issue [#194](https://github.com/Touryapp/tourya-api/issues/194) — corrección de Luis.
- PR previo [#205](https://github.com/Touryapp/tourya-api/pull/205) — usaba reservationDate por error.