### PR TITLE
fix(TC-019 #231 bug 3): reagendamiento ajusta booking count del dia original y del nuevo

### DIFF
--- a/database/migrations/089_tc019_fix_reschedule_booking_count.sql
+++ b/database/migrations/089_tc019_fix_reschedule_booking_count.sql
@@ -1,0 +1,97 @@
+-- Migration 089: TC-019 (#231) bug 3 — reagendamiento no refleja el cambio de disponibilidad
+-- Date: 2026-08-12
+-- Description:
+--   Luis reporto 2026-08-12: al reagendar una reserva la cantidad no se descuenta del dia
+--   original ni se suma al dia nuevo. La UI queda con disponibilidad "drift" ambos lados.
+--
+--   Causa raiz:
+--     El helper `fn_slot_booked_units_on_schedule` (migracion 078, restaurado en 088) filtra
+--     reservas activas por `delivery_status IN ('TEMPORAL','PENDING','DELIVERED')`. Cuando
+--     una reserva se reagenda via `handleRescheduleEqualOrLower`:
+--       - `shopping_cart_item.tour_schedule_id` y `slot_id` se actualizan al NUEVO schedule.
+--       - `reservation.delivery_status` pasa a 'RESCHEDULED'.
+--     El helper deja de contarla en el dia viejo (correcto: el item ya no apunta ahi) y NO
+--     la cuenta en el dia nuevo (bug: RESCHEDULED excluido). Resultado: bookings=0 en ambos
+--     lados; la nueva reserva se vuelve "invisible" para el calculo de disponibilidad.
+--
+--   Verificacion (dev, 2026-08-12):
+--     SELECT reservation_id, delivery_status, i.slot_id, i.tour_schedule_id, ts.schedule_date
+--       FROM reservation r JOIN shopping_cart_item i ON i.id=r.item_id
+--       JOIN tour_schedule ts ON ts.id=i.tour_schedule_id
+--       WHERE r.delivery_status='RESCHEDULED';
+--       -> RES 333 -> slot 1032 / schedule 3428 (grupo, tour 72)   -> helper = 0 (deberia 1)
+--       -> RES 335 -> slot 1042 / schedule 3465 (individual, tour 36) -> helper = 0 (deberia 2)
+--
+--   Esta migracion:
+--     PARTE 1) Recrea `fn_slot_booked_units_on_schedule` incluyendo 'RESCHEDULED' en el filtro.
+--              El helper es la fuente de verdad del SP `sp_get_tour_schedule_json` (via
+--              migracion 088), por lo que el fix impacta directo a la disponibilidad de la UI.
+--     PARTE 2) Backfill idempotente de los campos denormalizados
+--              `tour_schedule_config_slot.bookings` y `.availability` usando la definicion
+--              nueva (RESCHEDULED cuenta como activa). Cierra drift acumulado tanto por este
+--              bug como por transiciones sin recalculate (patron BE-27).
+--
+--   Idempotente: correr N veces produce el mismo resultado. Diff Java del mismo PR ajusta la
+--   query JPA `ReservationRepository.countActiveBookingUnitsForSlotOnDate` para que
+--   `ensureSlotHasCapacity` no habilite oversell en la fecha destino de un reagendamiento.
+
+------------------------------------------------------------------------
+-- PARTE 1: fn_slot_booked_units_on_schedule — incluir RESCHEDULED
+------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.fn_slot_booked_units_on_schedule(p_slot_id int, p_schedule_id int)
+RETURNS int
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT COALESCE(SUM(
+    CASE
+      WHEN t.price_type = 'grupo' THEN 1
+      ELSE COALESCE((
+        SELECT SUM(d.quantity)
+        FROM shopping_cart_item_detail d
+        WHERE d.shopping_cart_item_id = i.id
+      ), 0)
+    END
+  ), 0)::int
+  FROM reservation r
+  JOIN shopping_cart_item i ON i.id = r.item_id
+  JOIN tour_schedule ts ON ts.id = i.tour_schedule_id
+  JOIN tour t ON t.id = ts.tour_id
+  WHERE i.slot_id = p_slot_id
+    AND ts.id = p_schedule_id
+    -- TC-019 (#231) bug 3: RESCHEDULED tambien ocupa cupo — el cliente asistira al nuevo dia.
+    AND r.delivery_status IN ('TEMPORAL', 'PENDING', 'DELIVERED', 'RESCHEDULED');
+$$;
+
+COMMENT ON FUNCTION public.fn_slot_booked_units_on_schedule(int, int) IS
+  'TC-004 + TC-019 (#231): unidades reservadas activas (TEMPORAL/PENDING/DELIVERED/RESCHEDULED) para un slot en un tour_schedule especifico. Respeta priceType (grupo=1 por reserva, individual=suma pax). RESCHEDULED se cuenta porque el item apunta al nuevo (slot,schedule) tras el reagendamiento.';
+
+------------------------------------------------------------------------
+-- PARTE 2: backfill denormalizado `slot.bookings` y `slot.availability`
+--          usando la definicion nueva (RESCHEDULED cuenta). Complementa
+--          la migracion 080 (BE-27) para el nuevo caso.
+------------------------------------------------------------------------
+UPDATE public.tour_schedule_config_slot s
+SET bookings = COALESCE((
+    SELECT SUM(
+        CASE
+            WHEN t.price_type = 'grupo' THEN 1
+            ELSE COALESCE((
+                SELECT SUM(d.quantity)
+                FROM shopping_cart_item_detail d
+                WHERE d.shopping_cart_item_id = i.id
+            ), 0)
+        END
+    )
+    FROM reservation r
+    JOIN shopping_cart_item i ON i.id = r.item_id
+    JOIN tour_schedule ts ON ts.id = i.tour_schedule_id
+    JOIN tour t ON t.id = ts.tour_id
+    WHERE i.slot_id = s.id
+      AND r.delivery_status IN ('TEMPORAL', 'PENDING', 'DELIVERED', 'RESCHEDULED')
+), 0)::int
+WHERE s.bookings IS NOT NULL;
+
+UPDATE public.tour_schedule_config_slot
+SET availability = GREATEST(0, COALESCE(capacity, 0) - COALESCE(bookings, 0))
+WHERE capacity IS NOT NULL;

--- a/src/main/java/com/tourya/api/repository/ReservationRepository.java
+++ b/src/main/java/com/tourya/api/repository/ReservationRepository.java
@@ -249,14 +249,20 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     );
 
     /**
-     * TC-004: cuenta unidades reservadas para un slot en una fecha específica.
+     * TC-004 + TC-019 (#231) bug 3: cuenta unidades reservadas para un slot en una fecha
+     * específica.
      *
-     * Suma unidades activas (TEMPORAL/PENDING/DELIVERED) respetando priceType:
+     * Suma unidades activas (TEMPORAL/PENDING/DELIVERED/RESCHEDULED) respetando priceType:
      *  - grupo: 1 unidad por reserva
      *  - individual: suma de pax (shopping_cart_item_detail.quantity)
      *
      * Se cuenta por (shopping_cart_item.slot_id, tour_schedule.schedule_date) para
      * evitar el bug del contador global slot.bookings (ver TC-004).
+     *
+     * RESCHEDULED cuenta como activa porque tras reagendar el item apunta al nuevo
+     * (slot, schedule) y el cliente asistira ese día — omitirla habilita oversell en
+     * la fecha destino (TC-019 #231 bug 3, Luis 2026-08-12). Debe mantenerse en sincronía
+     * con el helper SQL {@code fn_slot_booked_units_on_schedule} (migración 089).
      */
     @Query(value = """
         SELECT COALESCE(SUM(
@@ -275,7 +281,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         JOIN tour t ON t.id = ts.tour_id
         WHERE i.slot_id = :slotId
           AND ts.schedule_date = :scheduleDate
-          AND r.delivery_status IN ('TEMPORAL', 'PENDING', 'DELIVERED')
+          AND r.delivery_status IN ('TEMPORAL', 'PENDING', 'DELIVERED', 'RESCHEDULED')
         """,
         nativeQuery = true)
     Integer countActiveBookingUnitsForSlotOnDate(


### PR DESCRIPTION
## Issue
Cierra bug 3 de TC-019 #231 (Luis 2026-08-12): "al reagendar la cantidad definida en la reserva se debe restar en el booking del dia original y sumarse en el nuevo dia; esto no esta funcionando".

## Causa raiz
El helper `fn_slot_booked_units_on_schedule` (migraciones 078/088), fuente de verdad de `sp_get_tour_schedule_json`, filtra reservas activas por `delivery_status IN ('TEMPORAL','PENDING','DELIVERED')`. El flujo `handleRescheduleEqualOrLower` en `ReservationService`:

1. Actualiza `shopping_cart_item.tour_schedule_id` y `slot_id` al NUEVO schedule/slot.
2. Marca la reserva como `RESCHEDULED`.

Como `RESCHEDULED` no estaba en la lista de estados activos, el helper dejaba de contar la reserva en el dia viejo (correcto, el item ya no apunta ahi) y NO la contaba en el dia nuevo (bug: RESCHEDULED excluido). Resultado: la nueva reserva se vuelve "invisible" para la UI de disponibilidad. Efecto colateral: `ensureSlotHasCapacity` con la misma query JPA habilitaba oversell en la fecha destino.

## Fix
- **Migracion 089** `089_tc019_fix_reschedule_booking_count.sql`:
  - **PARTE 1**: Recrea `fn_slot_booked_units_on_schedule` incluyendo `'RESCHEDULED'` en el filtro.
  - **PARTE 2**: Backfill idempotente de `tour_schedule_config_slot.bookings` y `.availability` usando la definicion nueva (complementa migracion 080 para el caso RESCHEDULED).
- **`ReservationRepository.countActiveBookingUnitsForSlotOnDate`**: incluye `RESCHEDULED` en el `IN` para mantener sincronia con el helper SQL y prevenir oversell en la fecha destino.

`ReservationService.java` no requiere cambios: ya actualiza el item correctamente. El bug era puramente en la definicion de "reserva activa" a nivel de query.

## Verificacion end-to-end (dev, psql)
Antes del fix (state real en dev):

| Reserva | Estado | Tipo | Slot | Schedule | Pax | helper (antes) | esperado |
|---:|---|---|---:|---:|---:|---:|---:|
| 335 | RESCHEDULED | individual | 1042 | 3465 | 2 | 0 | 2 |
| 333 | RESCHEDULED | grupo | 1032 | 3428 | 2 | 0 | 1 |

Despues del fix:

| helper(1042, 3465) | helper(1032, 3428) |
|:---:|:---:|
| 2 | 1 |

Simulacion de reagendamiento (RES 336 PENDING, slot 1032, schedule 3431 -> 3432) dentro de transaccion `BEGIN ... ROLLBACK`:
- BEFORE: `old_day=1, new_day=0`
- AFTER simulated reschedule (`UPDATE item.tour_schedule_id=3432, UPDATE reservation.delivery_status='RESCHEDULED'`): `old_day=0, new_day=1`
- Post-ROLLBACK: state restaurado (`1, 0`).

Migracion aplicada 2x -> mismo resultado (idempotente).

## Backfill dev
- 792 filas de `slot.bookings` recalculadas.
- 404 filas de `slot.availability` recalculadas.
- Cierra drift acumulado tanto por este bug como por transiciones sin `recalculate` (patron BE-27).

## Tests
`./mvnw compile -DskipTests` verde. Suites relevantes verdes:
- `ReservationServiceRescheduleTest` -> 14 tests OK
- `TourScheduleSlotAvailabilityServiceTest` -> 12 tests OK

## Test plan (para Luis)
- [ ] Crear reserva PENDING/DELIVERED en dev para un tour con capacidad limitada.
- [ ] Verificar en UI que el dia muestra `bookings = N` (donde N = pax del tour individual o 1 si grupo).
- [ ] Reagendar la reserva a otro dia disponible (misma capacidad o menor precio).
- [ ] Confirmar que el dia original vuelve a `bookings = 0` y el nuevo dia muestra `bookings = N`.
- [ ] Intentar sobre-reservar el dia destino: debe rechazarse por falta de cupo.