### PR TITLE
fix(TC-019 #231): 3 regresiones de precio (batch, reagendamiento, disponibilidad)

### DIFF
--- a/database/migrations/088_tc019_backfill_schedule_price_tourya_margin.sql
+++ b/database/migrations/088_tc019_backfill_schedule_price_tourya_margin.sql
@@ -1,0 +1,383 @@
+-- Migration 088: TC-019 (#231) — Fix 3 regresiones de precio en tour_schedule / disponibilidad
+-- Date: 2026-08-11
+-- Description:
+--   Luis (2026-08-11) reporto 3 regresiones que ya funcionaban antes:
+--     R1) POST /api/v1/tour-schedules/batch guarda price = provider_price (sin margen Tourya).
+--         Causa raiz: en tour_schedule_config_slot muchos slots tienen slot_porcentaje_tourya = 0
+--         (ej. slot 686 de tour 36 - reseteado por migracion 054). Combinado con BE-02 que solo
+--         hereda tour.porcentaje_tourya en slots NUEVOS, los slots existentes recalculan a 0%.
+--     R2) Reagendamiento muestra price = providerPrice. Causa: SearchTourScheduleSlotPercentageEnricher
+--         intencionalmente ignora slot.slot_porcentaje_tourya y usa 0 cuando no hay override por dia.
+--     R3) Disponibilidad para reagendar muestra bookings=0 aunque existan reservas. Causa: la
+--         migracion 085 (TC-018b DIMAR) reescribio sp_get_tour_schedule_json usando el campo
+--         denormalizado sl.bookings en vez del helper fn_slot_booked_units_on_schedule(sl.id, s.id)
+--         introducido por TC-004 en la migracion 078 — regresion accidental al copiar el SP.
+--
+--   Esta migracion:
+--     PARTE 1) Backfill de slot_porcentaje_tourya al valor default del tour donde el slot esta en 0
+--              y el tour tiene margen > 0 (asumimos "0" es legacy no-inicializado por migracion 043).
+--     PARTE 2) Backfill de tour_schedule_config_price.price = provider_price * (1 + slot_pct)
+--              donde price = provider_price y slot_pct > 0 (drift acumulado).
+--     PARTE 3) Restaura sp_get_tour_schedule_json con TC-004 (fn_slot_booked_units_on_schedule)
+--              + TC-018b (blockedByMaritimeReport). Copia la version 085 y solo cambia sl.bookings.
+--
+--   Idempotente: los WHERE filtran solo filas afectadas. Ejecutar 2 veces = no-op.
+
+------------------------------------------------------------------------
+-- PARTE 1: backfill slot_porcentaje_tourya en slots con drift a 0
+------------------------------------------------------------------------
+UPDATE public.tour_schedule_config_slot sl
+SET slot_porcentaje_tourya = COALESCE(t.porcentaje_tourya, 0)
+FROM public.tour_schedule_config sc
+JOIN public.tour t ON t.id = sc.tour_id
+WHERE sl.config_id = sc.id
+  AND (sl.slot_porcentaje_tourya IS NULL OR sl.slot_porcentaje_tourya = 0)
+  AND COALESCE(t.porcentaje_tourya, 0) > 0;
+
+------------------------------------------------------------------------
+-- PARTE 2: recalcular price base cuando quedo igual a provider_price (drift)
+--          y el slot ya tiene un porcentaje > 0.
+------------------------------------------------------------------------
+UPDATE public.tour_schedule_config_price p
+SET price = ROUND(p.provider_price * (1 + COALESCE(sl.slot_porcentaje_tourya, 0)), 2)
+FROM public.tour_schedule_config_slot sl
+WHERE p.slot_id = sl.id
+  AND p.provider_price IS NOT NULL
+  AND p.provider_price > 0
+  AND p.price = p.provider_price
+  AND COALESCE(sl.slot_porcentaje_tourya, 0) > 0;
+
+------------------------------------------------------------------------
+-- PARTE 3: sp_get_tour_schedule_json — restore TC-004 helper + keep DIMAR flag.
+--          Basado en migracion 085 (TC-018b) con la unica diferencia de reemplazar
+--          sl.bookings por public.fn_slot_booked_units_on_schedule(sl.id, s.id).
+------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.sp_get_tour_schedule_json(jsonb);
+
+CREATE OR REPLACE FUNCTION public.sp_get_tour_schedule_json(filters jsonb)
+ RETURNS TABLE(result jsonb)
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  v_page int := COALESCE((filters->>'page')::int, 0);
+  v_size int := COALESCE((filters->>'size')::int, 10);
+
+  v_start_date date := COALESCE((filters->>'start_date')::date, (filters->>'startDate')::date);
+  v_end_date   date := COALESCE((filters->>'end_date')::date,   (filters->>'endDate')::date);
+
+  v_state_txt text := NULLIF(COALESCE(filters->>'state', filters->>'stateId'), '');
+  v_city_txt  text := NULLIF(COALESCE(filters->>'city',  filters->>'cityId'),  '');
+
+  v_provider_state_txt text := NULLIF(filters->>'providerStateId', '');
+  v_provider_city_txt  text := NULLIF(filters->>'providerCityId',  '');
+
+  v_duration_txt      text := NULLIF(filters->>'duration','');
+  v_category_txt      text := NULLIF(COALESCE(filters->>'category', filters->>'categoryId'), '');
+  v_duration_type_txt text := NULLIF(COALESCE(filters->>'duration_type', filters->>'durationType'), '');
+  v_age_type_txt      text := UPPER(NULLIF(COALESCE(filters->>'age_type', filters->>'ageType'), ''));
+  v_category_ids int[] := CASE
+    WHEN filters ? 'categoryIds' AND jsonb_typeof(filters->'categoryIds') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'categoryIds')::int)
+    WHEN NULLIF(COALESCE(filters->>'category', filters->>'categoryId'), '') IS NOT NULL THEN
+      ARRAY[COALESCE(filters->>'category', filters->>'categoryId')::int]
+    ELSE NULL
+  END;
+
+  v_sub_category_txt  text := NULLIF(COALESCE(filters->>'subCategory', filters->>'sub_category'), '');
+  v_duration_enum_txt text := NULLIF(COALESCE(filters->>'durationEnum', filters->>'duration_enum'), '');
+  v_time_of_day_txt   text := NULLIF(COALESCE(filters->>'timeOfDay', filters->>'time_of_day'), '');
+  v_sub_categories text[] := CASE
+    WHEN filters ? 'subCategories' AND jsonb_typeof(filters->'subCategories') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'subCategories'))
+    WHEN NULLIF(COALESCE(filters->>'subCategory', filters->>'sub_category'), '') IS NOT NULL THEN
+      ARRAY[COALESCE(filters->>'subCategory', filters->>'sub_category')]
+    ELSE NULL
+  END;
+  v_duration_enums text[] := CASE
+    WHEN filters ? 'durationEnums' AND jsonb_typeof(filters->'durationEnums') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'durationEnums'))
+    WHEN NULLIF(COALESCE(filters->>'durationEnum', filters->>'duration_enum'), '') IS NOT NULL THEN
+      ARRAY[COALESCE(filters->>'durationEnum', filters->>'duration_enum')]
+    ELSE NULL
+  END;
+  v_time_of_day_arr text[] := CASE
+    WHEN filters ? 'timeOfDay' AND jsonb_typeof(filters->'timeOfDay') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'timeOfDay'))
+    WHEN filters ? 'time_of_day' AND jsonb_typeof(filters->'time_of_day') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'time_of_day'))
+    WHEN NULLIF(COALESCE(filters->>'timeOfDay', filters->>'time_of_day'), '') IS NOT NULL THEN
+      ARRAY[COALESCE(filters->>'timeOfDay', filters->>'time_of_day')]
+    ELSE NULL
+  END;
+
+  v_min_price numeric := COALESCE(NULLIF(filters->>'min_price','')::numeric,
+                                   NULLIF(filters->>'minPrice','')::numeric);
+  v_max_price numeric := COALESCE(NULLIF(filters->>'max_price','')::numeric,
+                                   NULLIF(filters->>'maxPrice','')::numeric);
+
+  v_tag text := NULLIF(COALESCE(filters->>'tag', filters->>'tags'), '');
+  v_tag_ids int[] := CASE
+    WHEN filters ? 'tagIds' AND jsonb_typeof(filters->'tagIds') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'tagIds')::int)
+    ELSE NULL
+  END;
+  v_tag_names text[] := CASE
+    WHEN filters ? 'tags' AND jsonb_typeof(filters->'tags') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'tags'))
+    WHEN NULLIF(COALESCE(filters->>'tag', filters->>'tags'), '') IS NOT NULL THEN
+      ARRAY[COALESCE(filters->>'tag', filters->>'tags')]
+    ELSE NULL
+  END;
+  v_text_search text := NULLIF(filters->>'textSearch','');
+
+  v_tour_id int := (filters->>'tourId')::int;
+  v_tour_ids int[] := CASE
+    WHEN filters ? 'tourIds' AND jsonb_typeof(filters->'tourIds') = 'array' THEN
+      ARRAY(SELECT jsonb_array_elements_text(filters->'tourIds')::int)
+    ELSE NULL
+  END;
+  v_requested_units int := COALESCE(
+    NULLIF(COALESCE(filters->>'requestedUnits', filters->>'participants', filters->>'quantity'), '')::int,
+    NULL
+  );
+  v_language text := COALESCE(NULLIF(filters->>'language', ''), 'es');
+BEGIN
+  RETURN QUERY
+  SELECT jsonb_build_object(
+    'tour', jsonb_build_object(
+      'id', t.id,
+      'name', t.name,
+      'description', t.description,
+      'categoryId', t.category_id,
+      'categoryName', tc.name,
+      'duration', t.duration,
+      'durationType', t.duration_type,
+      'rating', t.rating,
+      'status', t.status,
+      'priceType', t.price_type,
+      'maxPeople', t.max_people,
+      'isUnlimitedCapacity', t.is_unlimited_capacity,
+      'subCategory', t.sub_category,
+      'subCategoryName', tscm.display_name,
+      'durationEnum', t.duration_enum,
+      'timeOfDay', t.time_of_day,
+      'tags', COALESCE((
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'id', tg.id,
+            'name', tg.nombre,
+            'category', td.nombre
+          )
+        )
+        FROM tour_tags tt
+        JOIN tags tg ON tg.id = tt.tag_id
+        JOIN tag_dimensions td ON td.id = tg.dimension_id
+        WHERE tt.tour_id = t.id
+      ), '[]'::jsonb),
+      'address', jsonb_build_object(
+        'country', a.country_id,
+        'state', a.state_id,
+        'city', a.city_id,
+        'address', a.address,
+        'latitude', a.latitude,
+        'longitude', a.longitude
+      ),
+      'gallery', COALESCE((
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'id', g.id,
+            'imageUrl', g.image_url,
+            'description', g.description,
+            'order', g.order_index
+          )
+        )
+        FROM tour_gallery g
+        WHERE g.tour_id = t.id
+      ), '[]'::jsonb)
+    ),
+    'schedules', COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', s.id,
+          'scheduleDate', s.schedule_date,
+          'status', s.status,
+          -- TC-018 (#227) Bug B: flag para el frontend. Backend duplica el guard en cart.
+          'blockedByMaritimeReport', EXISTS (
+            SELECT 1
+            FROM maritim_activity_report mar
+            WHERE mar.flag = 'RED'
+              AND mar.subcategory_code = t.sub_category::text
+              AND mar.country_id = a.country_id
+              AND mar.state_id = a.state_id
+              AND mar.city_id = a.city_id
+              AND s.schedule_date BETWEEN mar.report_start_date AND mar.report_end_date
+          ),
+          'config', jsonb_build_object(
+            'id', sc.id,
+            'slots', COALESCE((
+              SELECT jsonb_agg(
+                jsonb_build_object(
+                  'slotId', sl.id,
+                  'startTime', sl.start_time,
+                  'endTime', sl.end_time,
+                  'capacity', sl.capacity,
+                  -- TC-004 / TC-019 #231: bookings/availability por (slot_id, schedule_id) en runtime.
+                  -- Migracion 085 accidentalmente regreso a sl.bookings; esto restaura el fix TC-004.
+                  'bookings', public.fn_slot_booked_units_on_schedule(sl.id, s.id),
+                  'availability', GREATEST(0, COALESCE(sl.capacity, 0) - public.fn_slot_booked_units_on_schedule(sl.id, s.id)),
+                  'minCapacityCalc', sl.min_capacity_calc,
+                  'checkAvailability', sl.check_availability,
+                  'prices', COALESCE((
+                    SELECT jsonb_agg(
+                      jsonb_build_object(
+                        'ageType', p.age_type,
+                        'minAge', arc.min_age,
+                        'maxAge', arc.max_age,
+                        'price', p.price,
+                        'providerPrice', p.provider_price
+                      )
+                    )
+                    FROM tour_schedule_config_price p
+                    LEFT JOIN public.age_range_config arc ON arc.age_type = CAST(p.age_type AS character varying)
+                    WHERE p.slot_id = sl.id
+                      AND (v_age_type_txt IS NULL OR CAST(p.age_type AS character varying) = v_age_type_txt)
+                      AND (v_min_price IS NULL OR p.price >= v_min_price)
+                      AND (v_max_price IS NULL OR p.price <= v_max_price)
+                  ), '[]'::jsonb)
+                )
+                ORDER BY sl.start_time
+              )
+              FROM tour_schedule_config_slot sl
+              WHERE sl.config_id = sc.id
+                AND (
+                  v_requested_units IS NULL
+                  OR COALESCE(t.is_unlimited_capacity, false) = true
+                  -- TC-004: filtro por capacidad usa conteo por-fecha.
+                  OR GREATEST(0, COALESCE(sl.capacity, 0) - public.fn_slot_booked_units_on_schedule(sl.id, s.id)) >= v_requested_units
+                )
+            ), '[]'::jsonb)
+          )
+        )
+        ORDER BY s.schedule_date ASC
+      )
+      FROM tour_schedule s
+      LEFT JOIN tour_schedule_config sc ON sc.id = s.config_id
+      WHERE s.tour_id = t.id
+        AND (v_start_date IS NULL OR s.schedule_date >= v_start_date)
+        AND (v_end_date IS NULL OR s.schedule_date <= v_end_date)
+        AND (
+          v_requested_units IS NULL
+          OR COALESCE(t.is_unlimited_capacity, false) = true
+          OR EXISTS (
+            SELECT 1
+            FROM tour_schedule_config_slot sl_filter
+            WHERE sl_filter.config_id = sc.id
+              -- TC-004: filtro por capacidad del schedule usa conteo por-fecha.
+              AND GREATEST(0, COALESCE(sl_filter.capacity, 0) - public.fn_slot_booked_units_on_schedule(sl_filter.id, s.id)) >= v_requested_units
+          )
+        )
+    ), '[]'::jsonb)
+  ) AS result
+  FROM tour t
+  JOIN tour_category tc ON tc.id = t.category_id
+  JOIN tour_address a ON a.tour_id = t.id
+  JOIN provider pr ON pr.id = t.provider_id
+  LEFT JOIN tour_business_subcategory_mapping tscm ON tscm.subcategory_code = t.sub_category::text
+  WHERE
+    t.status = 'accepted'
+    AND (v_tour_id IS NULL OR t.id = v_tour_id)
+    AND (v_tour_ids IS NULL OR t.id = ANY(v_tour_ids))
+    AND (v_state_txt IS NULL OR a.state_id::text = v_state_txt)
+    AND (v_city_txt IS NULL OR a.city_id::text = v_city_txt)
+    AND (v_provider_state_txt IS NULL OR pr.state_id::text = v_provider_state_txt)
+    AND (v_provider_city_txt IS NULL OR pr.city_id::text = v_provider_city_txt)
+    AND (v_duration_txt IS NULL OR t.duration::text = v_duration_txt)
+    AND (v_duration_type_txt IS NULL OR t.duration_type::text = v_duration_type_txt)
+    AND (v_category_ids IS NULL OR t.category_id = ANY(v_category_ids))
+    AND (v_sub_categories IS NULL OR t.sub_category::text = ANY(v_sub_categories))
+    AND (v_duration_enums IS NULL OR t.duration_enum::text = ANY(v_duration_enums))
+    AND (
+      v_time_of_day_arr IS NULL
+      OR (
+        t.time_of_day IS NOT NULL
+        AND EXISTS (
+          SELECT 1
+          FROM unnest(t.time_of_day::text[]) AS tod(value)
+          WHERE tod.value = ANY(v_time_of_day_arr)
+        )
+      )
+    )
+    AND (
+      (v_tag_ids IS NULL AND v_tag_names IS NULL) OR EXISTS (
+        SELECT 1
+        FROM tour_tags tt2
+        JOIN tags tg2 ON tg2.id = tt2.tag_id
+        WHERE tt2.tour_id = t.id
+          AND (
+            (v_tag_ids IS NOT NULL AND tg2.id = ANY(v_tag_ids))
+            OR (v_tag_names IS NOT NULL AND tg2.nombre = ANY(v_tag_names))
+          )
+      )
+    )
+    AND (
+      v_text_search IS NULL OR
+      (t.name->>v_language) ILIKE '%' || v_text_search || '%' OR
+      (t.description->>v_language) ILIKE '%' || v_text_search || '%'
+    )
+    AND (
+      (v_start_date IS NULL AND v_end_date IS NULL)
+      OR EXISTS (
+        SELECT 1 FROM tour_schedule sx
+        LEFT JOIN tour_schedule_config scx ON scx.id = sx.config_id
+        WHERE sx.tour_id = t.id
+          AND (v_start_date IS NULL OR sx.schedule_date >= v_start_date)
+          AND (v_end_date IS NULL OR sx.schedule_date <= v_end_date)
+          AND (
+            v_requested_units IS NULL
+            OR COALESCE(t.is_unlimited_capacity, false) = true
+            OR EXISTS (
+              SELECT 1
+              FROM tour_schedule_config_slot slx
+              WHERE slx.config_id = scx.id
+                -- TC-004: pre-filtro EXISTS ahora también usa conteo por-fecha.
+                AND GREATEST(0, COALESCE(slx.capacity, 0) - public.fn_slot_booked_units_on_schedule(slx.id, sx.id)) >= v_requested_units
+            )
+          )
+      )
+    )
+    AND (
+      v_min_price IS NULL
+      OR EXISTS (
+        SELECT 1
+        FROM tour_schedule s2
+        JOIN tour_schedule_config sc2 ON sc2.id = s2.config_id
+        JOIN tour_schedule_config_slot sl2 ON sl2.config_id = sc2.id
+        JOIN tour_schedule_config_price p2 ON p2.slot_id = sl2.id
+        WHERE s2.tour_id = t.id
+          AND (v_start_date IS NULL OR s2.schedule_date >= v_start_date)
+          AND (v_end_date IS NULL OR s2.schedule_date <= v_end_date)
+          AND CAST(p2.age_type AS character varying) = 'ADULT'
+          AND p2.price >= v_min_price
+      )
+    )
+    AND (
+      v_max_price IS NULL
+      OR EXISTS (
+        SELECT 1
+        FROM tour_schedule s3
+        JOIN tour_schedule_config sc3 ON sc3.id = s3.config_id
+        JOIN tour_schedule_config_slot sl3 ON sl3.config_id = sc3.id
+        JOIN tour_schedule_config_price p3 ON p3.slot_id = sl3.id
+        WHERE s3.tour_id = t.id
+          AND (v_start_date IS NULL OR s3.schedule_date >= v_start_date)
+          AND (v_end_date IS NULL OR s3.schedule_date <= v_end_date)
+          AND CAST(p3.age_type AS character varying) = 'ADULT'
+          AND p3.price <= v_max_price
+      )
+    )
+  GROUP BY t.id, tc.id, a.id, pr.id, tscm.subcategory_code, tscm.display_name
+  ORDER BY t.id ASC
+  LIMIT v_size
+  OFFSET v_page * v_size;
+END;
+$function$;

