### PR TITLE
feat(TC-009 #196): persistir document_type en tourist_profile

### DIFF
--- a/database/migrations/083_tc009_add_document_type_to_tourist_profile.sql
+++ b/database/migrations/083_tc009_add_document_type_to_tourist_profile.sql
@@ -1,0 +1,13 @@
+-- TC-009 (#196): agregar document_type al tourist_profile.
+--
+-- Antes: document_type solo vivia en payment.payer_document_type, se re-preguntaba
+-- en cada compra. Ahora se persiste en el perfil para pre-llenar futuras compras.
+--
+-- Sin enum: permanece como varchar libre para compatibilidad con payment (que ya
+-- usa varchar). Valores esperados de la UI: 'CC', 'CE', 'PP', 'NIT', 'TI'.
+
+ALTER TABLE tourist_profile
+    ADD COLUMN IF NOT EXISTS document_type varchar(50) NULL;
+
+COMMENT ON COLUMN tourist_profile.document_type IS
+    'TC-009: tipo de documento del turista (CC/CE/PP/NIT/TI). Se persiste para pre-llenar checkout.';

--- a/src/main/java/com/tourya/api/models/TouristProfile.java
+++ b/src/main/java/com/tourya/api/models/TouristProfile.java
@@ -39,6 +39,9 @@ public class TouristProfile {
     @Column(name = "last_name", length = 120)
     private String lastName;
 
+    @Column(name = "document_type", length = 50)
+    private String documentType;
+
     @Column(name = "document_number", length = 64)
     private String documentNumber;
 

--- a/src/main/java/com/tourya/api/models/request/TouristProfileUpsertRequest.java
+++ b/src/main/java/com/tourya/api/models/request/TouristProfileUpsertRequest.java
@@ -13,6 +13,9 @@ public class TouristProfileUpsertRequest {
     @Schema(example = "González")
     private String lastName;
 
+    @Schema(description = "Tipo de documento de identidad (CC/CE/PP/NIT/TI)", example = "CC")
+    private String documentType;
+
     @Schema(description = "Número de documento de identidad", example = "1020304050")
     private String documentNumber;
 

--- a/src/main/java/com/tourya/api/models/responses/TouristProfileResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/TouristProfileResponse.java
@@ -10,6 +10,7 @@ public class TouristProfileResponse {
     private Integer userId;
     private String firstName;
     private String lastName;
+    private String documentType;
     private String documentNumber;
     private String phone;
     private String email;

--- a/src/main/java/com/tourya/api/services/TouristProfileService.java
+++ b/src/main/java/com/tourya/api/services/TouristProfileService.java
@@ -54,6 +54,7 @@ public class TouristProfileService {
 
         profile.setFirstName(request.getFirstName());
         profile.setLastName(request.getLastName());
+        profile.setDocumentType(request.getDocumentType());
         profile.setDocumentNumber(request.getDocumentNumber());
         profile.setPhone(request.getPhone());
         profile.setEmail(request.getEmail());
@@ -112,6 +113,7 @@ public class TouristProfileService {
                 .userId(profile.getUserId())
                 .firstName(profile.getFirstName())
                 .lastName(profile.getLastName())
+                .documentType(profile.getDocumentType())
                 .documentNumber(profile.getDocumentNumber())
                 .phone(profile.getPhone())
                 .email(profile.getEmail())


### PR DESCRIPTION
## Contexto

Luis reporto en TC-009 (#196) que el modal de completar-perfil del checkout debe pre-llenar con datos del turista, incluyendo tipo de documento. Hoy el \`document_type\` solo vivia en \`payment.payer_document_type\` y se re-preguntaba en cada compra. Ahora se persiste en el perfil para pre-llenar futuras compras (respuesta explicita de Luis 2026-07-23).

## Cambios

- **Migracion 083**: \`ALTER TABLE tourist_profile ADD COLUMN document_type varchar(50)\`. Ya aplicada manualmente a Cloud SQL dev.
- **Entity** \`TouristProfile\`: campo \`documentType\` mapeado.
- **DTOs** \`TouristProfileResponse\` + \`TouristProfileUpsertRequest\`: agregado \`documentType\`.
- **\`TouristProfileService.upsertMyProfile\`** + **\`toResponse\`**: persistir y devolver \`documentType\`.

## Notas

- Sin enum: se mantiene como \`varchar\` para simetria con \`payment.payer_document_type\`. Valores esperados de la UI: \`CC/CE/PP/NIT/TI\`.
- Prerequisito de PR frontend TC-009 (proximo, task #145).

## Test plan

- [ ] Pipeline verde.
- [ ] \`GET /api/v1/tourist/profile\` retorna \`documentType\` en el JSON (probar con Postman/curl).
- [ ] \`PUT /api/v1/tourist/profile\` acepta y persiste \`documentType\`.
- [ ] Regresion: el resto de campos siguen funcionando (firstName, lastName, phone, country, etc.).

Relacionado con #196.