### PR TITLE
feat(TC-021 #236 backend): scrub datos cliente al PROVIDER cuando falta >1 dia al tour

### DIFF
--- a/src/main/java/com/tourya/api/services/ReservationService.java
+++ b/src/main/java/com/tourya/api/services/ReservationService.java
@@ -966,6 +966,23 @@ public class ReservationService {
      * @return Una página de {@link ReservationDetailsResponse}.
      */
     @Transactional(readOnly = true)
+    /**
+     * TC-021 (#236): true si la scheduleDate esta a >= 2 dias del hoy Colombia.
+     * Cuando returns true, el flow debe ocultar datos personales del cliente al PROVIDER.
+     * Fail-closed: si no puede parsear scheduleDate, esconde (mejor privacidad).
+     */
+    private boolean shouldHideCustomerData(String scheduleDate) {
+        if (scheduleDate == null || scheduleDate.isBlank()) return true;
+        try {
+            LocalDate schedule = LocalDate.parse(scheduleDate.substring(0, Math.min(10, scheduleDate.length())));
+            LocalDate today = LocalDate.now(BOGOTA);
+            long diffDays = java.time.temporal.ChronoUnit.DAYS.between(today, schedule);
+            return diffDays > 1;
+        } catch (Exception ex) {
+            return true;
+        }
+    }
+
     public PageResponse<ReservationDetailsResponse> getProviderReservations(
             int page,
             int size,
@@ -1013,14 +1030,32 @@ public class ReservationService {
                         size
                 );
 
+        // TC-021 (#236): scrub datos personales del cliente cuando caller es PROVIDER
+        // (no ADMIN/BACKOFFICE) y falta mas de 1 dia para el scheduleDate. Defense-in-depth
+        // del guard frontend en provider-tour-management (canSeeCustomerData). Evita que
+        // un provider bypass la UI llamando /reservations?providerId=X directamente.
+        boolean scrubCustomerData = Utils.isProviderSide(roles) && !Utils.isTouryaBackoffice(roles);
+
         for (ReservationDetailsResponse reservation : content) {
             enrichCustomerProfileImage(reservation);
+
+            if (scrubCustomerData && shouldHideCustomerData(reservation.getScheduleDate())) {
+                reservation.setPayerName(null);
+                reservation.setPayerEmail(null);
+                reservation.setPayerPhone(null);
+                reservation.setPayerDocumentType(null);
+                reservation.setPayerDocumentNumber(null);
+                reservation.setServiceResponsibleName(null);
+                reservation.setServiceResponsibleEmail(null);
+                reservation.setServiceResponsiblePhone(null);
+            }
+
             try {
                 RescheduleValidationResponse validation = validateRescheduleReservation(
                         reservation.getReservationId(), connectedUser);
                 reservation.setCanReschedule(validation.getCanReschedule());
             } catch (Exception e) {
-                log.warn("Error validating reschedule for reservation {}: {}", 
+                log.warn("Error validating reschedule for reservation {}: {}",
                         reservation.getReservationId(), e.getMessage());
                 reservation.setCanReschedule(false);
             }


### PR DESCRIPTION
## Contexto

Defense-in-depth del guard frontend PR #106. Evita que un provider bypass la UI llamando \`GET /reservations?providerId=X\` directamente y vea \`payerName/Email/Phone/Doc*\` + \`serviceResponsible*\` del cliente antes del día -1 del tour.

## Cambios (1 archivo, +26 líneas)

**`ReservationService.java`:**

1. Nuevo helper `shouldHideCustomerData(scheduleDate)`:
   - True si `diffDays > 1` respecto \`LocalDate.now(BOGOTA)\`.
   - **Fail-closed**: si no puede parsear scheduleDate, retorna true (esconder = mejor privacidad).

2. En `getProviderReservations`, dentro del `for` de post-processing:
   - Bandera \`scrubCustomerData = isProviderSide && !isTouryaBackoffice\`.
   - Si activa Y \`shouldHideCustomerData(schedule) = true\`, seteo a null: \`payerName, payerEmail, payerPhone, payerDocumentType, payerDocumentNumber, serviceResponsibleName, serviceResponsibleEmail, serviceResponsiblePhone\`.

Preserva `tourName, providerPrice, scheduleDate, totalTourists, tourImageUrl` — provider sigue viendo la info operativa del tour, solo se ocultan datos personales del cliente.

## Reglas efectivas

| Rol | Regla |
|---|---|
| **PROVIDER puro / PROVIDER_OPERATOR** | `diffDays > 1` → scrub. `<= 1` (mañana/hoy/pasado) → visible. |
| **ADMIN / BACKOFFICE_OPERATION** | Siempre visibles (\`isTouryaBackoffice=true\` excluye). |
| **CLIENT** | No aplica (customerUserId branch else). |

## Alcance

Endpoint afectado: `GET /reservations` (paginado provider/admin). Otros endpoints (\`GET /reservations/{id}\`, \`GET /reservations/qr/{qrUrl}\`) fuera de scope — el modal del frontend usa el paginado. Si en el futuro se detecta bypass por esos endpoints, aplicar el mismo pattern.

## Test plan
- [ ] Deploy → como PROVIDER llamar \`GET /reservations\` para una reserva con scheduleDate >= 2 días: response debe traer payer/serviceResponsible con \`null\`.
- [ ] Como PROVIDER, misma llamada pero reserva con scheduleDate mañana/hoy: response debe traer los datos completos.
- [ ] Como ADMIN o BACKOFFICE: response siempre completa sin importar la fecha.
- [ ] Frontend PR #106 sigue funcionando (ya oculta en UI aunque backend devuelva null).