### PR TITLE
feat(TC-016 #219 B): expone travelerBreakdown por ageType en sp_get_provider_reservations

### DIFF
--- a/database/migrations/084_tc016_sp_get_provider_reservations_traveler_breakdown.sql
+++ b/database/migrations/084_tc016_sp_get_provider_reservations_traveler_breakdown.sql
@@ -1,0 +1,158 @@
+-- Migration 084: TC-016 (#219) — expone travelerbreakdown en sp_get_provider_reservations
+-- Date: 2026-08-07
+-- Description:
+--   Luis pidio en #219 mostrar en detalle de reserva del proveedor y en el carrito
+--   el desglose por ageType (adulto/niño/infante) con cantidad.
+--
+--   El detalle por ageType ya vive en shopping_cart_item_detail (age_type + quantity).
+--   Aqui exponemos ese detalle como un array JSONB en la columna nueva travelerbreakdown
+--   para que el frontend lo consuma sin llamadas adicionales.
+--
+--   Cambio aditivo — no rompe otros callers. Cualquier mapper que no lea la nueva
+--   columna simplemente la ignora.
+
+DROP FUNCTION IF EXISTS public.sp_get_provider_reservations(int4, int4, int8, varchar, varchar);
+
+CREATE OR REPLACE FUNCTION public.sp_get_provider_reservations(
+    p_provider_id integer DEFAULT NULL,
+    p_customer_user_id integer DEFAULT NULL,
+    p_reservation_id bigint DEFAULT NULL,
+    p_delivery_status character varying DEFAULT NULL,
+    p_sub_category character varying DEFAULT NULL
+)
+RETURNS TABLE(
+    reservationid bigint,
+    reservationdate timestamp without time zone,
+    reservationdeliverystatus character varying,
+    reservationcreateddate timestamp without time zone,
+    paymentid bigint,
+    paymenttransactionid character varying,
+    payername character varying,
+    payeremail character varying,
+    payerphone character varying,
+    payerdocumenttype character varying,
+    payerdocumentnumber character varying,
+    shoppingitemid integer,
+    shoppingtotalprice numeric,
+    shoppingunitprice numeric,
+    providerprice numeric,
+    shoppingquantity integer,
+    producttype character varying,
+    productid integer,
+    totaltourists bigint,
+    tourid integer,
+    tourname jsonb,
+    tourcategoryid integer,
+    tourproviderid integer,
+    toursubcategory character varying,
+    tourscheduleid integer,
+    scheduledate date,
+    slotid integer,
+    slottime_start time without time zone,
+    slottime_end time without time zone,
+    service_responsible_name character varying,
+    service_responsible_email character varying,
+    service_responsible_phone character varying,
+    max_cancellation_date date,
+    max_rescheduling_date date,
+    cancellation_reason character varying,
+    cancellation_date timestamp without time zone,
+    providername character varying,
+    tourimageurl text,
+    -- TC-016 (#219): desglose de viajeros por ageType agregado como jsonb.
+    travelerbreakdown jsonb
+)
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+    RETURN QUERY
+    SELECT
+        r.reservation_id,
+        r.reservation_date,
+        r.delivery_status,
+        r.created_date,
+        p.payment_id,
+        p.transaction_id,
+        p.payer_name,
+        p.payer_email,
+        p.payer_phone,
+        p.payer_document_type,
+        p.payer_document_number,
+        sci.id AS shoppingItemId,
+        sci.total_price,
+        sci.unit_price,
+        COALESCE((
+            SELECT SUM(
+                COALESCE(scid.provider_unit_price, 0) *
+                CASE WHEN t.price_type = 'grupo' THEN 1 ELSE COALESCE(scid.quantity, 0) END
+            )
+            FROM shopping_cart_item_detail scid
+            WHERE scid.shopping_cart_item_id = sci.id
+        ), 0)::numeric AS providerPrice,
+        sci.quantity,
+        sci.product_type,
+        sci.product_id,
+        COALESCE((
+            SELECT SUM(scid.quantity)
+            FROM shopping_cart_item_detail scid
+            WHERE scid.shopping_cart_item_id = sci.id
+        ), 0) AS totalTourists,
+        t.id AS tourId,
+        t.name AS tourName,
+        t.category_id,
+        t.provider_id,
+        t.sub_category::character varying AS tourSubcategory,
+        ts.id AS tourScheduleId,
+        sci.schedule_date,
+        tscs.id AS slotId,
+        tscs.start_time,
+        tscs.end_time,
+        r.service_responsible_name,
+        r.service_responsible_email,
+        r.service_responsible_phone,
+        r.max_cancellation_date,
+        r.max_rescheduling_date,
+        r.cancellation_reason,
+        r.cancellation_date,
+        pr.name AS providername,
+        (SELECT tg.image_url
+           FROM tour_gallery tg
+          WHERE tg.tour_id = t.id
+          ORDER BY tg.order_index ASC NULLS LAST, tg.id ASC
+          LIMIT 1) AS tourimageurl,
+        -- TC-016 (#219): agregacion por ageType, ordenada para output estable.
+        COALESCE((
+            SELECT jsonb_agg(jsonb_build_object(
+                'ageType', scid.age_type,
+                'quantity', scid.quantity,
+                'unitPrice', scid.unit_price,
+                'providerUnitPrice', scid.provider_unit_price
+            ) ORDER BY scid.age_type)
+            FROM shopping_cart_item_detail scid
+            WHERE scid.shopping_cart_item_id = sci.id
+        ), '[]'::jsonb) AS travelerbreakdown
+    FROM reservation r
+    JOIN shopping_cart_item sci ON sci.id = r.item_id
+    JOIN shopping_cart sc ON sc.id = sci.shopping_cart_id
+    LEFT JOIN payment p ON p.payment_id = r.payment_id
+    LEFT JOIN tour_schedule ts ON ts.id = sci.tour_schedule_id
+    LEFT JOIN tour_schedule_config_slot tscs ON tscs.id = sci.slot_id
+    LEFT JOIN tour t ON t.id = sci.product_id
+    LEFT JOIN provider pr ON pr.id = t.provider_id
+    WHERE
+        (p_provider_id IS NULL OR t.provider_id = p_provider_id)
+        AND (p_customer_user_id IS NULL OR sc.user_id = p_customer_user_id)
+        AND (p_reservation_id IS NULL OR r.reservation_id = p_reservation_id)
+        AND (p_delivery_status IS NULL OR r.delivery_status = p_delivery_status)
+        AND (p_sub_category IS NULL OR t.sub_category::text = p_sub_category)
+    GROUP BY
+        r.reservation_id,
+        p.payment_id,
+        sci.id,
+        sc.id,
+        t.id,
+        ts.id,
+        tscs.id,
+        pr.name;
+END;
+$function$;

--- a/src/main/java/com/tourya/api/models/mapper/ReservationDetailsMapper.java
+++ b/src/main/java/com/tourya/api/models/mapper/ReservationDetailsMapper.java
@@ -1,15 +1,21 @@
 package com.tourya.api.models.mapper;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tourya.api._utils.ReservationDisplayId;
 import com.tourya.api.models.TranslatedField;
 import com.tourya.api.models.responses.ReservationDetailsResponse;
+import com.tourya.api.models.responses.TravelerBreakdownDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ReservationDetailsMapper {
@@ -73,6 +79,10 @@ public class ReservationDetailsMapper {
 
                 .totalTourists(rs.getLong("totaltourists")) // BIGINT OK ✔
 
+                // TC-016 (#219): parseo del jsonb travelerbreakdown. readOptional* porque
+                // migraciones anteriores del SP no tenian esta columna (patron aditivo).
+                .travelerBreakdown(parseTravelerBreakdown(readOptionalString(rs, "travelerbreakdown")))
+
                 .tourId(rs.getInt("tourid"))
                 .tourName(tourName)
                 .tourCategoryId(rs.getInt("tourcategoryid"))
@@ -108,5 +118,17 @@ public class ReservationDetailsMapper {
                         ? rs.getTimestamp("cancellation_date").toLocalDateTime() : null)
 
                 .build();
+    }
+
+    private List<TravelerBreakdownDto> parseTravelerBreakdown(String json) {
+        if (json == null || json.isBlank()) {
+            return Collections.emptyList();
+        }
+        try {
+            return objectMapper.readValue(json, new TypeReference<List<TravelerBreakdownDto>>() {});
+        } catch (Exception ex) {
+            log.warn("Failed to parse travelerbreakdown JSON, returning empty list. json={}", json, ex);
+            return Collections.emptyList();
+        }
     }
 }

--- a/src/main/java/com/tourya/api/models/responses/ReservationDetailsResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/ReservationDetailsResponse.java
@@ -4,6 +4,8 @@ import com.tourya.api.models.TranslatedField;
 import lombok.Builder;
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 @Builder
 public class ReservationDetailsResponse {
@@ -39,6 +41,9 @@ public class ReservationDetailsResponse {
     private Integer productId;
 
     private Long totalTourists; // BIGINT ✔
+
+    /** TC-016 (#219): desglose de viajeros por ageType (ADULT/CHILD/INFANT) con cantidad. */
+    private List<TravelerBreakdownDto> travelerBreakdown;
 
     // --- Tour ---
     private Integer tourId;

--- a/src/main/java/com/tourya/api/models/responses/TravelerBreakdownDto.java
+++ b/src/main/java/com/tourya/api/models/responses/TravelerBreakdownDto.java
@@ -1,0 +1,22 @@
+package com.tourya.api.models.responses;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * TC-016 (#219): desglose de viajeros por ageType dentro de un shopping_cart_item.
+ * Cada item de reserva puede tener varios ageTypes (ADULT/CHILD/INFANT) con distinta cantidad.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TravelerBreakdownDto {
+    /** Valor del enum AgePriceType almacenado en shopping_cart_item_detail.age_type (ADULT/CHILD/INFANT). */
+    private String ageType;
+    private Integer quantity;
+    private Double unitPrice;
+    private Double providerUnitPrice;
+}


### PR DESCRIPTION
## Contexto

TC-016 (#219) parte B — desglose de viajeros por ageType (ADULT/CHILD/INFANT) en el detalle de reserva del proveedor y en el carrito.

La parte A (país/ciudad/nombre en mapa) fue mergeada en PRs #224 (api) + #98 (front).

## Cambios

**Migración 084** — expone `travelerbreakdown jsonb` en `sp_get_provider_reservations`:
- \`jsonb_agg\` de \`shopping_cart_item_detail\` con \`ageType/quantity/unitPrice/providerUnitPrice\`, ordenado por \`ageType\`.
- \`COALESCE\` a \`'[]'::jsonb\` para items sin detail.
- Sigue patrón aditivo de TC-005 (#188 — providername/tourimageurl).

**Backend Java:**
- \`TravelerBreakdownDto\`: nuevo POJO (Lombok Builder).
- \`ReservationDetailsResponse\`: agrega \`List<TravelerBreakdownDto> travelerBreakdown\`.
- \`ReservationDetailsMapper\`: lee la columna con \`readOptionalString\` + \`TypeReference\` (tolera SPs viejos sin la columna).

## Estado migración

Ya aplicada a Cloud SQL dev (verificada con \`SELECT jsonb_pretty(travelerbreakdown) FROM sp_get_provider_reservations(...) LIMIT 3\` — devuelve desglose real).

## Test plan
- [ ] Deploy backend → \`curl\` a \`/reservations/provider\` como PROVIDER debe traer \`travelerBreakdown: [{ageType, quantity, unitPrice, providerUnitPrice}]\` por reserva.
- [ ] Reserva 1-item con solo ADULT → array de 1 elemento con quantity correcta.
- [ ] Reserva mixta ADULT+CHILD → array de 2 elementos.
- [ ] Reservas históricas sin \`shopping_cart_item_detail\` → array vacío (no null).
- [ ] Frontend consumer (PR siguiente): sin cambios de contrato, campo nuevo opcional.