### PR TITLE
diag(TC-018 #227 reabierto): admin trigger DIMAR alert + logs INFO detallados

### DIFF
--- a/src/main/java/com/tourya/api/controller/AdminJobsController.java
+++ b/src/main/java/com/tourya/api/controller/AdminJobsController.java
@@ -1,6 +1,11 @@
 package com.tourya.api.controller;
 
+import com.tourya.api.exceptions.ResourceNotFoundException;
 import com.tourya.api.jobs.PendingReservationNoShowJob;
+import com.tourya.api.models.MaritimActivityReport;
+import com.tourya.api.repository.MaritimActivityReportRepository;
+import com.tourya.api.services.ReservationService;
+import com.tourya.api.services.maritime.events.MaritimeAlertCreatedEvent;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -8,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,6 +35,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminJobsController {
 
     private final PendingReservationNoShowJob pendingReservationNoShowJob;
+    private final ReservationService reservationService;
+    private final MaritimActivityReportRepository maritimActivityReportRepository;
 
     @PostMapping("/no-show/trigger")
     @PreAuthorize("hasAuthority('ADMIN')")
@@ -38,5 +46,37 @@ public class AdminJobsController {
         log.info("Admin trigger manual: PendingReservationNoShowJob.markNoShows()");
         pendingReservationNoShowJob.markNoShows();
         return ResponseEntity.ok("PendingReservationNoShowJob ejecutado. Revisar logs Cloud Run para el resultado.");
+    }
+
+    /**
+     * TC-018 (#227 reabierto): trigger sincrono del hook DIMAR para un reporte especifico.
+     * Ejecuta {@code cancelAffectedByRedAlert} en el mismo hilo (no async) para diagnostico
+     * y para re-procesar reportes cuyo listener original haya fallado o no se disparo
+     * (p.ej. reporte creado antes del deploy del fix).
+     */
+    @PostMapping("/dimar-alert/{reportId}/trigger")
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @Operation(summary = "Re-procesar hook DIMAR de un reporte especifico",
+            description = "Ejecuta sincronamente cancelAffectedByRedAlert para el reporte dado. Solo ADMIN.")
+    public ResponseEntity<String> triggerDimarAlert(@PathVariable("reportId") Long reportId) {
+        MaritimActivityReport report = maritimActivityReportRepository.findById(reportId)
+                .orElseThrow(() -> new ResourceNotFoundException("Maritime report not found: " + reportId));
+
+        MaritimeAlertCreatedEvent event = new MaritimeAlertCreatedEvent(
+                report.getId(),
+                report.getSubcategoryCode(),
+                report.getCountry() != null ? report.getCountry().getId() : null,
+                report.getState() != null ? report.getState().getId() : null,
+                report.getCity() != null ? report.getCity().getId() : null,
+                report.getReportStartDate(),
+                report.getReportEndDate(),
+                report.getFlag());
+
+        log.info("Admin trigger manual DIMAR alert: reportId={}, subcat={}, country={}, state={}, city={}, dates={}..{}, flag={}",
+                event.reportId(), event.subcategoryCode(), event.countryId(),
+                event.stateId(), event.cityId(), event.startDate(), event.endDate(), event.flag());
+
+        reservationService.cancelAffectedByRedAlert(event);
+        return ResponseEntity.ok("Hook DIMAR ejecutado para reporte " + reportId + ". Revisar logs Cloud Run.");
     }
 }

--- a/src/main/java/com/tourya/api/services/ReservationService.java
+++ b/src/main/java/com/tourya/api/services/ReservationService.java
@@ -1212,6 +1212,11 @@ public class ReservationService {
      */
     @Transactional
     public void cancelAffectedByRedAlert(MaritimeAlertCreatedEvent event) {
+        // TC-018 (#227 reabierto): log INFO detallado del inicio para diagnostico via Cloud Run logs.
+        log.info("BE-23 START cancelAffectedByRedAlert reportId={}, subcat={}, country={}, state={}, city={}, dates={}..{}, flag={}",
+                event.reportId(), event.subcategoryCode(), event.countryId(),
+                event.stateId(), event.cityId(), event.startDate(), event.endDate(), event.flag());
+
         com.tourya.api.constans.enums.TourSubCategoryEnum subCategory;
         try {
             subCategory = com.tourya.api.constans.enums.TourSubCategoryEnum.of(event.subcategoryCode());
@@ -1239,6 +1244,10 @@ public class ReservationService {
                 event.startDate(),
                 event.endDate(),
                 openStatuses);
+
+        // TC-018 (#227 reabierto): log del count antes del loop para saber si el query encontro reservas.
+        log.info("BE-23 alert {} query returned {} affected reservations (statuses={})",
+                event.reportId(), affected.size(), openStatuses);
 
         if (affected.isEmpty()) {
             log.info("BE-23 no affected reservations for alert {}", event.reportId());


### PR DESCRIPTION
## Contexto

Luis reportó en TC-018 (#227) que tras el fix del PR #229, al crear un reporte marítimo RED las reservas PENDING/RESCHEDULED **siguen sin cancelarse**.

Auditoría BD confirma:
- Reporte 46 en BD: \`subcat=parasail, loc=1/33/453, dates=2026-08-12..13, flag=RED\`, creado 2026-08-10 19:44 UTC.
- Reserva 329: \`PENDING, parasail, misma loc, schedule_date=2026-08-13\`.
- La query del hook (simulada manualmente contra la BD) **SÍ retorna esta reserva**.
- Sin embargo la reserva sigue en PENDING.

## Hipótesis

1. **Deploy timing**: el reporte 46 se creó a las 19:44 UTC y mi PR #229 se desplegó ~20:00 UTC. Cuando Luis creó el reporte el código nuevo aún no estaba corriendo. Pero incluso con el código viejo el listener debía dispararse (`create()` publicaba evento antes del PR).
2. Excepción silenciada en el flow del listener (post-commit + async → cualquier throw solo aparece como `log.warn`).
3. Bug en el flujo de credit/notification que rollbackea la tx.

## Este PR agrega diagnóstico (no fix)

**1. Nuevo endpoint admin trigger:**
\`\`\`
POST /admin/jobs/dimar-alert/{reportId}/trigger
\`\`\`
Ejecuta \`cancelAffectedByRedAlert\` sincronamente (no async) para un reporte específico. Permite:
- Re-procesar reportes cuyo listener original no se disparó.
- Ver excepciones en el response HTTP (no solo en logs).

**2. Logs INFO detallados en `cancelAffectedByRedAlert`:**
- Al INICIO: dump del event (reportId, subcat, loc, dates, flag).
- Después del query: count de affected + statuses buscados.

## Uso planeado tras deploy

1. Curl al trigger contra reporte 46 (auth ADMIN):
\`\`\`
POST /admin/jobs/dimar-alert/46/trigger
\`\`\`
2. Revisar logs Cloud Run — ahora tienen dumps completos.
3. Si canceló, sabemos que el fix funcionó pero el listener original no se disparó (deploy timing). Si no canceló, hay bug real en el service.
4. Si es lo segundo, siguiente PR con fix real.

## Test plan
- [ ] Deploy → curl endpoint contra reporte 46.
- [ ] Verificar en logs: aparece \"BE-23 START cancelAffectedByRedAlert reportId=46 ...\".
- [ ] Verificar en logs: aparece \"BE-23 alert 46 query returned N affected reservations\". Esperamos N=1 (reserva 329).
- [ ] Verificar en BD: `SELECT delivery_status FROM reservation WHERE reservation_id=329;` — debe ser CANCELED.