### PR TITLE
fix(TC-011 #206 reabierto): aislar tx de recalculate para no revertir el job NO_SHOW

### DIFF
--- a/src/main/java/com/tourya/api/services/TourScheduleSlotAvailabilityService.java
+++ b/src/main/java/com/tourya/api/services/TourScheduleSlotAvailabilityService.java
@@ -11,6 +11,7 @@ import com.tourya.api.repository.TourScheduleConfigRepository;
 import com.tourya.api.repository.TourScheduleConfigSlotRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -109,7 +110,15 @@ public class TourScheduleSlotAvailabilityService {
         }
     }
 
-    @Transactional
+    /**
+     * TC-011 (#206 reabierto Luis 2026-08-04): `REQUIRES_NEW` para aislar la
+     * transaccion del caller. Sin esto, si `Slot not found` (u otro runtime
+     * exception aqui) marcaba la transaccion externa del `PendingReservationNoShowJob`
+     * como rollback-only, revirtiendo TODOS los `save(reservation)` del job
+     * (log: `UnexpectedRollbackException: silently rolled back`). Efecto visible:
+     * el job decia "Marcadas 11 reservas" pero al hacer commit revertia todo.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void recalculate(Integer slotId) {
         TourScheduleConfigSlot slot = tourScheduleConfigSlotRepository.findById(slotId)
                 .orElseThrow(() -> new ResourceNotFoundException("Slot not found"));


### PR DESCRIPTION
Luis 2026-08-05: la reserva 325 (\`turistaprueba07\`, RESCHEDULED, \`scheduleDate=2026-07-30\`) seguía sin pasar a NO_SHOW aunque el fix del PR #217 (procesar RESCHEDULED también) ya estaba desplegado.

## Causa raíz (logs Cloud Run confirman)

\`PendingReservationNoShowJob.markNoShows\` es \`@Transactional\`. Adentro:
1. Loop marca 11 reservas con \`setDeliveryStatus(NO_SHOW)\` + \`save(r)\`.
2. Loop recalcula slots afectados: \`tourScheduleSlotAvailabilityService.recalculate(slotId)\`.
3. \`recalculate\` es también \`@Transactional\` (default REQUIRED → se une a la tx del caller).
4. Un slot (415) no existe → \`recalculate\` lanza \`ResourceNotFoundException\`.
5. Spring marca la tx REQUIRED como **rollback-only**.
6. El \`catch\` come la exception y sigue el loop, pero la tx principal ya está marcada.
7. Al final del método, commit lanza: \`UnexpectedRollbackException: silently rolled back\`.
8. Rollback → ninguno de los 11 \`save(reservation)\` persiste.

**Log evidencia**: cada día (5, 6, 7 ago) el job dice "Marcadas 11 reservas como NO_SHOW" pero en DB las MISMAS 11 siguen en PENDING/RESCHEDULED.

## Fix

\`TourScheduleSlotAvailabilityService.recalculate\`: \`@Transactional\` → \`@Transactional(propagation = Propagation.REQUIRES_NEW)\`.

Con esto cada \`recalculate(slotId)\` corre en su propia tx independiente. Una excepción adentro solo revierte esa tx puntual, no afecta la tx del job.

Mismo patrón que HOTFIX #179b (que introdujo tx aislada en \`TemporalReservationExpiryJob\` para evitar el mismo problema).

## Test plan

- [ ] Pipeline verde + deploy.
- [ ] Mañana 12:00 UTC (7am Bogotá) el job debe procesar y persistir las 11 reservas.
- [ ] Verificar en DB: reservas con \`scheduleDate < CURRENT_DATE\` en PENDING/RESCHEDULED debe bajar a 0.
- [ ] Log NO debe tener \`UnexpectedRollbackException\` post-fix.
- [ ] \`recalculate\` sigue disparando warn "Slot not found" para slots inexistentes pero no rompe el commit del job.

Closes #206 tras corrida del job.