### PR TITLE
fix(TC-011 #206 reabierto): job NO_SHOW procesa RESCHEDULED ademas de PENDING

### DIFF
--- a/src/main/java/com/tourya/api/jobs/PendingReservationNoShowJob.java
+++ b/src/main/java/com/tourya/api/jobs/PendingReservationNoShowJob.java
@@ -28,16 +28,21 @@ public class PendingReservationNoShowJob {
     private final TourScheduleSlotAvailabilityService tourScheduleSlotAvailabilityService;
 
     /**
-     * Diario 7am (hora Colombia): marca como NO_SHOW las reservas PENDING cuyo scheduleDate ya pasó.
-     * BE-27: por cada NO_SHOW llama {@code recalculate(slotId)} para que {@code slot.bookings}
-     * refleje la liberacion del cupo (antes quedaba inflado con el drift acumulandose).
+     * Diario 7am (hora Colombia): marca como NO_SHOW las reservas cuyo scheduleDate
+     * ya pasó y siguen en un estado activo (PENDING o RESCHEDULED).
+     *
+     * <p>TC-011 (#206 reabierto Luis 2026-08-03): las reservas RESCHEDULED tambien
+     * deben pasar a NO_SHOW si la nueva fecha ya paso (antes solo procesaba PENDING).</p>
+     *
+     * <p>BE-27: por cada NO_SHOW llama {@code recalculate(slotId)} para que
+     * {@code slot.bookings} refleje la liberacion del cupo.</p>
      */
     @Scheduled(cron = "0 0 7 * * *", zone = "America/Bogota")
     @Transactional
     public void markNoShows() {
         LocalDate today = LocalDate.now(CO_ZONE);
         List<Reservation> pendingPast = reservationRepository.findPendingWithScheduleDateBefore(
-                DeliveryStatusEnum.PENDING,
+                List.of(DeliveryStatusEnum.PENDING, DeliveryStatusEnum.RESCHEDULED),
                 today
         );
         if (pendingPast.isEmpty()) return;

--- a/src/main/java/com/tourya/api/repository/ReservationRepository.java
+++ b/src/main/java/com/tourya/api/repository/ReservationRepository.java
@@ -196,16 +196,19 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
                 startDate, endDate, statusNames);
     }
 
+    // TC-011 (#206 reabierto Luis 2026-08-03): aceptar lista de estados para que
+    // el job NO_SHOW procese tanto PENDING como RESCHEDULED (reservas reagendadas
+    // cuya nueva fecha ya paso). Antes era `= :status` unico.
     @Query("""
         SELECT r
         FROM Reservation r
         JOIN r.shoppingCartItem item
-        WHERE r.deliveryStatus = :status
+        WHERE r.deliveryStatus IN :statuses
           AND item.scheduleDate IS NOT NULL
           AND item.scheduleDate < :today
         """)
     List<Reservation> findPendingWithScheduleDateBefore(
-            @Param("status") DeliveryStatusEnum status,
+            @Param("statuses") List<DeliveryStatusEnum> statuses,
             @Param("today") LocalDate today
     );
 


### PR DESCRIPTION
Luis 2026-08-04 en #206 (reabierto): reserva de \`turistaprueba07@yopmail.com\` en estado **"Reagendada"** con \`scheduleDate=2026-07-30\` (ya pasada) no fue marcada NO_SHOW por el job diario.

**Root cause**: \`PendingReservationNoShowJob.markNoShows\` solo consultaba \`DeliveryStatusEnum.PENDING\`. Las reservas re-agendadas (\`RESCHEDULED\`) cuya nueva fecha ya pasó quedaban colgadas indefinidamente.

## Fix

- \`ReservationRepository.findPendingWithScheduleDateBefore\`: parámetro cambia de \`DeliveryStatusEnum status\` (único) a \`List<DeliveryStatusEnum> statuses\` con \`WHERE r.deliveryStatus IN :statuses\`.
- \`PendingReservationNoShowJob\`: pasa \`List.of(PENDING, RESCHEDULED)\`.

## Test plan

- [ ] Pipeline verde + deploy.
- [ ] Ejecución del job **mañana 7am Bogotá** debe marcar como NO_SHOW la reserva de \`turistaprueba07@yopmail.com\` (RESCHEDULED con \`scheduleDate=2026-07-30\`).
- [ ] Regresión: PENDING con \`scheduleDate<hoy\` siguen siendo procesadas.
- [ ] Regresión: reservas RESCHEDULED con \`scheduleDate>=hoy\` NO se tocan.
- [ ] \`recalculate(slotId)\` sigue disparándose para liberar cupo (BE-27).

Closes #206 tras la próxima corrida del job (mañana 12:00 UTC).