### PR TITLE
fix(TC-018 #227 Bug A): dispara hook DIMAR en update + incluye RESCHEDULED + fail loud

### DIFF
--- a/src/main/java/com/tourya/api/services/MaritimActivityReportService.java
+++ b/src/main/java/com/tourya/api/services/MaritimActivityReportService.java
@@ -130,6 +130,11 @@ public class MaritimActivityReportService {
         LocationRefs location = resolveAndValidateLocation(request);
         validateCategoryAndSubcategory(request.getBusinessCategoryId(), request.getSubcategoryCode());
 
+        // TC-018 (#227) Bug A hipotesis 1: capturar flag previo para saber si esta edicion
+        // TRANSICIONA el reporte a RED. En ese caso debemos publicar MaritimeAlertCreatedEvent
+        // igual que en create(), para que el listener AFTER_COMMIT cancele reservas.
+        MaritimeFlagEnum previousFlag = report.getFlag();
+
         report.setCountry(location.country());
         report.setState(location.state());
         report.setCity(location.city());
@@ -139,7 +144,28 @@ public class MaritimActivityReportService {
         report.setReportStartDate(request.getReportStartDate());
         report.setReportEndDate(request.getReportEndDate());
 
-        return toResponse(maritimActivityReportRepository.save(report));
+        MaritimActivityReport saved = maritimActivityReportRepository.save(report);
+
+        // TC-018 (#227): dispara el hook si el reporte ES RED tras la edicion. Cubre dos casos:
+        //   (a) transicion GREEN/YELLOW -> RED,
+        //   (b) reporte ya RED pero editado (p.ej. cambio de subcategoria, ubicacion o rango
+        //       de fechas) — necesitamos re-evaluar reservas afectadas con los nuevos criterios.
+        // El listener es idempotente por reserva (skip si ya CANCELED).
+        if (saved.getFlag() == MaritimeFlagEnum.RED) {
+            eventPublisher.publishEvent(new MaritimeAlertCreatedEvent(
+                    saved.getId(),
+                    saved.getSubcategoryCode(),
+                    saved.getCountry() != null ? saved.getCountry().getId() : null,
+                    saved.getState() != null ? saved.getState().getId() : null,
+                    saved.getCity() != null ? saved.getCity().getId() : null,
+                    saved.getReportStartDate(),
+                    saved.getReportEndDate(),
+                    saved.getFlag()));
+            log.info("BE-23 MaritimeAlertCreatedEvent published for RED report {} (update, previousFlag={})",
+                    saved.getId(), previousFlag);
+        }
+
+        return toResponse(saved);
     }
 
     @Transactional

--- a/src/main/java/com/tourya/api/services/ReservationService.java
+++ b/src/main/java/com/tourya/api/services/ReservationService.java
@@ -1221,10 +1221,15 @@ public class ReservationService {
             return;
         }
 
+        // TC-018 (#227) Bug A hipotesis 3: se replica el bug de TC-011 (#206) — la lista
+        // original NO incluia RESCHEDULED, por lo que reservas reagendadas al dia del reporte
+        // quedaban fuera de la cancelacion. Agregamos RESCHEDULED (una reserva reagendada
+        // sigue siendo activa y debe cancelarse si el reporte cubre su nueva fecha).
         List<DeliveryStatusEnum> openStatuses = List.of(
                 DeliveryStatusEnum.PENDING,
                 DeliveryStatusEnum.RESERVED,
-                DeliveryStatusEnum.IN_TRANSIT);
+                DeliveryStatusEnum.IN_TRANSIT,
+                DeliveryStatusEnum.RESCHEDULED);
 
         List<Reservation> affected = reservationRepository.findAffectedByRedAlert(
                 subCategory,
@@ -1257,28 +1262,26 @@ public class ReservationService {
     }
 
     private void cancelOneByRedAlert(Reservation r, Long reportId) {
-        // Idempotencia: si otra corrida ya la canceló, saltar.
+        // Idempotencia: si otra corrida ya la canceló, saltar (return silencioso legitimo).
         if (r.getDeliveryStatus() == DeliveryStatusEnum.CANCELED) {
             return;
         }
+        // TC-018 (#227) Bug A hipotesis 4: los data-integrity errors (sin itemId, sin cart,
+        // sin tour) antes eran silent returns que dejaban el counter `failed` en 0 y hacian
+        // parecer que el hook corrio OK cuando en realidad no cancelo nada. Ahora lanzamos
+        // excepcion para que el catch outer los cuente y aparezcan en el log final.
         if (r.getItemId() == null) {
-            log.warn("BE-23 alert {} reservationId={} without itemId, skipping",
-                    reportId, r.getReservationId());
-            return;
+            throw new IllegalStateException("reservationId=" + r.getReservationId() + " without itemId");
         }
 
         ShoppingCartItem item = shoppingCartItemRepository.findById(r.getItemId()).orElse(null);
         if (item == null || item.getTourSchedule() == null) {
-            log.warn("BE-23 alert {} reservationId={} lacks cart/schedule linkage",
-                    reportId, r.getReservationId());
-            return;
+            throw new IllegalStateException("reservationId=" + r.getReservationId() + " lacks cart/schedule linkage");
         }
 
         Tour tour = tourRepository.findById(item.getTourSchedule().getTourId()).orElse(null);
         if (tour == null) {
-            log.warn("BE-23 alert {} reservationId={} tour not found",
-                    reportId, r.getReservationId());
-            return;
+            throw new IllegalStateException("reservationId=" + r.getReservationId() + " tour not found");
         }
 
         r.setDeliveryStatus(DeliveryStatusEnum.CANCELED);


### PR DESCRIPTION
## Contexto

Luis reportó (issue #227) que al crear/editar reporte marítimo RED el mensaje dice "N reservas se cancelaron" pero la BD sigue mostrando esas reservas en PENDING.

Auditoría del hook BE-23 (task #107 mío) identifica **3 bugs ortogonales** que juntos explican el síntoma. Este PR arregla los 3 en un solo cambio chico.

## Fix 1 — update() no publicaba evento (root cause más probable)

\`MaritimActivityReportService.update()\` solo persistía el reporte pero NO publicaba \`MaritimeAlertCreatedEvent\` aunque el flag cambiara a RED. El listener AFTER_COMMIT nunca se disparaba.

**Cubre 2 casos:**
- (a) Transición GREEN/YELLOW → RED al editar.
- (b) Reporte ya RED pero editado (cambio de subcategoría/ubicación/rango de fechas) — re-evalúa reservas con los nuevos criterios. El listener es idempotente por reserva.

## Fix 2 — falta RESCHEDULED en openStatuses (regresión TC-011)

\`ReservationService.cancelAffectedByRedAlert\` usaba \`openStatuses = [PENDING, RESERVED, IN_TRANSIT]\` — reservas reagendadas al día del reporte quedaban fuera. Es el mismo pattern del bug que arreglé en TC-011 (#206), replicado aquí.

**Fix:** agregar \`DeliveryStatusEnum.RESCHEDULED\`.

## Fix 3 — silent returns ocultaban fallas

\`cancelOneByRedAlert\` hacía \`return\` silencioso cuando itemId/cart/schedule/tour eran null (data-integrity errors). El counter \`failed\` no se incrementaba → log final \`canceled 0 (failed isolated: 0)\` parecía OK cuando en realidad no canceló nada.

**Fix:** lanzar \`IllegalStateException\` para que caiga en el catch outer y se contabilice como falla real visible en logs.

## Test plan
- [ ] Deploy → crear reporte NUEVO RED que cubra reservas PENDING → deben pasar a CANCELED + generar credit + tocar slot availability.
- [ ] Editar reporte YA existente cambiando flag de GREEN a RED → hook debe disparar y cancelar.
- [ ] Editar reporte YA RED extendiendo rango de fechas → hook debe re-evaluar y cancelar reservas nuevas afectadas.
- [ ] Reserva en RESCHEDULED cuya nueva scheduleDate cae en rango del reporte RED → debe cancelarse.
- [ ] Reserva con \`itemId=null\` → log final debe mostrar \`failed isolated: 1\` (no 0).
- [ ] Reporte con subcategoría inválida → sigue haciendo skip silencioso con warn (comportamiento existente OK).

## Notas
- Bug B (bloqueo en carrito) va en PR aparte con migración SP 085 + guard + DTO nuevo.
- Frontend PR va después del deploy de ambos backends.