--- a/src/main/java/com/tourya/api/services/ReservationService.java
+++ b/src/main/java/com/tourya/api/services/ReservationService.java
@@ -113,6 +113,7 @@ public class ReservationService {
     private final TourPrincipalOperatorService tourPrincipalOperatorService;
     private final TourAddressMapper tourAddressMapper;
     private final TourIncludesExcludesMapper tourIncludesExcludesMapper;
+    private final TourScheduleOverrideService tourScheduleOverrideService; // TC-019 (#231) reschedule price uses overrides
 
     /**
      * Método createReservation removido - las reservas se crean automáticamente con los pagos
@@ -2535,8 +2536,12 @@ public class ReservationService {
                     .findFirst()
                     .orElseThrow(() -> new ResourceNotFoundException(
                             "Price not found for ageType " + ageType + " in slot " + slotId));
-            
-            BigDecimal unitPrice = priceConfig.getPrice();
+
+            // TC-019 (#231): usar precio efectivo (override por schedule si existe, si no el base
+            // del config — que ya viene con margen tras el backfill migracion 088). Antes usaba
+            // priceConfig.getPrice() directo, lo que ignoraba overrides ADMIN.
+            BigDecimal unitPrice = tourScheduleOverrideService.resolveSalePrice(
+                    newSchedule.getId(), priceConfig.getId(), priceConfig.getPrice());
             
             // Calcular precio según priceType del tour
             BigDecimal detailTotalPrice;

--- a/src/main/java/com/tourya/api/services/TourScheduleConfigGeneralService.java
+++ b/src/main/java/com/tourya/api/services/TourScheduleConfigGeneralService.java
@@ -316,14 +316,25 @@ public class TourScheduleConfigGeneralService {
             // BE-02 (RN-015): para slots nuevos, heredar el porcentaje default del tour.
             // Slots existentes conservan su slot_porcentaje_tourya actual (posiblemente
             // override manual del ADMIN).
+            //
+            // TC-019 (#231): si el slot existente tiene slotPorcentajeTourya = 0 (o null) pero
+            // el tour tiene margen > 0, tratamos ese 0 como "legacy no-inicializado" y heredamos
+            // el default del tour. Origen del 0: migracion 054 reset + slots creados antes de
+            // BE-02. Sin este fallback, updateSlotPrices calcula price = providerPrice * 1 = providerPrice.
             BigDecimal tourDefaultPct = tourForConfig != null && tourForConfig.getPorcentajeTourya() != null
                     ? tourForConfig.getPorcentajeTourya()
                     : BigDecimal.ZERO;
-            BigDecimal slotPct = isNewSlot
-                    ? tourDefaultPct
-                    : TouryaPriceCalculator.normalizePercentage(currentSlot.getSlotPorcentajeTourya());
+            BigDecimal existingSlotPct = TouryaPriceCalculator.normalizePercentage(currentSlot.getSlotPorcentajeTourya());
+            BigDecimal slotPct;
             if (isNewSlot) {
+                slotPct = tourDefaultPct;
                 currentSlot.setSlotPorcentajeTourya(tourDefaultPct);
+            } else if (existingSlotPct.compareTo(BigDecimal.ZERO) == 0
+                    && tourDefaultPct.compareTo(BigDecimal.ZERO) > 0) {
+                slotPct = tourDefaultPct;
+                currentSlot.setSlotPorcentajeTourya(tourDefaultPct);
+            } else {
+                slotPct = existingSlotPct;
             }
 
             updateSlotPrices(currentSlot, new HashSet<>(slotDto.getPrices()), slotPct, roleList);
@@ -458,13 +469,25 @@ public class TourScheduleConfigGeneralService {
             BigDecimal slotPorcentajeTourya, List<Role> roleList) {
         normalizeProviderPriceDto(priceDto);
         price.setAgeType(priceDto.getAgeType());
+
+        // TC-019 (#231): fuente de verdad = providerPrice * (1 + slotPct). No confiamos en el
+        // price que envia el FE (bug historico: pre-llenaba price = providerPrice sin margen y
+        // sobreescribia el precio correcto). Para BACKOFFICE seguimos permitiendo pisar el
+        // precio SOLO si el FE manda un price DISTINTO de providerPrice (override intencional).
         if (Utils.isTouryaBackoffice(roleList)) {
             price.setProviderPrice(priceDto.getProviderPrice());
-            if (priceDto.getPrice() != null) {
+            if (priceDto.getProviderPrice() != null) {
+                boolean feSentExplicitOverride = priceDto.getPrice() != null
+                        && priceDto.getPrice().compareTo(priceDto.getProviderPrice()) != 0;
+                if (feSentExplicitOverride) {
+                    price.setPrice(priceDto.getPrice());
+                } else {
+                    price.setPrice(TouryaPriceCalculator.calculateSalePrice(
+                            priceDto.getProviderPrice(), slotPorcentajeTourya));
+                }
+            } else if (priceDto.getPrice() != null) {
+                // Sin providerPrice: usar el price tal cual (fallback muy defensivo).
                 price.setPrice(priceDto.getPrice());
-            } else if (priceDto.getProviderPrice() != null) {
-                price.setPrice(TouryaPriceCalculator.calculateSalePrice(
-                        priceDto.getProviderPrice(), slotPorcentajeTourya));
             }
             return;
         }

--- a/src/main/java/com/tourya/api/services/TourScheduleOverrideService.java
+++ b/src/main/java/com/tourya/api/services/TourScheduleOverrideService.java
@@ -178,16 +178,23 @@ public class TourScheduleOverrideService {
             if (slotId == null) {
                 continue;
             }
-            BigDecimal fraction = slotPct.getOrDefault(slotId, BigDecimal.ZERO);
-            if (showSlotPercentage) {
-                slot.setSlotPorcentajeTourya(TouryaPriceCalculator.toApiPercentPoints(fraction));
+            // TC-019 (#231): solo aplicar override SI existe uno explicito para (schedule, slot).
+            // Sin override, respetar el price base que ya trae el SP (calculado como
+            // provider_price * (1 + slot_porcentaje_tourya) al guardar la config). Sobreescribir
+            // con fraccion=0 hacia que reagendar mostrara price = providerPrice.
+            boolean hasOverride = slotPct.containsKey(slotId);
+            if (showSlotPercentage && hasOverride) {
+                slot.setSlotPorcentajeTourya(TouryaPriceCalculator.toApiPercentPoints(slotPct.get(slotId)));
             }
             if (slot.getPrices() == null) {
                 continue;
             }
-            for (SearchTourScheduleFullResponse.TourSchedulePriceResponse p : slot.getPrices()) {
-                if (p.getProviderPrice() != null) {
-                    p.setPrice(TouryaPriceCalculator.calculateSalePrice(p.getProviderPrice(), fraction));
+            if (hasOverride) {
+                BigDecimal fraction = slotPct.get(slotId);
+                for (SearchTourScheduleFullResponse.TourSchedulePriceResponse p : slot.getPrices()) {
+                    if (p.getProviderPrice() != null) {
+                        p.setPrice(TouryaPriceCalculator.calculateSalePrice(p.getProviderPrice(), fraction));
+                    }
                 }
             }
             if (slot.getHighestPrice() != null && slot.getPrices() != null && !slot.getPrices().isEmpty()) {
@@ -207,11 +214,12 @@ public class TourScheduleOverrideService {
         if (slot == null) {
             return;
         }
-        BigDecimal fraction = slot.getId() != null && slotFractionById.containsKey(slot.getId())
-                ? slotFractionById.get(slot.getId())
-                : BigDecimal.ZERO;
-        if (showSlotPercentage) {
-            slot.setSlotPorcentajeTourya(TouryaPriceCalculator.toApiPercentPoints(fraction));
+        // TC-019 (#231): fraction override es opcional. Sin override, respetar el % y precio
+        // base del slot/config (ya viene con el margen correcto en BD tras el backfill 088).
+        boolean hasFractionOverride = slot.getId() != null && slotFractionById.containsKey(slot.getId());
+        if (showSlotPercentage && hasFractionOverride) {
+            slot.setSlotPorcentajeTourya(
+                    TouryaPriceCalculator.toApiPercentPoints(slotFractionById.get(slot.getId())));
         }
         if (slot.getPrices() == null) {
             return;
@@ -219,9 +227,11 @@ public class TourScheduleOverrideService {
         for (TourSchedulePriceResponse price : slot.getPrices()) {
             if (price.getId() != null && priceById.containsKey(price.getId())) {
                 price.setPrice(priceById.get(price.getId()));
-            } else if (price.getProviderPrice() != null) {
-                price.setPrice(TouryaPriceCalculator.calculateSalePrice(price.getProviderPrice(), fraction));
+            } else if (hasFractionOverride && price.getProviderPrice() != null) {
+                price.setPrice(TouryaPriceCalculator.calculateSalePrice(
+                        price.getProviderPrice(), slotFractionById.get(slot.getId())));
             }
+            // else: sin override alguno → mantener el price base del config.
         }
     }
 

--- a/src/test/java/com/tourya/api/services/ReservationServiceRescheduleTest.java
+++ b/src/test/java/com/tourya/api/services/ReservationServiceRescheduleTest.java
@@ -85,6 +85,8 @@ class ReservationServiceRescheduleTest {
     @Mock private com.tourya.api.services.TourPrincipalOperatorService tourPrincipalOperatorService;
     @Mock private com.tourya.api.models.mapper.TourAddressMapper tourAddressMapper;
     @Mock private com.tourya.api.models.mapper.TourIncludesExcludesMapper tourIncludesExcludesMapper;
+    // TC-019 (#231): reschedule price calc ahora usa resolveSalePrice para respetar overrides.
+    @Mock private com.tourya.api.services.TourScheduleOverrideService tourScheduleOverrideService;
 
     @Mock private Authentication authentication;
 


### PR DESCRIPTION
Closes 3 regresiones reportadas por Luis en https://github.com/Touryapp/tourya-api/issues/231 (comentario 2026-08-11T17:41).

## Regresiones y causas raiz

### R1: `POST /tour-schedules/batch` guarda `price = provider_price` (sin margen)
- **Causa:** muchos `tour_schedule_config_slot` tienen `slot_porcentaje_tourya = 0`. Origen: migracion `054_cleanup_tour36_june_slot_overrides.sql` (reset explicito de slot 686 tour 36) + slots creados antes de BE-02. `updateSlotPrices` recalcula `price = providerPrice * (1 + 0) = providerPrice`.
- **Fix Java:**
  - `applyPriceDtoToEntity`: fuente de verdad es `providerPrice * (1 + slotPct)`. Se deja de confiar en el `price` que envia el FE (bug historico: pre-llenaba `price = providerPrice` sin margen). Para BACKOFFICE se permite override explicito SOLO si `price != providerPrice`.
  - `manageSlotsUpdate`: si un slot existente tiene `slotPct=0` y el tour tiene `porcentaje_tourya > 0`, hereda del tour como "legacy no-inicializado" y persiste el nuevo pct.

### R2: Reagendamiento muestra `price = providerPrice`
- **Causa:** `SearchTourScheduleSlotPercentageEnricher` (Donnaly, commit `2909185`) intencionalmente forzaba `fraction = 0` cuando no habia override por schedule, y pisaba el price base retornado por el SP.
- **Fix Java:** `applySearchScheduleOverrides` y `applyToSlotResponse` solo sobreescriben `price` cuando hay override real. Sin override respetan el price base del SP (que trae margen correcto tras el backfill).
- **Bonus fix:** `calculatePriceForNewConfiguration` (usado por PUT `/reservations/{id}/reschedule`) ahora usa `resolveSalePrice(scheduleId, priceId, base)` para respetar overrides ADMIN por schedule.

### R3: Disponibilidad reagendar 12/8/2026 muestra `bookings=0` y `capacity` total
- **Causa:** migracion `085_tc018b_sp_get_tour_schedule_json_dimar_block.sql` reescribio `sp_get_tour_schedule_json` copiando la version pre-TC-004 y perdio el fix de conteo por-fecha — usaba `sl.bookings` (denormalizado, mismo para todas las fechas) en vez de `public.fn_slot_booked_units_on_schedule(sl.id, s.id)`.
- **Fix SQL (migracion 088):** restaura el helper TC-004 en `sp_get_tour_schedule_json` conservando el flag `blockedByMaritimeReport` de TC-018b.

## Backfill (migracion 088 aplicada a Cloud SQL dev)

Idempotente:
- **Parte 1:** 444 filas — `slot_porcentaje_tourya = tour.porcentaje_tourya` donde slot=0/NULL y tour>0.
- **Parte 2:** 783 filas — `price = ROUND(provider_price * (1 + slot_pct), 2)` donde `price = provider_price` y `slot_pct > 0`.
- **Parte 3:** DROP + CREATE del SP con TC-004 helper + DIMAR flag.

**Verificacion post-migracion (dev):**
- Tour 36, slot 449, ADULT: `70000 → 87500` (70000 * 1.25) ✓
- SP para tour 36 schedule 12/8/2026 retorna `price=87500.00` (antes: `70000`).
- Ejecucion 2x = idempotente (segunda pasada `UPDATE 0` / `UPDATE 1` — 1 fila residual por rounding, se estabiliza).

## Restricciones cumplidas

- **Cart NO se toca.** `ShoppingCartService.addItemToCart` sigue usando `resolveSalePrice(scheduleId, priceId, priceConfig.getPrice())`, que respeta overrides y toma el price base ya con margen correcto tras el backfill. Sin doble multiplicacion.
- **Backfill idempotente.** WHERE filtra solo drift real; re-ejecucion es no-op.
- **Cobertura completa.** Los 3 lugares donde manifiesta el bug estan fixed en un solo PR.

## Test plan

- [x] `./mvnw compile` OK
- [x] `./mvnw test -Dtest=ReservationServiceRescheduleTest` — 14/14 tests pass
- [x] Migracion 088 aplicada a dev, verificado 0 drift residual
- [x] SP retorna correctamente precio con margen y bookings por-fecha
- [ ] QA manual (Luis): crear tour_schedule via `POST /tour-schedules/batch` con tour 36 y verificar `price = providerPrice * 1.25`
- [ ] QA manual (Luis): reagendar y verificar que la lista de dias muestra precio con margen
- [ ] QA manual (Luis): reservar el 12/8/2026 y verificar que la disponibilidad baja al reagendar