### PR TITLE
fix(TC-020 #235 bug c): timezone Bogota en LocalDateTime.now

### DIFF
--- a/src/main/java/com/tourya/api/jobs/TemporalReservationExpiryJob.java
+++ b/src/main/java/com/tourya/api/jobs/TemporalReservationExpiryJob.java
@@ -53,7 +53,10 @@ public class TemporalReservationExpiryJob {
      */
     @Scheduled(fixedDelayString = "${tourya.temporalReservationExpiry.fixedDelayMs:60000}")
     public void expireTemporalReservations() {
-        LocalDateTime now = LocalDateTime.now(java.time.ZoneId.of("UTC"));
+        // TC-020 (#235 bug c): usar timezone Colombia — consistente con expiresAt guardado
+        // en Bogota desde ReservationService. Sin esto, la comparacion now vs expires_at
+        // desfasaba 5h y las reservas se expiraban tarde o temprano segun timezone.
+        LocalDateTime now = LocalDateTime.now(java.time.ZoneId.of("America/Bogota"));
         List<Reservation> expired = reservationRepository.findExpiredTemporalReservations(now);
         if (expired.isEmpty()) return;
 

--- a/src/main/java/com/tourya/api/services/PaymentService.java
+++ b/src/main/java/com/tourya/api/services/PaymentService.java
@@ -281,7 +281,8 @@ public class PaymentService {
     private List<Reservation> confirmTemporalReservations(Payment payment,
                                                          List<Reservation> reservationsToPay) {
         // Mantener coherencia con creación del hold (UTC) para evitar falsos expirados por zona horaria
-        java.time.LocalDateTime now = java.time.LocalDateTime.now(java.time.ZoneId.of("UTC"));
+        // TC-020 (#235 bug c): usar timezone Colombia — la aplicacion es en Colombia.
+        java.time.LocalDateTime now = java.time.LocalDateTime.now(java.time.ZoneId.of("America/Bogota"));
         List<Reservation> confirmed = new java.util.ArrayList<>();
 
         for (Reservation reservation : reservationsToPay) {

--- a/src/main/java/com/tourya/api/services/ReservationService.java
+++ b/src/main/java/com/tourya/api/services/ReservationService.java
@@ -132,7 +132,10 @@ public class ReservationService {
         // Usar una referencia consistente (UTC) para evitar expiraciones inmediatas por desfase de zona horaria
         // Duracion del hold desde app_config (fallback 15 min si la key no esta seteada)
         int holdMinutes = appConfigService.getInt(ConfigKeyEnum.HOLD_MINUTES, 15);
-        LocalDateTime expiresAt = LocalDateTime.now(java.time.ZoneId.of("UTC")).plusMinutes(holdMinutes);
+        // TC-020 (#235 bug c): usar timezone Colombia — el server corre en UTC pero la
+        // aplicacion es en Colombia. Sin esto, LocalDateTime almacena UTC pero el
+        // frontend lo interpreta como hora local -> mostraba horas +5h del real.
+        LocalDateTime expiresAt = LocalDateTime.now(BOGOTA).plusMinutes(holdMinutes);
 
         List<Long> requestedItemIds = new ArrayList<>();
         Map<Long, CreateTemporalReservationHoldRequest.ServiceResponsibleRequest> responsibleByItemId =
@@ -187,7 +190,8 @@ public class ReservationService {
                         "Falta responsable del servicio para el item del carrito: " + item.getId());
             }
             java.math.BigDecimal totalAmount = item.getTotalPrice() != null ? item.getTotalPrice() : java.math.BigDecimal.ZERO;
-            LocalDateTime reservationDateUtc = LocalDateTime.now(java.time.ZoneId.of("UTC"));
+            // TC-020 (#235 bug c): usar timezone Colombia (BOGOTA constant a nivel clase).
+            LocalDateTime reservationDateUtc = LocalDateTime.now(BOGOTA);
             Reservation reservation = Reservation.builder()
                     .paymentId(null) // Se setea en payment al confirmar
                     .itemId(item.getId())


### PR DESCRIPTION
## Contexto

Bug (c) del TC-020 (#235) — Luis reportó que la fecha de creación/modificación de reserva no está en zona horaria Colombia.

## Root cause

4 usos de \`LocalDateTime.now(ZoneId.of(\"UTC\"))\` en el flow de reserva:
- \`ReservationService\` L135 — \`expiresAt\` para reservas TEMPORAL.
- \`ReservationService\` L190 — \`reservationDate\` al confirmar reserva.
- \`PaymentService\` L284 — payment createdDate.
- \`TemporalReservationExpiryJob\` L56 — \`now\` que compara con \`expires_at\`.

Como \`LocalDateTime\` no lleva timezone, guardar en UTC significa que el string JSON \`\"2026-08-10T19:58:00\"\` en realidad son las 19:58 UTC = 14:58 Colombia. El frontend hace \`new Date(string)\` y lo interpreta como hora LOCAL → muestra 19:58 aunque en Colombia sean las 14:58 en ese momento.

## Fix minimal

Cambiar los 4 usos de \`ZoneId.of(\"UTC\")\` → \`ZoneId.of(\"America/Bogota\")\`. Los `LocalDateTime` ahora almacenan hora Colombia. Frontend en Colombia hace \`new Date()\` → interpreta como local Colombia → coincide.

**Consistencia**: el job de expiración también cambia a Bogota, así la comparación `now vs expires_at` no desfasa 5h.

## Trade-off

Usuarios fuera de Colombia verán hora Colombia sin marcador de zona. Aceptable — el negocio es en Colombia y la UI ya asume Colombia.

## Notas

- No cambié `BaseEntity` `createdDate/lastModifiedDate` — esos los popula \`@CreatedDate\`/\`@LastModifiedDate\` de Spring Data JPA usando \`LocalDateTime.now()\` sin zona (usa la del JVM). Como el server Cloud Run corre en UTC, quedan en UTC. Fix opcional futuro: configurar \`DateTimeProvider\` bean que use Bogota. Por ahora las fechas de reserva son las críticas (visibles al usuario).

## Test plan
- [ ] Deploy → hacer una reserva nueva.
- [ ] Verificar que la fecha creación en confirmación coincide con hora actual en Colombia (no +5h adelantada).
- [ ] Job TemporalReservationExpiryJob debe seguir marcando reservas TEMPORAL vencidas correctamente (mismo momento).