### PR TITLE
fix(TC-019 #231): batch /tour-schedules/batch ya no responde 404 Slot not found

### DIFF
--- a/src/main/java/com/tourya/api/services/TourScheduleConfigGeneralService.java
+++ b/src/main/java/com/tourya/api/services/TourScheduleConfigGeneralService.java
@@ -223,7 +223,10 @@ public class TourScheduleConfigGeneralService {
                 .filter(PayloadIdUtils::isPersistedId)
                 .toList();
         for (Integer slotId : slotIds) {
-            tourScheduleSlotAvailabilityService.recalculate(slotId);
+            // TC-019 (#231): usar variante REQUIRED — el batch acaba de INSERTar los slots
+            // en esta misma tx y aun no commiteo. REQUIRES_NEW abriria una tx nueva con
+            // connection distinta que no los ve (READ COMMITTED) -> "Slot not found" -> 404.
+            tourScheduleSlotAvailabilityService.recalculateInSameTransaction(slotId);
         }
     }
 

--- a/src/main/java/com/tourya/api/services/TourScheduleSlotAvailabilityService.java
+++ b/src/main/java/com/tourya/api/services/TourScheduleSlotAvailabilityService.java
@@ -117,9 +117,30 @@ public class TourScheduleSlotAvailabilityService {
      * como rollback-only, revirtiendo TODOS los `save(reservation)` del job
      * (log: `UnexpectedRollbackException: silently rolled back`). Efecto visible:
      * el job decia "Marcadas 11 reservas" pero al hacer commit revertia todo.
+     *
+     * TC-019 (#231): usar `recalculate` desde flujos donde el slot YA esta commiteado
+     * en BD (jobs, cancelaciones post-reserva). Para llamadas desde flujos donde el
+     * slot recien se creo/actualizo en la MISMA tx externa (batch de tour-schedule),
+     * usar `recalculateInSameTransaction` — sino REQUIRES_NEW no ve los INSERTs
+     * pendientes y lanza `ResourceNotFoundException("Slot not found")` -> 404.
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void recalculate(Integer slotId) {
+        doRecalculate(slotId);
+    }
+
+    /**
+     * TC-019 (#231): variante en la MISMA transaccion del caller. Usada por el batch
+     * de tour-schedule (create/update config) donde los slots recien fueron persistidos
+     * pero aun no commiteados. Si falla, marca la tx externa rollback-only — que es
+     * el comportamiento correcto: un slot faltante en el flujo de creacion es un bug real.
+     */
+    @Transactional
+    public void recalculateInSameTransaction(Integer slotId) {
+        doRecalculate(slotId);
+    }
+
+    private void doRecalculate(Integer slotId) {
         TourScheduleConfigSlot slot = tourScheduleConfigSlotRepository.findById(slotId)
                 .orElseThrow(() -> new ResourceNotFoundException("Slot not found"));
 


### PR DESCRIPTION
## Contexto

Luis reportó (issue #231, crítico) que como PROVIDER, al hacer clic en \"Agregar nuevo calendario\" en `/providers/tours/{tourId}/tour-schedule`, el frontend llama a `POST /tour-schedules/batch` y recibe:

\`\`\`json
{ \"errorCode\": 309, \"message\": \"Resource not found.\", \"error\": \"Slot not found\" }
\`\`\`

No se crea ningún tour_schedule → provider bloqueado para agendar tours.

## Root cause

Regresión de mi propio cambio en TC-011 (#206). \`TourScheduleSlotAvailabilityService.recalculate()\` está anotado \`@Transactional(propagation = REQUIRES_NEW)\` para aislar la tx del \`PendingReservationNoShowJob\`. Perfecto para ese caller, **pero rompe el batch**:

1. Tx externa: \`save(config)\` + \`save(slots)\` (aún sin commit).
2. Inmediatamente \`recalculateAvailabilityForAllSlots()\` → \`recalculate(slotId)\`.
3. Como es \`REQUIRES_NEW\`, abre **tx nueva con connection distinta**.
4. Postgres READ COMMITTED → la tx nueva no ve los INSERTs pendientes.
5. \`findById(slotId)\` → empty → \`ResourceNotFoundException(\"Slot not found\")\` → 404.

## Fix

Extraigo el body a un método privado `doRecalculate(slotId)` y expongo **dos variantes**:

\`\`\`java
@Transactional(propagation = Propagation.REQUIRES_NEW)
public void recalculate(Integer slotId) { doRecalculate(slotId); }  // usado por jobs

@Transactional  // REQUIRED default
public void recalculateInSameTransaction(Integer slotId) { doRecalculate(slotId); }  // usado por batch
\`\`\`

`TourScheduleConfigGeneralService.recalculateAvailabilityForAllSlots` usa la variante nueva `recalculateInSameTransaction` — reusa la tx del batch y ve los slots recién INSERTados.

**Trade-off:** si `recalculateInSameTransaction` falla en el batch, la tx externa hace rollback (comportamiento correcto: un slot faltante durante creación es un bug real). El job de expiry sigue aislando fallas individuales.

## Cambios (2 archivos, +26/-6)

- `TourScheduleSlotAvailabilityService.java`: refactor a `doRecalculate` privado + nueva variante pública.
- `TourScheduleConfigGeneralService.java` L226: cambia el call site.

## Test plan
- [ ] Deploy → como PROVIDER, ir a `/providers/tours/{tourId}/tour-schedule`, seleccionar template + rango + días → \"Agregar nuevo calendario\" → debe crear los tour_schedules sin 404.
- [ ] Update existente de un tour-schedule config → sin regresión.
- [ ] `PendingReservationNoShowJob` sigue funcionando (marca NO_SHOW y aislaria fallas si un slot desaparece mientras corre).

## Refinamientos separados
Luis pidió también en TC-019:
- Filtrar templates del dropdown por subcategoría del tour.
- Agregar campo Subcategoría al form de creación de Template.

Ambos son feature nueva (requieren migración `sub_category` en `tour_schedule_config`, endpoint filter, DTO + form). Van en PR aparte después que este hotfix desbloquee a Luis.