### PR TITLE
fix(TC-015 #218): exponer porcentajeTourya en TourFullDataResponse

### DIFF
--- a/src/main/java/com/tourya/api/models/mapper/TourMapper.java
+++ b/src/main/java/com/tourya/api/models/mapper/TourMapper.java
@@ -146,6 +146,9 @@ public class TourMapper {
         tourFullDataResponse.setMinAge(tour.getMinAge());
         tourFullDataResponse.setRating(tour.getRating());
         tourFullDataResponse.setStatus(tour.getStatus());
+        // TC-015 (#218): exponer porcentajeTourya asi el ADMIN puede verlo
+        // en GET /tour/admin/consultDataTourById/{id} y verificar el PATCH.
+        tourFullDataResponse.setPorcentajeTourya(tour.getPorcentajeTourya());
         tourFullDataResponse.setProvider(providerMapper.toProviderResponse(tour.getProvider()));
         tourFullDataResponse.setTourOperator(tourPrincipalOperatorService.resolveForTour(tour));
         tourFullDataResponse.setLocations(tourAddressResponseList);

--- a/src/main/java/com/tourya/api/models/responses/TourFullDataResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/TourFullDataResponse.java
@@ -44,6 +44,13 @@ public class TourFullDataResponse {
 
     private List<Integer> tagIds = new ArrayList<>();
 
-    /** Solo visible para backoffice Tourya (ADMIN / BACKOFFICE_OPERATION). */
-
+    /**
+     * Solo visible para backoffice Tourya (ADMIN / BACKOFFICE_OPERATION).
+     *
+     * TC-015 (#218 Luis 2026-08-06): comision del tour como fraccion decimal
+     * (0.25 = 25%). Se persistia via PATCH /tour/admin/{id}/porcentajeTourya
+     * pero el response no la exponia -> ADMIN no podia verificar si el valor
+     * quedo guardado ni consultarlo despues.
+     */
+    private java.math.BigDecimal porcentajeTourya;
 }


### PR DESCRIPTION
Luis 2026-08-06: ADMIN acepta un tour y define \`porcentajeTourya\` en el modal. El PATCH \`/tour/admin/{id}/porcentajeTourya\` guarda bien en DB (\`tour.porcentaje_tourya\`) pero el response no lo expone → el ADMIN no puede verificar el valor guardado ni consultarlo después para editarlo.

## Root cause

\`TourFullDataResponse\` tenía un comentario placeholder ("Solo visible para backoffice Tourya") pero **nunca se declaró el campo**. \`TourMapper.toTourFullDataResponse\` tampoco lo seteaba. Todos los endpoints que devuelven este DTO tienen el mismo hueco:
- \`GET /tour/admin/consultDataTourById/{id}\`
- \`PATCH /tour/admin/{id}/porcentajeTourya\`
- \`PUT /tour/admin/acceptTourById/{id}\`
- \`PUT /tour/admin/returnedTourById\` / \`cancelTourById\` / \`user/submitTourById\`

## Fix

1. \`TourFullDataResponse\`: agregar \`private BigDecimal porcentajeTourya\`.
2. \`TourMapper.toTourFullDataResponse\`: setear el campo desde \`tour.getPorcentajeTourya()\`.

## Nota — botones diferentes

El campo global \`tour.porcentaje_tourya\` es distinto del per-slot \`slot_porcentaje_tourya\` (que sigue siendo editable desde el calendario del proveedor). El calendario copia el default global al crear el slot y luego ADMIN puede sobreescribirlo por slot. El PR de frontend siguiente agregará UI para editar el % global tras aceptar.

## Test plan

- [ ] Pipeline verde + deploy.
- [ ] \`PATCH /tour/admin/{id}/porcentajeTourya\` con \`{"porcentajeTourya":0.30}\` → \`response.porcentajeTourya === 0.30\`.
- [ ] \`GET /tour/admin/consultDataTourById/{id}\` devuelve el mismo valor.
- [ ] Regresión: otros campos siguen viniendo (name, price, etc).

Prerequisito del PR frontend (task #158) que agrega UI para editar el % post-aceptación.