### PR TITLE
feat(TC-017 #220): agrega HOTEL_PICKUP a AddressTypeEnum

### DIFF
--- a/src/main/java/com/tourya/api/constans/enums/AddressTypeEnum.java
+++ b/src/main/java/com/tourya/api/constans/enums/AddressTypeEnum.java
@@ -9,7 +9,9 @@ import lombok.AllArgsConstructor;
 public enum AddressTypeEnum {
     MEETING_POINT("Meeting Point"),
     END_POINT("End Point"),
-    PICK_UP_POINT("Pick-up Point");
+    PICK_UP_POINT("Pick-up Point"),
+    // TC-017 (#220): recogida en el hotel del cliente. Sin ubicacion fisica del tour.
+    HOTEL_PICKUP("Hotel Pickup");
 
     private String value;
 

--- a/src/main/java/com/tourya/api/models/request/TourAddressRequest.java
+++ b/src/main/java/com/tourya/api/models/request/TourAddressRequest.java
@@ -10,13 +10,13 @@ import lombok.Data;
 @Data
 public class TourAddressRequest {
     private Integer Id;
-    @NotNull(message = "countryId is mandatory")
+    // TC-017 (#220): country/state/city opcionales para permitir addressType=HOTEL_PICKUP
+    // (recogida en el hotel del cliente, sin ubicacion fisica del tour). El frontend
+    // valida la exclusividad segun el tipo elegido.
     private Integer countryId;
 
-    @NotNull(message = "stateId is mandatory")
     private Integer stateId;
 
-    @NotNull(message = "cityId is mandatory")
     private Integer cityId;
 
     private Double latitude = 0.0;


### PR DESCRIPTION
## Contexto

TC-017 (#220) — cliente puede tener un tour que \"recoge en el hotel del turista\" en vez de tener un punto de encuentro físico. Luis pidió:
1. Flag/tipo especial para \"Recogida en el hotel\".
2. Ocultar botón \"Agregar nuevo\" ubicación cuando aplica.
3. Mensaje explícito en tour-detail y detalle de reserva.

## Cambios

- **AddressTypeEnum**: nuevo valor \`HOTEL_PICKUP(\"Hotel Pickup\")\`.
- **TourAddressRequest**: remueve \`@NotNull\` de \`countryId/stateId/cityId\` porque HOTEL_PICKUP no tiene ubicación física. El frontend valida exclusividad según el tipo elegido.

## Por qué esta opción

- **Sin migración DDL**: \`tour_address.address_type\` es \`varchar(30)\`, acepta el nuevo string \`'Hotel Pickup'\` sin cambios de esquema.
- **Sin refactors**: auditoría (\`grep addressType src/main/java/\`) confirmó que ningún código de negocio (validaciones, filtros, jobs, specs) ramifica por \`addressType\` — solo pass-through en DTOs/mapper. Agregar un nuevo valor es seguro.
- **Ortogonal al viaje del cliente**: coordenadas GPS, país/estado/ciudad quedan nullable en el request; el service ya persiste NULL si viene vacío (la columna DDL ya era NULL).

## Test plan

- [ ] Deploy → \`POST /tourAddress/user/save/{tourId}\` con \`{ addressType: \"Hotel Pickup\", location: {...} }\` sin country/state/city debe persistir sin error.
- [ ] \`POST\` con \`addressType: \"Meeting Point\"\` sin country debe seguir aceptando (validación se movió al frontend) — si Luis quiere validación server-side estricta, se agrega en el service en un PR aparte.
- [ ] Enum PG obsoleto en \`ddl.sql\` L14-19 (valores en español, no usado por la columna) queda tal cual — cleanup cosmético opcional.

## Frontend PR
Viene después: agrega opción HOTEL_PICKUP al dropdown provider, oculta controles de ubicación física cuando se selecciona, oculta botón \"Agregar nuevo\" si ya existe una location HOTEL_PICKUP, muestra mensaje 🏨 \"Recogen en tu hotel\" en tours-detail y modal reserva.