### PR TITLE
fix(TC-007 #194 scope extra): guard temporal en decline BE-24

### DIFF
--- a/src/main/java/com/tourya/api/services/ReservationService.java
+++ b/src/main/java/com/tourya/api/services/ReservationService.java
@@ -2574,6 +2574,20 @@ public class ReservationService {
             throw new OperationNotPermittedException("La reserva no tiene tour asociado.");
         }
 
+        // TC-007 (#194 scope extra): no permitir declinar si la fecha del tour ya paso.
+        // Cuando scheduleDate < hoy la reserva debe transicionar a NO_SHOW via job, no
+        // via decline manual del provider (evita creditos retroactivos por reservas viejas).
+        LocalDate scheduleDate = item.getScheduleDate();
+        if (scheduleDate == null) {
+            throw new OperationNotPermittedException("La reserva no tiene fecha de agenda.");
+        }
+        LocalDate todayInBogota = LocalDate.now(BOGOTA);
+        if (scheduleDate.isBefore(todayInBogota)) {
+            throw new OperationNotPermittedException(
+                    "No se puede declinar: la fecha del tour (" + scheduleDate
+                            + ") ya paso. Debe esperar a que el job marque la reserva como NO_SHOW.");
+        }
+
         Tour tour = tourRepository.findById(item.getTourSchedule().getTourId())
                 .orElseThrow(() -> new ResourceNotFoundException("Tour not found"));
 


### PR DESCRIPTION
## Contexto

Luis pidio en TC-007 que el boton **"No puedo atender"** tenga el mismo guard temporal que **"Confirmar"** (solo activo el dia del tour). Este PR rechaza el endpoint \`POST /api/v1/reservations/{id}/provider-decline\` si el \`scheduleDate\` del item ya paso.

## Cambio

\`ReservationService.declineReservationByProvider\`: despues de cargar el \`ShoppingCartItem\`, valida que \`item.getScheduleDate() >= LocalDate.now(BOGOTA)\`. Si esta en el pasado lanza \`OperationNotPermittedException\` (mapeada a 400) con mensaje amigable.

## Racional

Cuando la fecha del tour ya paso, la reserva debe transicionar a NO_SHOW via el job \`PendingReservationNoShowJob\`, no via decline manual del provider. Sin este guard el provider podia crear creditos retroactivos por reservas que ya son NO_SHOW pero el job aun no las proceso.

## Test plan

- [ ] Pipeline verde.
- [ ] \`POST /provider-decline\` sobre reserva con \`scheduleDate = HOY\` -> 200 OK.
- [ ] \`POST /provider-decline\` sobre reserva con \`scheduleDate < HOY\` -> **400** con mensaje "No se puede declinar: la fecha del tour (X) ya paso...".
- [ ] Regresion: guards existentes (estado terminal, ya declinada, ownership) siguen funcionando.

PR frontend complementario aparte (esconde el boton en el UI para reservas viejas).

Relacionado con #194.