### PR TITLE
feat(admin-bookings): expone providerName y tourImageUrl en SP (#188)

### DIFF
--- a/database/migrations/082_issue188_admin_bookings_provider_and_image.sql
+++ b/database/migrations/082_issue188_admin_bookings_provider_and_image.sql
@@ -1,0 +1,150 @@
+-- Migration 082: TC-005 refinamientos (#188) — expone providername y tourimageurl en sp_get_provider_reservations
+-- Date: 2026-07-26
+-- Description:
+--   Luis pidio en #188 mostrar en la tabla /admin/bookings-management:
+--     - Imagen del tour (columna nueva).
+--     - Nombre del proveedor (columna nueva).
+--
+--   Auditoria revelo que la tabla `provider` NO tiene columnas `legal_name` ni `trade_name` —
+--   solo tiene `name` (varchar 100). Y `tour_gallery` NO tiene columna `main` — solo `order_index`.
+--   Por tanto se usa `p.name` como nombre del proveedor y la primera imagen ordenada por
+--   `order_index ASC NULLS LAST, id ASC` como imagen principal (fallback natural).
+--
+--   Cambio aditivo — no rompe otros callers: cualquier ResultSet mapper que no lea las 2
+--   nuevas columnas simplemente las ignora. En consumers PROVIDER y CLIENT la columna
+--   nueva aparece pero el frontend ADMIN es el unico que la muestra por config.
+
+DROP FUNCTION IF EXISTS public.sp_get_provider_reservations(int4, int4, int8, varchar, varchar);
+
+CREATE OR REPLACE FUNCTION public.sp_get_provider_reservations(
+    p_provider_id integer DEFAULT NULL,
+    p_customer_user_id integer DEFAULT NULL,
+    p_reservation_id bigint DEFAULT NULL,
+    p_delivery_status character varying DEFAULT NULL,
+    p_sub_category character varying DEFAULT NULL
+)
+RETURNS TABLE(
+    reservationid bigint,
+    reservationdate timestamp without time zone,
+    reservationdeliverystatus character varying,
+    reservationcreateddate timestamp without time zone,
+    paymentid bigint,
+    paymenttransactionid character varying,
+    payername character varying,
+    payeremail character varying,
+    payerphone character varying,
+    payerdocumenttype character varying,
+    payerdocumentnumber character varying,
+    shoppingitemid integer,
+    shoppingtotalprice numeric,
+    shoppingunitprice numeric,
+    providerprice numeric,
+    shoppingquantity integer,
+    producttype character varying,
+    productid integer,
+    totaltourists bigint,
+    tourid integer,
+    tourname jsonb,
+    tourcategoryid integer,
+    tourproviderid integer,
+    toursubcategory character varying,
+    tourscheduleid integer,
+    scheduledate date,
+    slotid integer,
+    slottime_start time without time zone,
+    slottime_end time without time zone,
+    service_responsible_name character varying,
+    service_responsible_email character varying,
+    service_responsible_phone character varying,
+    max_cancellation_date date,
+    max_rescheduling_date date,
+    cancellation_reason character varying,
+    cancellation_date timestamp without time zone,
+    -- TC-005 refinamientos (#188): nuevas columnas para la tabla /admin/bookings-management.
+    providername character varying,
+    tourimageurl text
+)
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+    RETURN QUERY
+    SELECT
+        r.reservation_id,
+        r.reservation_date,
+        r.delivery_status,
+        r.created_date,
+        p.payment_id,
+        p.transaction_id,
+        p.payer_name,
+        p.payer_email,
+        p.payer_phone,
+        p.payer_document_type,
+        p.payer_document_number,
+        sci.id AS shoppingItemId,
+        sci.total_price,
+        sci.unit_price,
+        COALESCE((
+            SELECT SUM(
+                COALESCE(scid.provider_unit_price, 0) *
+                CASE WHEN t.price_type = 'grupo' THEN 1 ELSE COALESCE(scid.quantity, 0) END
+            )
+            FROM shopping_cart_item_detail scid
+            WHERE scid.shopping_cart_item_id = sci.id
+        ), 0)::numeric AS providerPrice,
+        sci.quantity,
+        sci.product_type,
+        sci.product_id,
+        COALESCE((
+            SELECT SUM(scid.quantity)
+            FROM shopping_cart_item_detail scid
+            WHERE scid.shopping_cart_item_id = sci.id
+        ), 0) AS totalTourists,
+        t.id AS tourId,
+        t.name AS tourName,
+        t.category_id,
+        t.provider_id,
+        t.sub_category::character varying AS tourSubcategory,
+        ts.id AS tourScheduleId,
+        sci.schedule_date,
+        tscs.id AS slotId,
+        tscs.start_time,
+        tscs.end_time,
+        r.service_responsible_name,
+        r.service_responsible_email,
+        r.service_responsible_phone,
+        r.max_cancellation_date,
+        r.max_rescheduling_date,
+        r.cancellation_reason,
+        r.cancellation_date,
+        -- TC-005 refinamientos (#188): nombre del proveedor + imagen principal del tour.
+        pr.name AS providername,
+        (SELECT tg.image_url
+           FROM tour_gallery tg
+          WHERE tg.tour_id = t.id
+          ORDER BY tg.order_index ASC NULLS LAST, tg.id ASC
+          LIMIT 1) AS tourimageurl
+    FROM reservation r
+    JOIN shopping_cart_item sci ON sci.id = r.item_id
+    JOIN shopping_cart sc ON sc.id = sci.shopping_cart_id
+    LEFT JOIN payment p ON p.payment_id = r.payment_id
+    LEFT JOIN tour_schedule ts ON ts.id = sci.tour_schedule_id
+    LEFT JOIN tour_schedule_config_slot tscs ON tscs.id = sci.slot_id
+    LEFT JOIN tour t ON t.id = sci.product_id
+    LEFT JOIN provider pr ON pr.id = t.provider_id
+    WHERE
+        (p_provider_id IS NULL OR t.provider_id = p_provider_id)
+        AND (p_customer_user_id IS NULL OR sc.user_id = p_customer_user_id)
+        AND (p_reservation_id IS NULL OR r.reservation_id = p_reservation_id)
+        AND (p_delivery_status IS NULL OR r.delivery_status = p_delivery_status)
+        AND (p_sub_category IS NULL OR t.sub_category::text = p_sub_category)
+    GROUP BY
+        r.reservation_id,
+        p.payment_id,
+        sci.id,
+        sc.id,
+        t.id,
+        ts.id,
+        tscs.id,
+        pr.name;
+END;
+$function$;

--- a/src/main/java/com/tourya/api/models/mapper/ReservationDetailsMapper.java
+++ b/src/main/java/com/tourya/api/models/mapper/ReservationDetailsMapper.java
@@ -78,6 +78,10 @@ public class ReservationDetailsMapper {
                 .tourCategoryId(rs.getInt("tourcategoryid"))
                 .tourSubCategory(readOptionalString(rs, "toursubcategory"))
                 .tourProviderId(rs.getInt("tourproviderid"))
+                // TC-005 refinamientos (#188): nombre y foto principal del tour. readOptional*
+                // porque migraciones anteriores del SP no tenian estas columnas.
+                .providerName(readOptionalString(rs, "providername"))
+                .tourImageUrl(readOptionalString(rs, "tourimageurl"))
 
                 .tourScheduleId(rs.getInt("tourscheduleid"))
                 .scheduleDate(rs.getString("scheduledate"))

--- a/src/main/java/com/tourya/api/models/responses/ReservationDetailsResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/ReservationDetailsResponse.java
@@ -46,6 +46,10 @@ public class ReservationDetailsResponse {
     private Integer tourCategoryId;
     private String tourSubCategory;
     private Integer tourProviderId;
+    /** TC-005 refinamientos (#188): nombre del proveedor (provider.name). Solo se usa por ADMIN. */
+    private String providerName;
+    /** TC-005 refinamientos (#188): imagen principal del tour desde tour_gallery (primera por order_index). */
+    private String tourImageUrl;
 
     // --- Schedule ---
     private Integer tourScheduleId;


### PR DESCRIPTION
Backend de los refinamientos del **#188 TC-005** — Luis pidió mostrar en la tabla `/admin/bookings-management`:
- Imagen del tour (columna nueva).
- Nombre del proveedor (columna nueva).

## Descubrimientos de la auditoría

1. La tabla `provider` **NO tiene** columnas `legal_name` ni `trade_name`. Solo tiene `name` (varchar 100 NULL). Uso `p.name`.
2. `tour_gallery` **NO tiene** columna `main`. Solo `order_index`. Uso `ORDER BY order_index ASC NULLS LAST, id ASC LIMIT 1` como "imagen principal" (fallback natural).

Estos 2 detalles ajustan la especificación original de Luis ("legal_name" y "main=true") a lo que existe en el schema. Si Luis quiere otro campo o quiere agregar columnas, iteramos.

## Cambios

**Migración 082** — recrea `sp_get_provider_reservations` agregando:
- `providername` (varchar) vía `LEFT JOIN provider pr ON pr.id = t.provider_id` con `pr.name`.
- `tourimageurl` (text) vía subquery correlacionada al `tour_gallery`.

Cambio aditivo — no rompe otros callers (mapper con `readOptionalString` ignora columnas ausentes).

**ReservationDetailsResponse.java** — 2 nuevos campos opcionales: `providerName`, `tourImageUrl`.

**ReservationDetailsMapper.java** — 2 setters con `readOptionalString()` que maneja null y ausencia de columna.

## Verificación

- `./mvnw compile` BUILD SUCCESS.
- Backend con código desplegado + migración sin aplicar tampoco rompe (`readOptionalString` retorna null y el frontend usa fallback `'tours-21.jpg'`).

## Post-merge

- **Aplicar migración 082** a Cloud SQL dev. Voy a ejecutarlo por comando gcloud tras merge.

## Frontend (PR separado)

Trabajo restante en **tourya-front**:
- 2 mappers (`mapProviderReservationToBooking` línea 600, `mapClientReservationToBooking` línea 654) — leer `providerName` y `tourImageUrl`.
- `admin/bookings-management` config service — eliminar columna "Fecha de Reserva" actual, renombrar "Check-in" → "Fecha de reserva", agregar columnas de proveedor y imagen, dual badge en columna precios (Cliente + Provider).
- Quitar botones Confirmar / Aprobar / Eliminar de la tabla ADMIN.
- Quitar todos los botones de acción del modal para ADMIN (dejar solo "Cerrar").
- i18n es/en/pt.

## Referencias

- Issue [#188](https://github.com/Touryapp/tourya-api/issues/188).
- Migración previa 079 (TC-005 grupo).