### PR TITLE
fix(TC-017 #220): tour_address country/state/city NULLABLE para Hotel Pickup

### DIFF
--- a/database/migrations/087_tc017_tour_address_hotel_pickup_nullable.sql
+++ b/database/migrations/087_tc017_tour_address_hotel_pickup_nullable.sql
@@ -1,0 +1,50 @@
+-- Migration 087: TC-017 (#220) — tour_address country/state/city NULLABLE cuando addressType='Hotel Pickup'
+-- Date: 2026-08-11
+-- Description:
+--   Cuando un tour es Hotel Pickup (recogida en el hotel del turista) no hay pais/estado/ciudad
+--   fija — la ubicacion es la del hotel del cliente al momento de la reserva. El backend Java
+--   ya fue relajado en PRs #226 y #228 (guard null en country/state/city lookup, enum matcher
+--   tolerante), pero la BD sigue con NOT NULL en tour_address.country_id/state_id/city_id, lo
+--   que hace fallar el INSERT con:
+--     ERROR: null value in column "country_id" of relation "tour_address" violates not-null constraint
+--
+--   Cambios (idempotentes):
+--   (a) Hace NULLABLE tour_address.country_id, state_id, city_id (DROP NOT NULL).
+--   (b) Agrega CHECK constraint tour_address_geo_required_unless_hotel_pickup:
+--       cuando address_type != 'Hotel Pickup', los tres geo IDs deben ser NOT NULL.
+--       Solo 'Hotel Pickup' permite las 3 columnas NULL. Se crea NOT VALID para no romper
+--       filas existentes (no deberia haberlas violando dado que los NOT NULL previos ya lo
+--       garantizaban), y luego se valida.
+--
+--   Nota: el valor almacenado en address_type es el display value del enum
+--   (AddressTypeEnum stores getValue() = 'Hotel Pickup', no la key 'HOTEL_PICKUP').
+--   Verificado en com.tourya.api.constans.enums.AddressTypeEnumConverter.
+
+-- (a) Relajar NOT NULL — idempotente: DROP NOT NULL no falla si ya es nullable.
+ALTER TABLE public.tour_address ALTER COLUMN country_id DROP NOT NULL;
+ALTER TABLE public.tour_address ALTER COLUMN state_id   DROP NOT NULL;
+ALTER TABLE public.tour_address ALTER COLUMN city_id    DROP NOT NULL;
+
+-- (b) CHECK constraint — solo Hotel Pickup admite geo NULL.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'tour_address_geo_required_unless_hotel_pickup'
+          AND conrelid = 'public.tour_address'::regclass
+    ) THEN
+        ALTER TABLE public.tour_address
+            ADD CONSTRAINT tour_address_geo_required_unless_hotel_pickup
+            CHECK (
+                address_type = 'Hotel Pickup'
+                OR (country_id IS NOT NULL AND state_id IS NOT NULL AND city_id IS NOT NULL)
+            )
+            NOT VALID;
+    END IF;
+END $$;
+
+-- Validar el constraint. Si alguna fila legacy no cumple, esto fallara y hay que
+-- revisar/backfillear antes de mergear. Con el schema previo (NOT NULL en las 3
+-- columnas) toda fila existente cumple la parte OR, asi que deberia pasar limpio.
+ALTER TABLE public.tour_address
+    VALIDATE CONSTRAINT tour_address_geo_required_unless_hotel_pickup;

--- a/src/main/java/com/tourya/api/models/TourAddress.java
+++ b/src/main/java/com/tourya/api/models/TourAddress.java
@@ -39,21 +39,21 @@ public class TourAddress extends BaseEntity {
     private Tour tour;
 
     // Many-to-One relationship with Country
-    //@ManyToOne
+    // TC-017 (#220): nullable=true — HOTEL_PICKUP no tiene ubicacion fisica.
+    // La regla de negocio "geo requerido salvo Hotel Pickup" se enforce en la BD
+    // via CHECK constraint tour_address_geo_required_unless_hotel_pickup (migration 087).
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "country_id", nullable = false)
+    @JoinColumn(name = "country_id")
     private Country country;
 
     // Many-to-One relationship with State
