### PR TITLE
fix(TC-017 #220): guard null en country/state/city lookup + enum matcher tolerante

### DIFF
--- a/src/main/java/com/tourya/api/constans/enums/AddressTypeEnum.java
+++ b/src/main/java/com/tourya/api/constans/enums/AddressTypeEnum.java
@@ -23,7 +23,9 @@ public enum AddressTypeEnum {
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public static AddressTypeEnum of(String value) {
         for (AddressTypeEnum e : values()) {
-            if (e.value.equalsIgnoreCase(value)) {
+            // TC-017 (#220): acepta tanto el display value ("Hotel Pickup") como la key ("HOTEL_PICKUP")
+            // para tolerar frontends que envien cualquiera de los dos formatos.
+            if (e.value.equalsIgnoreCase(value) || e.name().equalsIgnoreCase(value)) {
                 return e;
             }
         }

--- a/src/main/java/com/tourya/api/services/TourAddressService.java
+++ b/src/main/java/com/tourya/api/services/TourAddressService.java
@@ -46,9 +46,10 @@ public class TourAddressService {
             Provider provider = providerService.findByUserAndStatusActive(user);
             Tour tour = getTour(tourId, provider.getId());
             TourAddress tourAddress = tourAddressMapper.toTourAddress(tourAddressRequest);
-            Country country = getCountry(tourAddressRequest.getCountryId());
-            State state = getState(tourAddressRequest.getStateId());
-            City city = getCity(tourAddressRequest.getCityId());
+            // TC-017 (#220): guard null para HOTEL_PICKUP sin ubicacion fisica.
+            Country country = tourAddressRequest.getCountryId() != null ? getCountry(tourAddressRequest.getCountryId()) : null;
+            State state = tourAddressRequest.getStateId() != null ? getState(tourAddressRequest.getStateId()) : null;
+            City city = tourAddressRequest.getCityId() != null ? getCity(tourAddressRequest.getCityId()) : null;
 
 
             tourAddress.setTour(tour);
@@ -70,9 +71,10 @@ public class TourAddressService {
             List<TourAddress> tourAddressList = new ArrayList<>();
             for(TourAddressRequest tourAddressRequest : tourAddressRequestList){
                 TourAddress tourAddress = tourAddressMapper.toTourAddress(tourAddressRequest);
-                Country country = getCountry(tourAddressRequest.getCountryId());
-                State state = getState(tourAddressRequest.getStateId());
-                City city = getCity(tourAddressRequest.getCityId());
+                // TC-017 (#220): guard null para HOTEL_PICKUP sin ubicacion fisica.
+                Country country = tourAddressRequest.getCountryId() != null ? getCountry(tourAddressRequest.getCountryId()) : null;
+                State state = tourAddressRequest.getStateId() != null ? getState(tourAddressRequest.getStateId()) : null;
+                City city = tourAddressRequest.getCityId() != null ? getCity(tourAddressRequest.getCityId()) : null;
                 tourAddress.setTour(tour);
                 tourAddress.setCountry(country);
                 tourAddress.setState(state);

--- a/src/main/java/com/tourya/api/services/TourService.java
+++ b/src/main/java/com/tourya/api/services/TourService.java
@@ -331,9 +331,12 @@ public class TourService {
 
         for(TourAddressRequest request : incomingAddressRequests){
             TourAddress tourAddress;
-            Country country = getCountry(request.getCountryId());
-            State state = getState(request.getStateId());
-            City city = getCity(request.getCityId());
+            // TC-017 (#220): country/state/city pueden venir null cuando addressType=HOTEL_PICKUP
+            // (recogida en el hotel del cliente, sin ubicacion fisica). Guard evita
+            // IllegalArgumentException que lanzaria CrudRepository.findById(null) → 500 no manejado.
+            Country country = request.getCountryId() != null ? getCountry(request.getCountryId()) : null;
+            State state = request.getStateId() != null ? getState(request.getStateId()) : null;
+            City city = request.getCityId() != null ? getCity(request.getCityId()) : null;
 
 
             if(request.getId() != null && existingAddressesMap.containsKey(request.getId())){


### PR DESCRIPTION
## Contexto

Luis reportó **400 al editar tour** en \`POST /api/v1/tour/user/saveAll\` tras el merge del PR #226 (que agregó HOTEL_PICKUP).

Auditoría identificó dos bugs latentes que deben cerrarse independientemente del root cause del 400 específico:

1. **Guard null en country/state/city lookup**: sin esto, un tour con \`addressType=HOTEL_PICKUP\` (sin ubicación física) llega al service con \`countryId=null\` → \`CrudRepository.findById(null)\` lanza \`IllegalArgumentException\` → cae al catch-all → **500 no manejado**.
2. **Enum matcher defensivo**: acepta tanto \`\"Hotel Pickup\"\` (display value) como \`\"HOTEL_PICKUP\"\` (key) para tolerar cualquier formato del frontend.

## Cambios

**\`TourService.createOrUpdateTourAddressesForTour\` (L334-336):**
\`\`\`java
Country country = request.getCountryId() != null ? getCountry(request.getCountryId()) : null;
State state = request.getStateId() != null ? getState(request.getStateId()) : null;
City city = request.getCityId() != null ? getCity(request.getCityId()) : null;
\`\`\`

**\`TourAddressService.saveTourAddressByTourId\` (L49-51) y \`saveTourAddressListByTourId\` (L73-75):** mismo guard.

**\`AddressTypeEnum.of\`:**
\`\`\`java
if (e.value.equalsIgnoreCase(value) || e.name().equalsIgnoreCase(value)) {
    return e;
}
\`\`\`

## Estado del 400 de Luis

**No es la causa confirmada.** Un \`countryId=null\` produciría 500, no 400. Comenté en #220 pidiendo a Luis el body del response y payload para diagnosticar (probablemente algún \`@NotEmpty\` en \`timeOfDay\` u otra collection). Este PR va independiente porque los bugs latentes son reales.

## Test plan
- [ ] Deploy → como PROVIDER crear tour con addressType=\"Hotel Pickup\", sin país/estado/ciudad → debe persistir sin error.
- [ ] Editar el mismo tour → sin error.
- [ ] Enviar \`{\"addressType\": \"HOTEL_PICKUP\"}\` (con la key, no el value) → debe deserializar correctamente al enum.
- [ ] Enviar \`{\"addressType\": \"Hotel Pickup\"}\` (con el value) → debe seguir funcionando.
- [ ] Tour normal con MEETING_POINT y country/state/city válidos → sin regresión.