### PR TITLE
feat(TC-019 #231): sub_category en tour_schedule_config + filtro por subcategoria en templates

### DIFF
--- a/database/migrations/086_tc019_tour_schedule_config_sub_category.sql
+++ b/database/migrations/086_tc019_tour_schedule_config_sub_category.sql
@@ -1,0 +1,82 @@
+-- Migration 086: TC-019 (#231) — agrega sub_category a tour_schedule_config + filter en get_templates_by_provider
+-- Date: 2026-08-10
+-- Description:
+--   Luis pidio en #231 que el combo de Template en Configuracion de Calendario del tour
+--   filtre solo templates de la misma subcategoria que el tour, y que en la creacion
+--   de Template haya un campo Subcategoria.
+--
+--   Cambios:
+--   (a) Agrega columna sub_category (tour_subcategory_enum, nullable) a tour_schedule_config.
+--       Templates existentes quedan con NULL (no filtrable por subcat hasta ser editados).
+--   (b) Recrea get_templates_by_provider para aceptar un segundo parametro p_sub_category
+--       opcional. Si viene, filtra por c.sub_category::text = p_sub_category. Tambien
+--       incluye sub_category en el JSON output para el frontend.
+
+ALTER TABLE public.tour_schedule_config
+  ADD COLUMN IF NOT EXISTS sub_category tour_subcategory_enum NULL;
+
+DROP FUNCTION IF EXISTS public.get_templates_by_provider(integer);
+DROP FUNCTION IF EXISTS public.get_templates_by_provider(integer, text);
+
+CREATE OR REPLACE FUNCTION public.get_templates_by_provider(
+    p_provider_id integer,
+    p_sub_category text DEFAULT NULL
+)
+RETURNS SETOF jsonb
+LANGUAGE plpgsql
+AS $function$
+BEGIN
+    RETURN QUERY
+    SELECT jsonb_build_object(
+        'id', c.id,
+        'providerId', c.provider_id,
+        'label', c.label,
+        'daysOfWeek', c.days_of_week,
+        -- TC-019 (#231): expone la subcategoria del template para que el frontend pueda
+        -- distinguir a que subcategorias aplica y mostrarla en la lista.
+        'subCategory', c.sub_category,
+        'slots', (
+            SELECT COALESCE(
+                jsonb_agg(
+                    jsonb_build_object(
+                        'id', s.id,
+                        'startTime', s.start_time,
+                        'endTime', s.end_time,
+                        'capacity', s.capacity,
+                        'bookings', COALESCE(s.bookings, 0),
+                        'availability', COALESCE(s.availability, 0),
+                        'minCapacityCalc', s.min_capacity_calc,
+                        'checkAvailability', COALESCE(s.check_availability, false),
+                        'prices', (
+                            SELECT COALESCE(
+                                jsonb_agg(
+                                    jsonb_build_object(
+                                        'id', p.id,
+                                        'ageType', p.age_type,
+                                        'price', p.price,
+                                        'providerPrice', p.provider_price
+                                    )
+                                    ORDER BY p.id
+                                ),
+                                '[]'::jsonb
+                            )
+                            FROM public.tour_schedule_config_price p
+                            WHERE p.slot_id = s.id
+                        )
+                    )
+                    ORDER BY s.id
+                ),
+                '[]'::jsonb
+            )
+            FROM public.tour_schedule_config_slot s
+            WHERE s.config_id = c.id
+        )
+    )
+    FROM public.tour_schedule_config c
+    WHERE c.provider_id = p_provider_id
+      AND COALESCE(c.is_template, false) = true
+      -- TC-019 (#231): filtrar por subcategoria si viene. Templates con sub_category=NULL
+      -- se ocultan al pasar filtro (no aplican a ninguna subcat especifica).
+      AND (p_sub_category IS NULL OR c.sub_category::text = p_sub_category);
+END;
+$function$;

--- a/src/main/java/com/tourya/api/controller/TourScheduleController.java
+++ b/src/main/java/com/tourya/api/controller/TourScheduleController.java
@@ -166,8 +166,12 @@ public class TourScheduleController {
     }
 
     @GetMapping("/templates")
-    public ResponseEntity<List<TourScheduleConfigResponse>> getTemplatesByProvider(Authentication connectedUser) {
-        return ResponseEntity.ok(configTemplateService.getConfigTemplatesByProvider(connectedUser));
+    public ResponseEntity<List<TourScheduleConfigResponse>> getTemplatesByProvider(
+            // TC-019 (#231): filtro opcional. Si viene, el SP filtra por sub_category = subCategory
+            // + templates con NULL quedan afuera (no aplican a subcategoria especifica).
+            @RequestParam(value = "subCategory", required = false) String subCategory,
+            Authentication connectedUser) {
+        return ResponseEntity.ok(configTemplateService.getConfigTemplatesByProvider(connectedUser, subCategory));
     }
 
     @PutMapping("/tours/{tourId}/percentage")

--- a/src/main/java/com/tourya/api/models/TourScheduleConfig.java
+++ b/src/main/java/com/tourya/api/models/TourScheduleConfig.java
@@ -1,6 +1,8 @@
 package com.tourya.api.models;
 
 import com.tourya.api.common.BaseEntity;
+import com.tourya.api.constans.enums.TourSubCategoryEnum;
+import com.tourya.api.constans.enums.TourSubCategoryEnumConverter;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -62,4 +64,10 @@ public class TourScheduleConfig extends BaseEntity {
 
     @Column(name = "is_template")
     private Boolean isTemplate;
+
+    // TC-019 (#231): subcategoria que aplica al template. NULL para templates legacy
+    // (creados antes de esta feature). El dropdown filtra por subCategory del tour.
+    @Convert(converter = TourSubCategoryEnumConverter.class)
+    @Column(name = "sub_category", columnDefinition = "tour_subcategory_enum")
+    private TourSubCategoryEnum subCategory;
 }

--- a/src/main/java/com/tourya/api/models/request/TourScheduleConfigCreationRequest.java
+++ b/src/main/java/com/tourya/api/models/request/TourScheduleConfigCreationRequest.java
@@ -27,4 +27,8 @@ public class TourScheduleConfigCreationRequest {
     @Valid // Habilita la validación anidada de los slots
     @NotEmpty(message = "La configuración debe tener al menos un slot de horario")
     private Set<TourScheduleConfigSlotDto> slots = new HashSet<>(); // CAMBIO: De List a Set, inicialización
+
+    // TC-019 (#231): subcategoria que aplica al template. Nullable (retrocompatible con
+    // clientes viejos). El frontend usa el valor del enum tal como se guarda en tour.sub_category.
+    private String subCategory;
 }

--- a/src/main/java/com/tourya/api/models/responses/TourScheduleConfigResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/TourScheduleConfigResponse.java
@@ -16,4 +16,6 @@ public class TourScheduleConfigResponse {
     private String label;
     private List<String> daysOfWeek;
     private Set<TourScheduleSlotResponse> slots = new HashSet<>();
+    // TC-019 (#231): permite al frontend saber a que subcategoria aplica el template.
+    private String subCategory;
 }

--- a/src/main/java/com/tourya/api/repository/TourConfigTemplateRepository.java
+++ b/src/main/java/com/tourya/api/repository/TourConfigTemplateRepository.java
@@ -27,10 +27,17 @@ public class TourConfigTemplateRepository {
         this.objectMapper = objectMapper;
     }
     public List<TourScheduleConfigResponse> findByProviderId(Provider provider) {
+        return findByProviderIdAndSubCategory(provider, null);
+    }
+
+    // TC-019 (#231): filtro opcional por subcategoria. Si viene null, devuelve todos los
+    // templates del provider. Si viene, filtra por c.sub_category = subCategory en el SP.
+    public List<TourScheduleConfigResponse> findByProviderIdAndSubCategory(Provider provider, String subCategory) {
         Integer  providerId = provider.getId();
 
-        Query query = entityManager.createNativeQuery("SELECT get_templates_by_provider(:providerId)");
+        Query query = entityManager.createNativeQuery("SELECT get_templates_by_provider(:providerId, :subCategory)");
         query.setParameter("providerId", providerId);
+        query.setParameter("subCategory", subCategory);
 
         List<String> results = query.getResultList();
         if (results == null || results.isEmpty()) {

--- a/src/main/java/com/tourya/api/services/TourConfigTemplateService.java
+++ b/src/main/java/com/tourya/api/services/TourConfigTemplateService.java
@@ -5,8 +5,14 @@ import org.springframework.security.core.Authentication;
 
 import java.util.List;
 
+// TC-019 (#231): overload con filtro opcional por subcategoria.
+// interface expandida abajo
+
 public interface TourConfigTemplateService {
     List<TourScheduleConfigResponse> getConfigTemplatesByProvider(Authentication connectedUser);
+
+    // TC-019 (#231): filtro opcional por subcategoria. Si viene null/blank, devuelve todos.
+    List<TourScheduleConfigResponse> getConfigTemplatesByProvider(Authentication connectedUser, String subCategory);
 }
 
 

--- a/src/main/java/com/tourya/api/services/TourScheduleConfigGeneralService.java
+++ b/src/main/java/com/tourya/api/services/TourScheduleConfigGeneralService.java
@@ -113,6 +113,15 @@ public class TourScheduleConfigGeneralService {
 
         config.setDaysOfWeek(new ArrayList<>(request.getDaysOfWeek()));
         config.setIsTemplate(request.getIsTemplate());
+        // TC-019 (#231): parsea el string subCategory al enum si viene. Tolera valores
+        // desconocidos (silent skip) — el frontend valida el catalogo.
+        if (request.getSubCategory() != null && !request.getSubCategory().isBlank()) {
+            try {
+                config.setSubCategory(com.tourya.api.constans.enums.TourSubCategoryEnum.of(request.getSubCategory()));
+            } catch (Exception ex) {
+                // Silent skip: subCategory desconocida no bloquea la creacion (retrocompatible).
+            }
+        }
         return config;
     }
 
@@ -234,6 +243,14 @@ public class TourScheduleConfigGeneralService {
         existingConfig.setLabel(request.getLabel());
         existingConfig.setDaysOfWeek(new ArrayList<>(request.getDaysOfWeek()));
         existingConfig.setIsTemplate(request.getIsTemplate()); // <-- Mapear isTemplate
+        // TC-019 (#231): permitir editar la subcategoria del template.
+        if (request.getSubCategory() != null && !request.getSubCategory().isBlank()) {
+            try {
+                existingConfig.setSubCategory(com.tourya.api.constans.enums.TourSubCategoryEnum.of(request.getSubCategory()));
+            } catch (Exception ex) {
+                // Silent skip.
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/tourya/api/services/impl/TourConfigTemplateServiceImpl.java
+++ b/src/main/java/com/tourya/api/services/impl/TourConfigTemplateServiceImpl.java
@@ -22,8 +22,14 @@ public class TourConfigTemplateServiceImpl implements TourConfigTemplateService 
 
     @Override
     public List<TourScheduleConfigResponse> getConfigTemplatesByProvider(Authentication connectedUser) {
+        return getConfigTemplatesByProvider(connectedUser, null);
+    }
+
+    @Override
+    public List<TourScheduleConfigResponse> getConfigTemplatesByProvider(Authentication connectedUser, String subCategory) {
         User user = ((User) connectedUser.getPrincipal());
         Provider provider = providerService.findByUserAndStatusActive(user);
-        return repository.findByProviderId(provider);
+        String normalized = (subCategory != null && !subCategory.isBlank()) ? subCategory : null;
+        return repository.findByProviderIdAndSubCategory(provider, normalized);
     }
 }


### PR DESCRIPTION
## Contexto

Refinamientos (items 2 y 3) del TC-019 (#231):
- Filtrar templates del dropdown en Configuración de Calendario del tour por subcategoría del tour.
- Agregar campo Subcategoría al form de creación de Template.

Fix crítico del 404 en el batch fue en PR #232 (mergeado).

## Cambios (9 archivos)

**Migración 086** — `tour_schedule_config.sub_category`:
- \`ALTER TABLE tour_schedule_config ADD COLUMN sub_category tour_subcategory_enum NULL;\`
- Recrea \`get_templates_by_provider(providerId, subCategory=NULL)\` con filtro opcional. Expone \`subCategory\` en el JSON.

**Entity + DTOs Java:**
- \`TourScheduleConfig\`: \`@Convert TourSubCategoryEnum sub_category\`.
- \`TourScheduleConfigCreationRequest\`: \`String subCategory\` (nullable).
- \`TourScheduleConfigResponse\`: \`String subCategory\`.

**Service:**
- \`buildConfigFromRequest\` + \`updateConfigProperties\`: parsea string → enum con \`TourSubCategoryEnum.of()\`. Silent skip para valores desconocidos (retrocompatible).

**Repository/Service/Controller:**
- \`TourConfigTemplateRepository.findByProviderIdAndSubCategory(provider, subCategory)\`.
- Service overload que pasa el filtro al repo.
- \`GET /tour-schedules/templates?subCategory=xxx\` (query param opcional).

## Retrocompatibilidad

- Clientes viejos que llamen \`GET /tour-schedules/templates\` sin subCategory → sigue devolviendo todos (comportamiento igual al anterior).
- Templates existentes tienen \`sub_category=NULL\` → al aplicar filtro por subcategoría se ocultan (no aplican a ninguna subcat específica). Deben ser editados por el provider para asignar.

## Estado migración
Aplicada a Cloud SQL dev (verificada con \`SELECT get_templates_by_provider(1, NULL)\` — 0 rows para provider 1, correcto).

## Test plan
- [ ] Deploy → como PROVIDER en form de creación de Template, seleccionar Subcategoría → guardar → BD tiene \`sub_category='snorkeling'\` (o el que elija).
- [ ] Editar el mismo template → cambiar subCategoría → persiste.
- [ ] En Configuración de Calendario de un tour con subCategory='snorkeling', hacer \`GET /tour-schedules/templates?subCategory=snorkeling\` → solo devuelve templates con esa subcat.
- [ ] Templates viejos con NULL → solo aparecen al llamar sin \`subCategory\` (o llamarlo con subCategory nulo).
- [ ] Frontend PR viene después de este merge (2 componentes: filtro dropdown en tour-schedule + campo select en template-form).