-    //@ManyToOne
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "state_id", nullable = false)
+    @JoinColumn(name = "state_id")
     private State state;
 
     // Many-to-One relationship with City
-    //@ManyToOne
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "city_id", nullable = false)
+    @JoinColumn(name = "city_id")
     private City city;
 
     @Column(name = "latitude")


### PR DESCRIPTION
## Contexto

Luis reportó en #220 (2026-08-11) que editar el tour id=36 con `addressType: "Hotel Pickup"` seguía respondiendo **500**:

```
ERROR: null value in column "country_id" of relation "tour_address" violates not-null constraint
Detail: Failing row contains (144, 36, null, null, null, 0, 0, null, ..., 48, null, Hotel Pickup, null).
```

El backend Java ya había sido relajado en PRs #226 (enum `HOTEL_PICKUP`) y #228 (guard null en lookups), pero la BD seguía con `NOT NULL` en `tour_address.country_id/state_id/city_id`, así que el INSERT explotaba antes de llegar al fallback aplicativo.

## Cambios

### `database/migrations/087_tc017_tour_address_hotel_pickup_nullable.sql`
- `ALTER TABLE tour_address ALTER COLUMN country_id/state_id/city_id DROP NOT NULL` — idempotente (no falla si ya son nullable).
- Nuevo CHECK `tour_address_geo_required_unless_hotel_pickup`:
  ```
  address_type = 'Hotel Pickup'
  OR (country_id IS NOT NULL AND state_id IS NOT NULL AND city_id IS NOT NULL)
  ```
  Solo Hotel Pickup admite geo NULL; el resto (Meeting Point / End Point / Pick-up Point) sigue exigiendo los tres. Creado `NOT VALID` + `VALIDATE CONSTRAINT` para no romper filas existentes (todas cumplen por el schema previo).

### `src/main/java/com/tourya/api/models/TourAddress.java`
- Elimina `nullable = false` de los `@JoinColumn` de `country/state/city`. La invariante geo-requerido-salvo-hotel-pickup queda enforce en BD.

## Verificación end-to-end (Cloud SQL dev, tourya-dev-db)

Migración aplicada limpiamente (`ALTER TABLE / DO / ALTER TABLE`). Confirmado:

```sql
SELECT column_name, is_nullable FROM information_schema.columns
WHERE table_schema='public' AND table_name='tour_address'
  AND column_name IN ('country_id','state_id','city_id');
-- city_id | YES ; country_id | YES ; state_id | YES
```

Inserts de prueba (BEGIN/ROLLBACK):

- `INSERT ... (NULL, NULL, NULL, ..., 'Hotel Pickup', ...)` -> **OK** (id 145, address_type Hotel Pickup, luego rollback).
- `INSERT ... (NULL, NULL, NULL, ..., 'Meeting Point', ...)` -> **rechazado** por CHECK `tour_address_geo_required_unless_hotel_pickup`.

## Test plan

- [ ] Franklin re-ejecuta el payload de Luis (tour id=36, `addressType: "Hotel Pickup"`) contra `POST /api/v1/tour/user/saveAll` una vez desplegado → 200/201, sin `not-null violation`.
- [ ] Editar cualquier tour existente con `addressType: "Meeting Point"` + geo válido → sigue funcionando.
- [ ] Intentar guardar `Meeting Point` con `countryId=null` → 500/400 (rechazo por CHECK) — comportamiento correcto, la app debería validar antes.
- [ ] Confirmar en Cloud Run logs que ya no aparece `null value in column "country_id"`.

## Refs

- Issue: #220 (TC-017)
- Previos: #226 (enum), #228 (guard null lookups)