### PR TITLE
hotfix(TC-019 #231): @ColumnTransformer para cast PG enum tour_subcategory_enum

### DIFF
--- a/src/main/java/com/tourya/api/models/TourScheduleConfig.java
+++ b/src/main/java/com/tourya/api/models/TourScheduleConfig.java
@@ -6,6 +6,7 @@ import com.tourya.api.constans.enums.TourSubCategoryEnumConverter;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.ColumnTransformer;
 
 import java.time.LocalDate;
 import java.util.HashSet;
@@ -67,7 +68,10 @@ public class TourScheduleConfig extends BaseEntity {
 
     // TC-019 (#231): subcategoria que aplica al template. NULL para templates legacy
     // (creados antes de esta feature). El dropdown filtra por subCategory del tour.
+    // TC-019 hotfix: @ColumnTransformer con cast explicito ?::tour_subcategory_enum —
+    // sin esto el driver JDBC manda varchar y PG rechaza (mismo pattern que Tour.subCategory).
     @Convert(converter = TourSubCategoryEnumConverter.class)
     @Column(name = "sub_category", columnDefinition = "tour_subcategory_enum")
+    @ColumnTransformer(write = "?::tour_subcategory_enum")
     private TourSubCategoryEnum subCategory;
 }


### PR DESCRIPTION
## Regresión del PR #233

Luis reportó 500 al crear \`tour_schedule_config\` con \`sub_category\` (el campo introducido en TC-019 PR #233):

\`\`\`
ERROR: column \"sub_category\" is of type tour_subcategory_enum but expression is of type character varying
Position: 150
[insert into tour_schedule_config (...,sub_category,tour_id) values (?,?,?,?,?,?,?,?)]
\`\`\`

## Root cause

En PR #233 puse \`@Convert(TourSubCategoryEnumConverter)\` + \`@Column(columnDefinition=\"tour_subcategory_enum\")\` pero **olvidé `@ColumnTransformer(write = \"?::tour_subcategory_enum\")`**. Sin ese cast explícito en el SQL, Hibernate envía el valor como String/varchar y PG rechaza porque la columna es un enum PG.

## Fix

Replicar las 3 anotaciones que YA existen en \`Tour.subCategory\` (que funciona OK):
\`\`\`java
@Convert(converter = TourSubCategoryEnumConverter.class)
@Column(name = \"sub_category\", columnDefinition = \"tour_subcategory_enum\")
@ColumnTransformer(write = \"?::tour_subcategory_enum\")
private TourSubCategoryEnum subCategory;
\`\`\`

+ import de `org.hibernate.annotations.ColumnTransformer`.

Sin cambios de DDL, service ni endpoint. Solo entity.

## Test plan
- [ ] Deploy → como PROVIDER en tour-schedule crear un template con subcategoría → INSERT debe funcionar sin 500.
- [ ] Editar template existente → UPDATE también.
- [ ] Crear tour-schedule batch para un tour → si el template asociado tiene subcategoría, INSERT del schedule config asociado también funciona.