### PR TITLE
feat(TC-022 #253): flujo devolucion de creditos (backend)

### DIFF
--- a/database/migrations/091_tc022_credit_refund_workflow.sql
+++ b/database/migrations/091_tc022_credit_refund_workflow.sql
@@ -1,0 +1,89 @@
+-- Migration 091: TC-022 credit refund workflow (issue #253)
+-- Date: 2026-08-13
+--
+-- Nuevo flujo: el turista puede solicitar la devolucion en efectivo de un
+-- credito no reservado (CREATED con saldo libre). Un usuario ADMIN o
+-- BACKOFFICE_OPERATION completa la devolucion subiendo un comprobante y el
+-- credito pasa a REFUNDED.
+--
+-- Transiciones validas:
+--   CREATED -> REFUND_REQUESTED  (endpoint turista)
+--   REFUND_REQUESTED -> REFUNDED (endpoint admin, con comprobante)
+--
+-- Cambios:
+--   1. credit_status_check: agrega REFUND_REQUESTED y REFUNDED.
+--      Nota: la columna credit.status es VARCHAR(20) con CHECK constraint
+--      (no un ENUM de PostgreSQL). En 074 se empezo a usar 'EXPIRED' sin
+--      actualizar el CHECK; esta migracion normaliza el catalogo completo:
+--      CREATED, RESERVED, CONSUMED, CANCELED, DELETED, EXPIRED,
+--      REFUND_REQUESTED, REFUNDED.
+--
+--   2. 3 columnas nuevas en public.credit:
+--      - refund_requested_at TIMESTAMPTZ NULL
+--      - refunded_at         TIMESTAMPTZ NULL
+--      - refund_proof_url    VARCHAR(500) NULL
+--
+-- Cero side effect sobre creditos existentes (usar/transferir/cancelar/expirar).
+
+BEGIN;
+
+-- 1. Actualizar CHECK constraint para admitir los nuevos valores.
+ALTER TABLE public.credit
+    DROP CONSTRAINT IF EXISTS credit_status_check;
+
+ALTER TABLE public.credit
+    ADD CONSTRAINT credit_status_check CHECK (
+        (status)::text = ANY (
+            (ARRAY[
+                'CREATED'::character varying,
+                'RESERVED'::character varying,
+                'CONSUMED'::character varying,
+                'CANCELED'::character varying,
+                'DELETED'::character varying,
+                'EXPIRED'::character varying,
+                'REFUND_REQUESTED'::character varying,
+                'REFUNDED'::character varying
+            ])::text[]
+        )
+    );
+
+-- 2. Columnas del flujo de devolucion.
+ALTER TABLE public.credit
+    ADD COLUMN IF NOT EXISTS refund_requested_at TIMESTAMPTZ NULL,
+    ADD COLUMN IF NOT EXISTS refunded_at         TIMESTAMPTZ NULL,
+    ADD COLUMN IF NOT EXISTS refund_proof_url    VARCHAR(500) NULL;
+
+COMMENT ON COLUMN public.credit.refund_requested_at IS
+    'TC-022: timestamp cuando el turista solicito la devolucion en efectivo (transicion CREATED -> REFUND_REQUESTED).';
+COMMENT ON COLUMN public.credit.refunded_at IS
+    'TC-022: timestamp cuando ADMIN/BACKOFFICE marco la devolucion como completada (transicion REFUND_REQUESTED -> REFUNDED).';
+COMMENT ON COLUMN public.credit.refund_proof_url IS
+    'TC-022: URL publica del comprobante de devolucion subido a S3/GCS (path credit-refund-proofs/{creditId}/...).';
+
+COMMIT;
+
+-- =============================================================================
+-- Rollback (comentado):
+-- BEGIN;
+-- ALTER TABLE public.credit
+--     DROP COLUMN IF EXISTS refund_proof_url,
+--     DROP COLUMN IF EXISTS refunded_at,
+--     DROP COLUMN IF EXISTS refund_requested_at;
+--
+-- ALTER TABLE public.credit
+--     DROP CONSTRAINT IF EXISTS credit_status_check;
+--
+-- ALTER TABLE public.credit
+--     ADD CONSTRAINT credit_status_check CHECK (
+--         (status)::text = ANY (
+--             (ARRAY[
+--                 'CREATED'::character varying,
+--                 'RESERVED'::character varying,
+--                 'CONSUMED'::character varying,
+--                 'CANCELED'::character varying,
+--                 'DELETED'::character varying,
+--                 'EXPIRED'::character varying
+--             ])::text[]
+--         )
+--     );
+-- COMMIT;

--- a/src/main/java/com/tourya/api/constans/enums/CreditStatusEnum.java
+++ b/src/main/java/com/tourya/api/constans/enums/CreditStatusEnum.java
@@ -37,7 +37,22 @@ public enum CreditStatusEnum {
      * todos los flujos de checkout y transferencia. El job CreditExpirationJob
      * hace la transicion CREATED -> EXPIRED en la fecha exacta de expiracion.
      */
-    EXPIRED
+    EXPIRED,
+
+    /**
+     * TC-022 (#253): el turista solicito la devolucion en efectivo del credito.
+     * Estado terminal para el turista (no puede reusar el credito). Espera a que
+     * un usuario ADMIN o BACKOFFICE_OPERATION suba el comprobante para pasar a REFUNDED.
+     * Transicion permitida: CREATED -> REFUND_REQUESTED.
+     */
+    REFUND_REQUESTED,
+
+    /**
+     * TC-022 (#253): ADMIN/BACKOFFICE_OPERATION confirmo la devolucion en efectivo
+     * y subio el comprobante (S3/GCS). Estado terminal.
+     * Transicion permitida: REFUND_REQUESTED -> REFUNDED.
+     */
+    REFUNDED
 }
 
 

--- a/src/main/java/com/tourya/api/controller/AdminCreditController.java
+++ b/src/main/java/com/tourya/api/controller/AdminCreditController.java
@@ -1,0 +1,87 @@
+package com.tourya.api.controller;
+
+import com.tourya.api.constans.enums.CreditStatusEnum;
+import com.tourya.api.models.responses.CreditResponse;
+import com.tourya.api.services.CreditService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+/**
+ * TC-022 (#253): endpoints backoffice/admin del flujo de devolucion de creditos.
+ * Guard de rol (ADMIN + BACKOFFICE_OPERATION) en el service via Utils.isTouryaBackoffice.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/admin/credits")
+@RequiredArgsConstructor
+@Tag(
+        name = "Admin Credits",
+        description = "Gestion global de creditos por backoffice: listado y devolucion en efectivo (TC-022 #253)."
+)
+public class AdminCreditController {
+
+    private final CreditService creditService;
+
+    @GetMapping
+    @Operation(
+            operationId = "adminListCredits",
+            summary = "Listar creditos (backoffice global, TC-022 #253)",
+            description = "Retorna un Page<CreditResponse> con datos del turista (touristName, touristEmail). "
+                    + "Filtro opcional por status. Solo ADMIN o BACKOFFICE_OPERATION."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Listado retornado"),
+            @ApiResponse(responseCode = "403", description = "Rol insuficiente")
+    })
+    public ResponseEntity<Page<CreditResponse>> listAll(
+            Authentication authentication,
+            @Parameter(description = "Filtrar por estado (opcional)")
+            @RequestParam(value = "status", required = false) CreditStatusEnum status,
+            @ParameterObject
+            @Parameter(description = "Paginacion via page, size, sort")
+            Pageable pageable) {
+        return ResponseEntity.ok(creditService.findAllForAdmin(authentication, status, pageable));
+    }
+
+    @PostMapping(value = "/{creditId}/upload-refund-proof",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(
+            operationId = "adminUploadCreditRefundProof",
+            summary = "Subir comprobante y marcar devolucion como REFUNDED (TC-022 #253)",
+            description = "Transicion REFUND_REQUESTED -> REFUNDED. Multipart form-data con campo 'proof' "
+                    + "(JPG/PNG o PDF, max 5MB). Solo ADMIN o BACKOFFICE_OPERATION."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Devolucion completada"),
+            @ApiResponse(responseCode = "400", description = "Transicion o archivo invalido"),
+            @ApiResponse(responseCode = "403", description = "Rol insuficiente"),
+            @ApiResponse(responseCode = "404", description = "Credito no existe")
+    })
+    public ResponseEntity<CreditResponse> uploadRefundProof(
+            @PathVariable("creditId") Long creditId,
+            @RequestPart("proof") MultipartFile proof,
+            Authentication authentication) throws IOException {
+        return ResponseEntity.ok(creditService.uploadRefundProof(creditId, proof, authentication));
+    }
+}

--- a/src/main/java/com/tourya/api/controller/CreditController.java
+++ b/src/main/java/com/tourya/api/controller/CreditController.java
@@ -103,4 +103,22 @@ public class CreditController {
             Authentication authentication) {
         return ResponseEntity.ok(creditService.transferCredit(creditId, request, authentication));
     }
+
+    @PostMapping("/{creditId}/request-refund")
+    @Operation(
+            operationId = "touristRequestCreditRefund",
+            summary = "Turista solicita la devolucion en efectivo del credito (TC-022 #253)",
+            description = "Transicion CREATED -> REFUND_REQUESTED. Guards: credito propio, "
+                    + "status actual CREATED, saldo libre (amount - reservedAmount) > 0, no vencido."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Devolucion solicitada"),
+            @ApiResponse(responseCode = "400", description = "Transicion no permitida"),
+            @ApiResponse(responseCode = "404", description = "Credito no existe")
+    })
+    public ResponseEntity<CreditResponse> requestRefund(
+            @PathVariable("creditId") Long creditId,
+            Authentication authentication) {
+        return ResponseEntity.ok(creditService.requestRefund(creditId, authentication));
+    }
 }

--- a/src/main/java/com/tourya/api/models/Credit.java
+++ b/src/main/java/com/tourya/api/models/Credit.java
@@ -88,6 +88,24 @@ public class Credit extends BaseEntity {
     @Column(name = "expired_notified_at")
     private LocalDateTime expiredNotifiedAt;
 
+    /**
+     * TC-022 (#253): timestamp de cuando el turista solicito la devolucion en efectivo.
+     */
+    @Column(name = "refund_requested_at")
+    private LocalDateTime refundRequestedAt;
+
+    /**
+     * TC-022 (#253): timestamp de cuando ADMIN/BACKOFFICE marco la devolucion como completada.
+     */
+    @Column(name = "refunded_at")
+    private LocalDateTime refundedAt;
+
+    /**
+     * TC-022 (#253): URL publica del comprobante de devolucion (S3/GCS).
+     */
+    @Column(name = "refund_proof_url", length = 500)
+    private String refundProofUrl;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reservation_id", insertable = false, updatable = false)
     private Reservation reservation;

--- a/src/main/java/com/tourya/api/models/responses/CreditResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/CreditResponse.java
@@ -28,6 +28,13 @@ public class CreditResponse {
     private LocalDate creationDate;
     private LocalDate expirationDate;
     private CreditStatusEnum status;
+
+    // TC-022 (#253): flujo de devolucion de creditos.
+    private LocalDateTime refundRequestedAt;
+    private LocalDateTime refundedAt;
+    private String refundProofUrl;
+
+    // TC-022: informacion embebida del turista (solo poblada en el listado admin).
+    private String touristName;
+    private String touristEmail;
 }
-
-

--- a/src/main/java/com/tourya/api/repository/CreditRepository.java
+++ b/src/main/java/com/tourya/api/repository/CreditRepository.java
@@ -2,6 +2,8 @@ package com.tourya.api.repository;
 
 import com.tourya.api.models.Credit;
 import com.tourya.api.constans.enums.CreditStatusEnum;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -29,6 +31,11 @@ public interface CreditRepository extends JpaRepository<Credit, Long> {
      * Busca créditos por estado
      */
     List<Credit> findByStatus(CreditStatusEnum status);
+
+    /**
+     * TC-022: listado paginado por estado (para admin/backoffice global).
+     */
+    Page<Credit> findByStatus(CreditStatusEnum status, Pageable pageable);
 
     /**
      * Busca créditos por estado y ordenados por fecha de creación

--- a/src/main/java/com/tourya/api/services/CreditService.java
+++ b/src/main/java/com/tourya/api/services/CreditService.java
@@ -2,6 +2,7 @@ package com.tourya.api.services;
 
 import com.tourya.api._utils.Utils;
 import com.tourya.api.constans.enums.CreditStatusEnum;
+import com.tourya.api.exceptions.InsufficientPrivilegesException;
 import com.tourya.api.exceptions.OperationNotPermittedException;
 import com.tourya.api.exceptions.ResourceNotFoundException;
 import com.tourya.api.models.Credit;
@@ -16,14 +17,23 @@ import com.tourya.api.repository.TouristProfileRepository;
 import com.tourya.api.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -32,9 +42,15 @@ import java.util.stream.Collectors;
 @Transactional
 public class CreditService {
 
+    private static final ZoneId BOGOTA = ZoneId.of("America/Bogota");
+    private static final long REFUND_PROOF_MAX_BYTES = 5L * 1024 * 1024; // 5MB
+    private static final String REFUND_PROOF_PREFIX = "credit-refund-proofs";
+    private static final String NOT_PRIVILEGES = "You have no privileges to perform this action.";
+
     private final CreditRepository creditRepository;
     private final TouristProfileRepository touristProfileRepository;
     private final UserRepository userRepository;
+    private final IStorageService storageService;
 
     @Transactional(readOnly = true)
     public List<CreditResponse> getAllCredits(Authentication authentication, CreditStatusEnum status) {
@@ -109,8 +125,132 @@ public class CreditService {
         return mapToResponse(credit);
     }
 
+    /**
+     * TC-022 (#253): el turista solicita la devolucion en efectivo del credito.
+     * Transicion permitida: CREATED -> REFUND_REQUESTED, solo si el saldo libre
+     * (amount - reservedAmount) es mayor a 0 y el credito pertenece al usuario.
+     */
+    public CreditResponse requestRefund(Long creditId, Authentication authentication) {
+        User owner = (User) authentication.getPrincipal();
+        Credit credit = creditRepository.findById(creditId)
+                .orElseThrow(() -> new ResourceNotFoundException("Credit not found: " + creditId));
+
+        if (!credit.getUserId().equals(owner.getId())) {
+            throw new OperationNotPermittedException("You can only request a refund on your own credits");
+        }
+        if (credit.getStatus() != CreditStatusEnum.CREATED) {
+            throw new OperationNotPermittedException(
+                    "Only credits in CREATED status can be refunded (current: " + credit.getStatus() + ")");
+        }
+        if (credit.getExpirationDate() != null && credit.getExpirationDate().isBefore(LocalDate.now(BOGOTA))) {
+            throw new OperationNotPermittedException("Cannot request refund on an expired credit");
+        }
+        BigDecimal reserved = credit.getReservedAmount() != null ? credit.getReservedAmount() : BigDecimal.ZERO;
+        BigDecimal available = credit.getAmount().subtract(reserved);
+        if (available.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new OperationNotPermittedException(
+                    "Credit has no free balance available for refund (reserved for cart)");
+        }
+
+        credit.setStatus(CreditStatusEnum.REFUND_REQUESTED);
+        credit.setRefundRequestedAt(LocalDateTime.now(BOGOTA));
+        credit = creditRepository.save(credit);
+
+        log.info("Credit {} refund requested by user {}", creditId, owner.getId());
+        return mapToResponse(credit);
+    }
+
+    /**
+     * TC-022 (#253): ADMIN/BACKOFFICE_OPERATION sube el comprobante y marca la
+     * devolucion como completada. Transicion: REFUND_REQUESTED -> REFUNDED.
+     */
+    public CreditResponse uploadRefundProof(Long creditId, MultipartFile proof, Authentication authentication)
+            throws IOException {
+        User user = (User) authentication.getPrincipal();
+        if (!Utils.isTouryaBackoffice(user.getRoles())) {
+            throw new InsufficientPrivilegesException(NOT_PRIVILEGES);
+        }
+
+        validateRefundProofFile(proof);
+
+        Credit credit = creditRepository.findById(creditId)
+                .orElseThrow(() -> new ResourceNotFoundException("Credit not found: " + creditId));
+
+        if (credit.getStatus() != CreditStatusEnum.REFUND_REQUESTED) {
+            throw new OperationNotPermittedException(
+                    "Only credits in REFUND_REQUESTED status can be marked as REFUNDED (current: "
+                            + credit.getStatus() + ")");
+        }
+
+        String url = storageService.uploadFile(REFUND_PROOF_PREFIX + "/" + creditId, proof);
+
+        credit.setStatus(CreditStatusEnum.REFUNDED);
+        credit.setRefundedAt(LocalDateTime.now(BOGOTA));
+        credit.setRefundProofUrl(url);
+        credit = creditRepository.save(credit);
+
+        log.info("Credit {} refunded by admin/backoffice user {} with proof {}", creditId, user.getId(), url);
+        return mapToResponse(credit);
+    }
+
+    /**
+     * TC-022 (#253): listado global paginado para ADMIN/BACKOFFICE_OPERATION.
+     * Retorna todos los creditos (filtrando opcionalmente por status) con datos
+     * embebidos del turista (touristName, touristEmail).
+     */
+    @Transactional(readOnly = true)
+    public Page<CreditResponse> findAllForAdmin(Authentication authentication,
+                                                CreditStatusEnum status,
+                                                Pageable pageable) {
+        User user = (User) authentication.getPrincipal();
+        if (!Utils.isTouryaBackoffice(user.getRoles())) {
+            throw new InsufficientPrivilegesException(NOT_PRIVILEGES);
+        }
+
+        Page<Credit> page = (status != null)
+                ? creditRepository.findByStatus(status, pageable)
+                : creditRepository.findAll(pageable);
+
+        Map<Integer, User> usersById = loadUsersForCredits(page.getContent());
+        return page.map(c -> mapToResponseWithTourist(c, usersById.get(c.getUserId())));
+    }
+
+    private Map<Integer, User> loadUsersForCredits(List<Credit> credits) {
+        if (credits.isEmpty()) {
+            return Map.of();
+        }
+        Set<Integer> userIds = credits.stream()
+                .map(Credit::getUserId)
+                .filter(java.util.Objects::nonNull)
+                .collect(Collectors.toCollection(HashSet::new));
+        Map<Integer, User> byId = new HashMap<>();
+        userRepository.findAllById(userIds).forEach(u -> byId.put(u.getId(), u));
+        return byId;
+    }
+
+    private void validateRefundProofFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("Refund proof file is required");
+        }
+        if (file.getSize() > REFUND_PROOF_MAX_BYTES) {
+            throw new IllegalArgumentException("Refund proof too large. Max 5MB");
+        }
+        String ct = file.getContentType() != null ? file.getContentType().toLowerCase() : "";
+        boolean ok = ct.equals("application/pdf")
+                || ct.equals("image/png")
+                || ct.equals("image/jpeg")
+                || ct.equals("image/jpg");
+        if (!ok) {
+            throw new IllegalArgumentException("Invalid file type. Only PDF or JPG/PNG images are allowed");
+        }
+    }
+
     private CreditResponse mapToResponse(Credit credit) {
-        return CreditResponse.builder()
+        return mapToResponseWithTourist(credit, null);
+    }
+
+    private CreditResponse mapToResponseWithTourist(Credit credit, User tourist) {
+        CreditResponse.CreditResponseBuilder builder = CreditResponse.builder()
                 .id(credit.getId())
                 .reservationId(credit.getReservationId())
                 .userId(credit.getUserId())
@@ -122,6 +262,12 @@ public class CreditService {
                 .creationDate(credit.getCreationDate())
                 .expirationDate(credit.getExpirationDate())
                 .status(credit.getStatus())
-                .build();
+                .refundRequestedAt(credit.getRefundRequestedAt())
+                .refundedAt(credit.getRefundedAt())
+                .refundProofUrl(credit.getRefundProofUrl());
+        if (tourist != null) {
+            builder.touristName(tourist.fullName()).touristEmail(tourist.getEmail());
+        }
+        return builder.build();
     }
 }


### PR DESCRIPTION
## Summary

Implementa el flujo de devolucion en efectivo de creditos (TC-022, issue #253).

- **2 estados nuevos** en `CreditStatusEnum`: `REFUND_REQUESTED` y `REFUNDED`.
- **3 columnas nuevas** en `public.credit`: `refund_requested_at`, `refunded_at`, `refund_proof_url`.
- **3 endpoints nuevos** (contrato acordado con frontend web y mobile).
- Cero side effect sobre los flujos existentes (usar, transferir, cancelar, expirar).

## Transiciones de estado

- `CREATED -> REFUND_REQUESTED` — via endpoint turista.
- `REFUND_REQUESTED -> REFUNDED` — via endpoint admin/backoffice (upload comprobante).
- Toda otra transicion se rechaza con 400 y mensaje explicativo.

## Contrato de endpoints (para consumo de web + mobile)

### 1. `POST /credits/{creditId}/request-refund` — turista

- **Auth**: JWT Bearer (turista propietario).
- **Guards**: credito propio, `status = CREATED`, `amount - reservedAmount > 0`, no vencido.
- **Body**: vacio.
- **Response 200**: `CreditResponse` actualizado (status `REFUND_REQUESTED`, `refundRequestedAt` timestamped).
- **400**: transicion no permitida (con mensaje).
- **404**: credito no existe.

### 2. `POST /admin/credits/{creditId}/upload-refund-proof` — admin/backoffice

- **Auth**: JWT Bearer con rol `ADMIN` o `BACKOFFICE_OPERATION`.
- **Content-Type**: `multipart/form-data`.
- **Form part**: `proof` (JPG, PNG o PDF, max 5MB).
- **Guards**: status actual debe ser `REFUND_REQUESTED`.
- **Response 200**: `CreditResponse` actualizado (`status=REFUNDED`, `refundedAt`, `refundProofUrl` con URL publica).
- **400**: transicion o archivo invalido.
- **403**: rol insuficiente.
- **404**: credito no existe.

Storage: usa `IStorageService` (funciona en AWS S3 y GCS transparentemente). Path del archivo: `credit-refund-proofs/{creditId}/{timestamp}_{filename}`. URL publica retornada por el provider.

### 3. `GET /admin/credits` — admin/backoffice

- **Auth**: JWT Bearer con rol `ADMIN` o `BACKOFFICE_OPERATION`.
- **Query params**: `page`, `size`, `sort` (Spring Data `Pageable`); `status` opcional (`CREATED`, `REFUND_REQUESTED`, `REFUNDED`, etc).
- **Response 200**: `Page<CreditResponse>` con `touristName` y `touristEmail` embebidos.
- **403**: rol insuficiente (turista, provider, etc).

### CreditResponse (extendido, unico DTO shared)

Campos existentes (`id`, `reservationId`, `userId`, `transferredFromUserId`, `transferredAt`, `amount`, `reservedAmount`, `shoppingCartItemId`, `creationDate`, `expirationDate`, `status`) + los nuevos:

- `refundRequestedAt: LocalDateTime`
- `refundedAt: LocalDateTime`
- `refundProofUrl: string`
- `touristName: string` (solo poblado en listado admin)
- `touristEmail: string` (solo poblado en listado admin)

## Migracion

`database/migrations/091_tc022_credit_refund_workflow.sql`

- Reemplaza `credit_status_check` con el catalogo completo: `CREATED, RESERVED, CONSUMED, CANCELED, DELETED, EXPIRED, REFUND_REQUESTED, REFUNDED`.
  - Nota tecnica: el CHECK del dev estaba en la version de migracion 014 (5 valores) — la 074 empezo a usar `EXPIRED` en runtime sin actualizarlo. Esta migracion normaliza el catalogo.
- Agrega `refund_requested_at`, `refunded_at`, `refund_proof_url` a `public.credit`.
- Rollback comentado al final.

**Estado dev**: aplicada a Cloud SQL `tourya-dev-db` / `TourYaDbDev`. Verificado con `information_schema.columns` + `pg_get_constraintdef`.

## Test plan

- [ ] Merge a `develop` y esperar CD deploy (workflow `Build & Deploy to Cloud Run (Dev)`).
- [ ] curl `POST /api/v1/credits/{id}/request-refund` con token turista dueno del credito -> 200 + `status=REFUND_REQUESTED`.
- [ ] curl `POST /api/v1/credits/{id}/request-refund` con token de otro turista -> 400/403.
- [ ] curl `POST /api/v1/credits/{id}/request-refund` sobre credito ya `REFUND_REQUESTED` -> 400.
- [ ] curl `POST /api/v1/admin/credits/{id}/upload-refund-proof` con multipart `proof=@comprobante.pdf` + token admin -> 200 + `refundProofUrl` accesible via GET.
- [ ] curl `POST /api/v1/admin/credits/{id}/upload-refund-proof` con token turista -> 403.
- [ ] curl `GET /api/v1/admin/credits?page=0&size=20` con token admin -> Page con turista embebido.
- [ ] curl `GET /api/v1/admin/credits?status=REFUND_REQUESTED` con token backoffice -> solo pendientes.
- [ ] curl `GET /api/v1/admin/credits` con token turista -> 403.

## Pendientes fuera de este PR

- Notificaciones/emails al turista (creado y confirmado) — item posterior, no bloquea el flujo base.
- Frontend web: consumir los 3 endpoints (contrato arriba).
- Mobile: consumir `POST /credits/{id}/request-refund` en la vista de creditos.

## Build

`./mvnw compile -DskipTests` -> BUILD SUCCESS.