### PR TITLE
fix(TC-014 #215): auto-purga cart items con scheduleDate vencido en GET

### DIFF
--- a/src/main/java/com/tourya/api/services/ShoppingCartService.java
+++ b/src/main/java/com/tourya/api/services/ShoppingCartService.java
@@ -588,6 +588,25 @@ public class ShoppingCartService {
      * @param statusFilter {@code ACTIVE} para carrito del usuario; {@code null} para listado/admin con todos los ítems
      */
     private ShoppingCartResponse buildShoppingCartResponse(ShoppingCart cart, ShoppingCartStatusEnum statusFilter) {
+        // TC-014 (#215 Luis 2026-08-03): purgar items del carrito con scheduleDate
+        // anterior a hoy antes de armar la respuesta. Los marcamos como ABANDONED
+        // para que la proxima consulta ni siquiera los vea (el filter ACTIVE de
+        // abajo los descarta). Se ejecuta solo cuando se pide el carrito del
+        // usuario (ACTIVE); el listado admin (statusFilter=null) no purga.
+        if (statusFilter == ShoppingCartStatusEnum.ACTIVE) {
+            LocalDate todayInBogota = LocalDate.now(CO_ZONE);
+            cart.getItems().stream()
+                    .filter(item -> item.getStatus() == ShoppingCartStatusEnum.ACTIVE)
+                    .filter(item -> item.getScheduleDate() != null
+                            && item.getScheduleDate().isBefore(todayInBogota))
+                    .forEach(item -> {
+                        log.info("TC-014: auto-purga cart item {} (scheduleDate={} < today={}) -> ABANDONED",
+                                item.getId(), item.getScheduleDate(), todayInBogota);
+                        item.setStatus(ShoppingCartStatusEnum.ABANDONED);
+                        shoppingCartItemRepository.save(item);
+                    });
+        }
+
         List<ShoppingCartItemResponse> itemResponses = cart.getItems().stream()
                 .filter(item -> statusFilter == null || item.getStatus() == statusFilter)
                 .map(item -> {


### PR DESCRIPTION
Luis 2026-08-03 en #215: el carrito muestra tours con \`scheduleDate\` ya pasada. Pide (a) no permitir agregar tours con fecha < hoy — **ya cubierto** por validación existente en \`ShoppingCartService.addItemToCart:157\` y \`addItemToExistingCart:316\` — y (b) al re-cargar el carrito, quitar los items con fecha vencida.

## Fix

\`ShoppingCartService.buildShoppingCartResponse(cart, statusFilter=ACTIVE)\`: antes de armar la respuesta, filtra los items con \`status=ACTIVE\` y \`scheduleDate < LocalDate.now(America/Bogota)\`, los marca como \`ABANDONED\` y guarda. El filter ACTIVE que sigue más abajo los descarta automáticamente.

Solo se ejecuta cuando \`statusFilter == ACTIVE\` (llamada normal desde \`GET /shopping-cart/user\`); el listado admin (\`statusFilter=null\`) no purga para no alterar listados históricos.

## Test plan

- [ ] Pipeline verde + deploy.
- [ ] Usuario con carrito que tenga 1 tour con \`scheduleDate=hoy\` y 1 con \`scheduleDate=ayer\` → \`GET /shopping-cart/user\` devuelve solo el de hoy. El item viejo queda \`status=ABANDONED\` en DB (verificar con SQL).
- [ ] Segunda llamada al GET no vuelve a "purgar" (el item ya no es ACTIVE).
- [ ] Regresión: si todos los items están vigentes, no se toca nada.
- [ ] Regresión: endpoint admin (\`statusFilter=null\`) sigue devolviendo items abandonados si los hubiera (no purga).

Closes #215 tras validación de Luis.