### PR TITLE
ci(deploy-dev): --min-instances=1 para que @Scheduled jobs corran (#206)

### DIFF
--- a/.github/workflows/gcp_deploy_develop.yml
+++ b/.github/workflows/gcp_deploy_develop.yml
@@ -50,7 +50,13 @@ jobs:
             --port=${{ env.PORT }}
             --service-account=tourya-dev-cloud-run@tourya-project-dev.iam.gserviceaccount.com
             --vpc-connector=tourya-dev-vpc-connector
-            --min-instances=0
+            # INF-05 quick fix (#206): min-instances=1 preserva 1 instancia viva para que
+            # los @Scheduled jobs (PendingReservationNoShowJob, TemporalReservationExpiryJob,
+            # TourReminder24hJob, CreditExpirationJob, ProviderPayoutOrderJob, etc.) disparen.
+            # Cloud Run scale-to-zero mata @Scheduled porque no hay instancia corriendo cuando
+            # llega la hora del cron. Costo ~$5-10/mes en dev. Para prod: migrar a Cloud
+            # Scheduler externo con controllers internos (roadmap INF-06).
+            --min-instances=1
             --max-instances=2
             --memory=1Gi
             --cpu=1


### PR DESCRIPTION
Hotfix persistente del **#206**.

## Bug encadenado

Ayer (26-jul) apliqué `min-instances=1` con `gcloud` manual como quick fix. **Cada deploy posterior (PR #207, #208) reseteó a 0** porque el workflow `gcp_deploy_develop.yml` tenía `--min-instances=0` hardcoded (línea 53).

Resultado: Cloud Run vuelve a escalar a 0 tras cada deploy → `@Scheduled` jobs no disparan. Es la razón por la que Luis reportó hoy que el job NO_SHOW sigue sin ejecutar.

## Fix

Cambiar la flag en el workflow: `--min-instances=0` → `--min-instances=1`.

## Impacto (todos los `@Scheduled` del proyecto ahora disparan de manera consistente)

- `PendingReservationNoShowJob` (7am Bogotá)
- `TemporalReservationExpiryJob` (cada 60s)
- `TourReminder24hJob` (8am Bogotá)
- `CreditExpirationJob` (5am Bogotá)
- `ProviderPayoutOrderJob` (Lun/Jue 7am Bogotá)
- `ReservationCancellationFlagsJob` (5am Bogotá)

## Costo y roadmap

- Dev: ~$5-10/mes.
- **Roadmap INF-06 (prod)**: migrar a Cloud Scheduler externo con controllers internos y OIDC. Ese es el fix definitivo para no pagar min-instances=1 en prod.

## Verificación

- [x] `min-instances=1` re-aplicado manualmente a la revisión actual (`tourya-dev-api-00205-llh`) para no esperar el merge.
- [x] Este PR fija el workflow para que futuros deploys preserven la flag.