### PR TITLE
fix(TC-020 #235 bug c): forzar timezone America/Bogota en JVM + JPA Auditing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,12 @@ RUN mvn clean package -DskipTests
 # Usa una imagen base de OpenJDK para ejecutar la aplicación
 FROM eclipse-temurin:17-jre-jammy
 
+# TC-020 #235 bug (c): Cloud Run defaults to UTC. Set container/JVM tz to America/Bogota
+# so that every LocalDateTime.now() bare (~28 sites across services + jobs) resolves to
+# Colombia local time. Install tzdata so /usr/share/zoneinfo has the zone, then export TZ.
+RUN apt-get update && apt-get install -y --no-install-recommends tzdata && rm -rf /var/lib/apt/lists/*
+ENV TZ=America/Bogota
+
 # Establece el directorio de trabajo dentro del contenedor
 WORKDIR /app
 
@@ -23,5 +29,5 @@ COPY --from=build /app/target/*SNAPSHOT.jar app.jar
 # Expone el puerto en el que la aplicación se ejecutará
 EXPOSE 8088
 
-# Comando para ejecutar la aplicación
-ENTRYPOINT ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseContainerSupport", "-Djava.security.egd=file:/dev/./urandom","-jar","/app/app.jar"]
+# Comando para ejecutar la aplicación (-Duser.timezone respalda a TZ para el JVM)
+ENTRYPOINT ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseContainerSupport", "-Djava.security.egd=file:/dev/./urandom", "-Duser.timezone=America/Bogota", "-jar", "/app/app.jar"]

--- a/src/main/java/com/tourya/api/TouryaApiApplication.java
+++ b/src/main/java/com/tourya/api/TouryaApiApplication.java
@@ -9,7 +9,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableJpaAuditing(auditorAwareRef = "auditorAware")
+@EnableJpaAuditing(auditorAwareRef = "auditorAware", dateTimeProviderRef = "bogotaDateTimeProvider")
 @EnableAsync
 @EnableScheduling
 @ComponentScan(basePackages = "com.tourya.api")

--- a/src/main/java/com/tourya/api/config/JpaAuditingConfig.java
+++ b/src/main/java/com/tourya/api/config/JpaAuditingConfig.java
@@ -1,0 +1,29 @@
+package com.tourya.api.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+/**
+ * TC-020 #235 bug (c): the default DateTimeProvider used by Spring Data JPA auditing
+ * relies on the JVM zone. Cloud Run runs in UTC, so @CreatedDate / @LastModifiedDate
+ * were persisted in UTC. Turistas veian fechas +5h.
+ *
+ * This bean forces every LocalDateTime stamped by @CreatedDate / @LastModifiedDate
+ * to America/Bogota, matching every explicit LocalDateTime.now(BOGOTA) already used
+ * across services and jobs.
+ */
+@Configuration
+public class JpaAuditingConfig {
+
+    private static final ZoneId BOGOTA = ZoneId.of("America/Bogota");
+
+    @Bean(name = "bogotaDateTimeProvider")
+    public DateTimeProvider bogotaDateTimeProvider() {
+        return () -> Optional.of(LocalDateTime.now(BOGOTA));
+    }
+}


### PR DESCRIPTION
## Bug reportado por Luis (TC-020 #235 bug c)

A pesar del PR #240 (que cambio 4 \`LocalDateTime.now(ZoneId.of(\"UTC\"))\` manuales a Bogota), las fechas creacion/modificacion siguen mostrando +5h adelantadas.

## Root cause real

Grep completo reveló dos problemas mas grandes que #240 no cubrio:

1. **28 llamadas a \`LocalDateTime.now()\` bare** (sin zone) esparcidas en \`ReservationService\`, \`ReviewService\`, \`AuthenticationService\`, \`CreditExpirationJob\`, \`TourGalleryService\`, \`ProviderUserService\`, \`RequestProviderGalleryService\`, \`CreditService\`, \`ReviewAnswerMapper\`, \`MetaResponse\`. Todas resolvian a UTC porque Cloud Run corre con JVM tz = UTC.

2. **JPA Auditing** (\`@CreatedDate\` / \`@LastModifiedDate\` en \`BaseEntity\`) usa el DateTimeProvider default de Spring Data, que tambien llama \`LocalDateTime.now()\` bare. Todas las entidades del sistema tienen fechas de auditoria en UTC.

## Fix (defense-in-depth, 3 archivos)

### 1. \`Dockerfile\` — JVM y container timezone
- Instalar \`tzdata\` en la imagen runtime (\`eclipse-temurin:17-jre-jammy\` no lo trae).
- \`ENV TZ=America/Bogota\` en el container.
- \`-Duser.timezone=America/Bogota\` en el ENTRYPOINT (respaldo explicito para el JVM).

Con esto los 28 sitios de \`LocalDateTime.now()\` bare quedan correctos automaticamente — sin tocar codigo, sin riesgo de regresion.

### 2. \`config/JpaAuditingConfig.java\` (nuevo)
Bean \`bogotaDateTimeProvider\` que retorna \`LocalDateTime.now(ZoneId.of(\"America/Bogota\"))\` explicito.

### 3. \`TouryaApiApplication.java\`
\`@EnableJpaAuditing(auditorAwareRef = \"auditorAware\", dateTimeProviderRef = \"bogotaDateTimeProvider\")\` — referencia el bean nuevo.

**Belt-and-suspenders:** aunque el Dockerfile setea TZ, el bean garantiza fechas de auditoria correctas si el JVM llegase a arrancar con otra TZ por accidente (ej. dev local sin TZ env).

## Backfill

**No se hace.** Las fechas historicas ya persistidas en UTC quedan como estan — no hay forma de distinguir cuales eran correctas y cuales victima del bug. Solo se corrige hacia adelante.

## Verificacion

- \`./mvnw compile -DskipTests\` OK localmente.
- Cambio principal es infra (Dockerfile) — se verifica post-deploy: crear reserva nueva y confirmar que \`createdDate\` corresponde a hora Colombia (no +5h).

## Test plan
- [ ] Post-deploy: hacer reserva nueva → verificar en confirmacion que la fecha coincide con hora actual Colombia.
- [ ] Verificar en BD: \`SELECT id, created_date FROM reservation ORDER BY id DESC LIMIT 3\` → dates ahora son en Bogota local.
- [ ] Verificar que jobs (\`CreditExpirationJob\`, etc.) siguen funcionando (los cron triggers pueden shift si dependen de \`0 0 * * *\` — Spring \`@Scheduled\` respeta la TZ del JVM, asi que el job de medianoche antes disparaba a las 19:00 Colombia; ahora disparara a las 00:00 Colombia. **Comportamiento esperado y deseado**).