### PR TITLE
feat(TC-016 #219 A): expose countryName/stateName/cityName in TourAddressResponse

### DIFF
--- a/src/main/java/com/tourya/api/models/mapper/TourAddressMapper.java
+++ b/src/main/java/com/tourya/api/models/mapper/TourAddressMapper.java
@@ -30,9 +30,18 @@ public class TourAddressMapper {
         tourAddressResponse.setAddressType(tourAddress.getAddressType());
         tourAddressResponse.setLatitude(tourAddress.getLatitude());
         tourAddressResponse.setLongitude(tourAddress.getLongitude());
-        tourAddressResponse.setCountryId(tourAddress.getCountry().getId());
-        tourAddressResponse.setStateId(tourAddress.getState().getId());
-        tourAddressResponse.setCityId(tourAddress.getCity().getId());
+        if (tourAddress.getCountry() != null) {
+            tourAddressResponse.setCountryId(tourAddress.getCountry().getId());
+            tourAddressResponse.setCountryName(tourAddress.getCountry().getName());
+        }
+        if (tourAddress.getState() != null) {
+            tourAddressResponse.setStateId(tourAddress.getState().getId());
+            tourAddressResponse.setStateName(tourAddress.getState().getName());
+        }
+        if (tourAddress.getCity() != null) {
+            tourAddressResponse.setCityId(tourAddress.getCity().getId());
+            tourAddressResponse.setCityName(tourAddress.getCity().getName());
+        }
         return tourAddressResponse;
     }
     public void updateTourAddressFromRequest(TourAddressRequest request, TourAddress entity) {

--- a/src/main/java/com/tourya/api/models/responses/TourAddressResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/TourAddressResponse.java
@@ -13,6 +13,14 @@ public class TourAddressResponse {
     private Integer countryId;
     private Integer stateId;
     private Integer cityId;
+    /**
+     * TC-016 (#219 Luis 2026-08-06): nombres del pais/estado/ciudad del meeting
+     * point para renderizar en tour-detail y detalle de reserva sin necesitar
+     * un segundo fetch al catalogo. Se pueblan desde `TourAddress.country/state/city.name`.
+     */
+    private String countryName;
+    private String stateName;
+    private String cityName;
     private Double latitude;
     private Double longitude;
     //private TourResponse tour;


### PR DESCRIPTION
Luis 2026-08-06 en #219: en tour-detail y detalle de reserva del turista, el meeting point debería mostrar país + ciudad + nombre del location (además de las coordenadas), pero el DTO \`TourAddressResponse\` solo devolvía IDs.

## Fix

- \`TourAddressResponse\`: agregar \`countryName\`, \`stateName\`, \`cityName\`.
- \`TourAddressMapper.toTourAddressResponse\`: setear los nuevos campos desde la entidad \`TourAddress\` (que ya tiene los ManyToOne a Country/State/City con \`.name\`).
- Guards \`!= null\` para evitar NPE si algún tour tiene datos incompletos.

## Impacto (endpoints afectados)

Todos los endpoints que devuelven listas de tour addresses (incluye \`TourFullDataResponse.locations\`, \`ReservationResponse.locations\`, \`ReservationDetailsResponse.locations\`) ahora traen nombres directos, sin que el frontend necesite un segundo fetch al catálogo de locations públicos.

## Test plan

- [ ] Pipeline verde + deploy.
- [ ] \`GET /public/tour/{id}\` → \`locations[0].countryName === "Colombia"\`, \`.cityName === "Cartagena"\`, etc.
- [ ] \`GET /reservations/{id}\` → \`locations[0].countryName\` presente.
- [ ] Regresión: \`countryId/stateId/cityId\` siguen presentes (no rompe consumidores existentes).

Prerequisito del PR frontend TC-016(A) que renderizará los nombres en el mapa de tour-detail y en el modal de detalle reserva. Parte (A) del TC-016; parte (B) desglose de viajeros vendrá en PR aparte.