### PR TITLE
fix(TC-019 #231 bug 4): al editar slotPorcentajeTourya recalcula price del slot

### DIFF
--- a/database/migrations/090_tc019_backfill_slot_pct_price_drift.sql
+++ b/database/migrations/090_tc019_backfill_slot_pct_price_drift.sql
@@ -1,0 +1,27 @@
+-- Migration 090: TC-019 (#231) bug 4 — Backfill drift entre slot_porcentaje_tourya y price base.
+-- Date: 2026-08-12
+-- Description:
+--   Luis 2026-08-12: al editar slotPorcentajeTourya en el "slot de un dia", el valor se guarda
+--   pero el price base del slot NO se recalcula (por dia se recalcula el override, pero si un
+--   flujo previo persistio el pct base sin recalcular price, quedo drift).
+--
+--   Analisis del backend (2026-08-12):
+--   - manageSlotsUpdate() en TourScheduleConfigGeneralService NO aceptaba slotPorcentajeTourya
+--     del DTO (el DTO no tenia el campo). Solo actualizaba el pct base cuando era slot nuevo o
+--     cuando el pct base era 0 y el tour tenia margen.
+--   - Este PR agrega el campo al DTO y hace que manageSlotsUpdate persista el nuevo pct + recalcule
+--     price base via applyPriceDtoToEntity (que ya recalcula desde providerPrice + slotPct).
+--   - Migration 088 (parte 2) ya cubrio el caso price == provider_price + slot_pct > 0. Este
+--     backfill cubre el caso residual: price != provider_price * (1 + slot_pct) con drift > 0.01.
+--
+--   Idempotente: WHERE filtra solo filas con drift. Ejecutar 2 veces = no-op.
+--   No toca overrides per-schedule (tour_schedule_price_override) — esos ya se manejan por endpoint.
+
+UPDATE public.tour_schedule_config_price p
+SET price = ROUND(p.provider_price * (1 + COALESCE(sl.slot_porcentaje_tourya, 0)), 2)
+FROM public.tour_schedule_config_slot sl
+WHERE p.slot_id = sl.id
+  AND p.provider_price IS NOT NULL
+  AND p.provider_price > 0
+  AND sl.slot_porcentaje_tourya IS NOT NULL
+  AND ABS(p.price - p.provider_price * (1 + sl.slot_porcentaje_tourya)) > 0.01;

--- a/src/main/java/com/tourya/api/models/request/TourScheduleConfigSlotDto.java
+++ b/src/main/java/com/tourya/api/models/request/TourScheduleConfigSlotDto.java
@@ -3,10 +3,13 @@ package com.tourya.api.models.request;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.tourya.api.config.EmptyStringAsNullIntegerDeserializer;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
+import java.math.BigDecimal;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -20,6 +23,14 @@ public class TourScheduleConfigSlotDto {
     private LocalTime endTime;
     @NotNull(message = "La capacidad del slot no puede ser nula")
     private Integer capacity;
+
+    // TC-019 (#231) bug 4: porcentaje Tourya del slot en puntos porcentuales (0-100).
+    // Nullable: si no viene, se preserva la logica existente (tour default para slots nuevos,
+    // valor de BD para existentes). Solo BACKOFFICE puede setearlo (RN-015); si un PROVIDER
+    // lo envia, se ignora silenciosamente.
+    @DecimalMin(value = "0", message = "slotPorcentajeTourya no puede ser negativo")
+    @DecimalMax(value = "100", message = "slotPorcentajeTourya no puede superar 100")
+    private BigDecimal slotPorcentajeTourya;
 
     @Valid // Habilita la validación anidada de los precios
     @NotEmpty(message = "Cada slot debe tener al menos un precio asociado")

--- a/src/main/java/com/tourya/api/services/TourScheduleConfigGeneralService.java
+++ b/src/main/java/com/tourya/api/services/TourScheduleConfigGeneralService.java
@@ -152,15 +152,19 @@ public class TourScheduleConfigGeneralService {
             // Antes se seteaba en ZERO y el ADMIN tenia que llamar despues a
             // PUT /tour-schedules/tours/{tourId}/percentage. Ahora nace ya con el valor
             // del tour; el ADMIN puede sobrescribirlo por rango de fechas via override.
+            //
+            // TC-019 (#231) bug 4: si el DTO trae slotPorcentajeTourya y el usuario es
+            // BACKOFFICE, se respeta el valor enviado (puede ser 0). Sino, se hereda tour default.
             BigDecimal tourDefaultPct = tourForConfig != null && tourForConfig.getPorcentajeTourya() != null
                     ? tourForConfig.getPorcentajeTourya()
                     : BigDecimal.ZERO;
-            slot.setSlotPorcentajeTourya(tourDefaultPct);
+            BigDecimal effectiveSlotPct = resolveSlotPctFromDto(slotDto, tourDefaultPct, roleList);
+            slot.setSlotPorcentajeTourya(effectiveSlotPct);
 
             if (slotDto.getPrices() != null) {
                 Set<TourScheduleConfigPrice> prices = new HashSet<>();
                 for (TourScheduleConfigPriceDto priceDto : slotDto.getPrices()) {
-                    TourScheduleConfigPrice price = buildPriceEntity(slot, priceDto, tourDefaultPct, roleList);
+                    TourScheduleConfigPrice price = buildPriceEntity(slot, priceDto, effectiveSlotPct, roleList);
                     prices.add(price);
                 }
                 slot.setPrices(prices);
@@ -168,6 +172,22 @@ public class TourScheduleConfigGeneralService {
             slots.add(slot);
         }
         return slots;
+    }
+
+    /**
+     * TC-019 (#231) bug 4: resuelve el slotPorcentajeTourya efectivo para persistir en la BD.
+     * Convierte el valor del DTO (puntos 0-100) a fraccion (0.0-1.0) via TouryaPriceCalculator.
+     * Solo BACKOFFICE puede setearlo (RN-015); providers usan el fallback.
+     */
+    private BigDecimal resolveSlotPctFromDto(TourScheduleConfigSlotDto slotDto, BigDecimal fallback,
+            List<Role> roleList) {
+        if (slotDto == null || slotDto.getSlotPorcentajeTourya() == null) {
+            return fallback;
+        }
+        if (!Utils.isTouryaBackoffice(roleList)) {
+            return fallback;
+        }
+        return TouryaPriceCalculator.fromApiPercentPoints(slotDto.getSlotPorcentajeTourya());
     }
 
     private Set<DayOfWeek> getValidDaysOfWeek(List<String> daysOfWeek) {
@@ -321,12 +341,24 @@ public class TourScheduleConfigGeneralService {
             // el tour tiene margen > 0, tratamos ese 0 como "legacy no-inicializado" y heredamos
             // el default del tour. Origen del 0: migracion 054 reset + slots creados antes de
             // BE-02. Sin este fallback, updateSlotPrices calcula price = providerPrice * 1 = providerPrice.
+            //
+            // TC-019 (#231) bug 4: si el DTO trae slotPorcentajeTourya explicito y el usuario es
+            // BACKOFFICE, ese valor pisa toda la logica anterior (fallback / herencia). Persistimos
+            // el nuevo pct en el slot base y ejecutamos updateSlotPrices con ese pct — lo que dispara
+            // applyPriceDtoToEntity y recalcula price = providerPrice * (1 + pct) en la BD base.
             BigDecimal tourDefaultPct = tourForConfig != null && tourForConfig.getPorcentajeTourya() != null
                     ? tourForConfig.getPorcentajeTourya()
                     : BigDecimal.ZERO;
             BigDecimal existingSlotPct = TouryaPriceCalculator.normalizePercentage(currentSlot.getSlotPorcentajeTourya());
+            BigDecimal explicitDtoPct = null;
+            if (slotDto.getSlotPorcentajeTourya() != null && Utils.isTouryaBackoffice(roleList)) {
+                explicitDtoPct = TouryaPriceCalculator.fromApiPercentPoints(slotDto.getSlotPorcentajeTourya());
+            }
             BigDecimal slotPct;
-            if (isNewSlot) {
+            if (explicitDtoPct != null) {
+                slotPct = explicitDtoPct;
+                currentSlot.setSlotPorcentajeTourya(explicitDtoPct);
+            } else if (isNewSlot) {
                 slotPct = tourDefaultPct;
                 currentSlot.setSlotPorcentajeTourya(tourDefaultPct);
             } else if (existingSlotPct.compareTo(BigDecimal.ZERO) == 0


### PR DESCRIPTION
## Contexto

Luis 2026-08-12T05:46 (issue #231): al asignar un valor al campo `slotPorcentajeTourya` en el slot de un dia, el valor se guarda pero el `price` no se actualiza tomando en cuenta el porcentaje definido en el slot.

## Causa raiz

**`TourScheduleConfigSlotDto` no tenia el campo `slotPorcentajeTourya`.** Los endpoints que persisten el slot base (`POST /config`, `PUT /config/{id}`, `POST /batch`) no podian recibir un slotPct explicito desde el frontend. `manageSlotsUpdate` solo actualizaba `slot_porcentaje_tourya` en dos casos:

- Slot nuevo -> hereda `tour.porcentaje_tourya`.
- Slot existente con pct=0 y `tour.default > 0` -> hereda tour default (fix TC-019 PR #243).

En cualquier otro caso, reusaba el pct existente en BD y recalculaba `price` desde ese pct. Consecuencia: si BACKOFFICE queria custom pct por slot via config edit, no habia camino.

## Fix (scope acotado)

**Solo afecta el flujo config edit / creation base. No toca overrides per-schedule.**

- Agregado `slotPorcentajeTourya` (0-100 puntos, nullable, `@DecimalMin(0)` / `@DecimalMax(100)`) a `TourScheduleConfigSlotDto`.
- `buildSlotsAndPricesFromRequest` y `manageSlotsUpdate` honran el valor del DTO cuando el usuario es BACKOFFICE (RN-015). Si viene:
  - Se convierte a fraccion via `TouryaPriceCalculator.fromApiPercentPoints` (40 -> 0.4).
  - Se persiste en el slot base (`tour_schedule_config_slot.slot_porcentaje_tourya`).
  - Se recalcula `price` via `applyPriceDtoToEntity` (misma helper de PR #243, siempre computa desde `providerPrice + slotPct`).
- Si no viene o el usuario es PROVIDER, se mantiene comportamiento previo (herencia tour default).
- Extraido helper privado `resolveSlotPctFromDto` para claridad.

## Compatibilidad y guards

- **Idempotente**: `applyPriceDtoToEntity` computa desde `providerPrice`, nunca desde `price` actual. Mandar el mismo request N veces = mismo resultado (no doble multiplicacion).
- **No rompe PR #243**: la logica de herencia (slot nuevo / pct=0 y tour default > 0) se preserva; solo se agrega un branch previo cuando el DTO trae valor explicito.
- **No toca overrides per-schedule** (`updateSlotPercentageForSlot` / `ByDateRange` en `TourScheduleOverrideService`) — esos ya escriben tanto `tour_schedule_slot_override` como `tour_schedule_price_override` correctamente. Cambiar la base desde el endpoint override tendria side effects sobre otros schedules del mismo slot.
- **No toca la logica del carrito**: `resolveSalePrice(scheduleId, priceId, priceConfig.getPrice())` sigue devolviendo override si existe, sino la base. Sin doble multiplicacion.

## Backfill (migration 090)

Detecta y corrige drift entre `price` base y `provider_price * (1 + slot_pct)`:

```sql
UPDATE tour_schedule_config_price p
SET price = ROUND(p.provider_price * (1 + COALESCE(sl.slot_porcentaje_tourya, 0)), 2)
FROM tour_schedule_config_slot sl
WHERE p.slot_id = sl.id
  AND p.provider_price > 0
  AND sl.slot_porcentaje_tourya IS NOT NULL
  AND ABS(p.price - p.provider_price * (1 + sl.slot_porcentaje_tourya)) > 0.01;
```

- **4 filas afectadas en dev**: slots 522/526/629 (tour 43), slot 527 (tour 36).
- **Idempotente**: WHERE ABS(...) > 0.01. Ejecutar 2 veces = UPDATE 0.
- Migration 088 (parte 2) ya cubrio el caso `price == provider_price` con `slot_pct > 0`. Este backfill cubre el residual con drift arbitrario.

## Verificacion end-to-end

Dev Cloud SQL `tourya-dev-db`:

- SELECT drift antes: 4 filas.
- Aplicar migration 090: `UPDATE 4`.
- SELECT drift despues: 0 filas.
- Re-aplicar migration: `UPDATE 0` (idempotencia OK).
- `./mvnw compile -DskipTests`: `BUILD SUCCESS` (0 errors, warnings preexistentes).

## Test plan

- [ ] Franklin aplica migration 090 en dev tras merge (ya aplicada durante desarrollo).
- [ ] Verificar en dev via SQL que un slot editado desde el config edit del BACKOFFICE con `slotPorcentajeTourya` custom persiste el pct y recalcula el price base.
- [ ] Confirmar que provider (no BACKOFFICE) enviando el campo lo ignora silenciosamente (fallback a tour default).
- [ ] Confirmar que endpoints per-schedule override (`PUT /tour-schedules/tours/{tourId}/percentage/{slotId}`) siguen funcionando igual (sin cambios).