### PR TITLE
feat(backend): 3 deudas mobile Sprint 2 — DTOs (blockedByMaritimeReport en detail + addressType en search/cart + travelerBreakdown en reservation turista)

### DIFF
--- a/src/main/java/com/tourya/api/models/responses/ReservationResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/ReservationResponse.java
@@ -69,6 +69,17 @@ public class ReservationResponse {
     private BigDecimal providerTotalAmount;
     /** Desglose por tipo de turista (ADULT, CHILD, INFANT). */
     private List<ReservationPriceBreakdownResponse> priceBreakdown = new ArrayList<>();
+    /**
+     * Sprint 2 mobile — deuda 3: expone el mismo desglose por ageType que ya trae
+     * {@link ReservationDetailsResponse#getTravelerBreakdown()} (vista provider,
+     * calculada por {@code sp_get_provider_reservations}, TC-016). Permite al mobile
+     * del turista renderizar en ReservationDetailPage el mismo bloque que ve el
+     * provider. Se puebla desde {@code shopping_cart_item_detail} (ageType, quantity,
+     * unitPrice, providerUnitPrice) en {@code ReservationService.enrichReservationResponse}.
+     * Redundante con {@code priceBreakdown} pero se mantiene el mismo tipo del provider
+     * para poder compartir componente de UI entre ambas vistas.
+     */
+    private List<TravelerBreakdownDto> travelerBreakdown = new ArrayList<>();
     private String travellers;
     private List<String> activities;
     private List<String> extraServices;

--- a/src/main/java/com/tourya/api/models/responses/SearchTourScheduleFullResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/SearchTourScheduleFullResponse.java
@@ -1,5 +1,6 @@
 package com.tourya.api.models.responses;
 
+import com.tourya.api.constans.enums.AddressTypeEnum;
 import com.tourya.api.models.TranslatedField;
 import lombok.Getter;
 import lombok.Setter;
@@ -61,6 +62,15 @@ public class SearchTourScheduleFullResponse {
         private String address;
         private Double latitude;
         private Double longitude;
+        /**
+         * Sprint 2 mobile — deuda 2: expone el {@code address_type} del meeting point
+         * (FIXED_LOCATION / HOTEL_PICKUP). Antes el mobile hacia deteccion heuristica
+         * con empty-check de city+address (TC-017). Nulo si no se pudo resolver la
+         * fila de {@code tour_address} correspondiente al tuple (country, state, city).
+         * Poblado por {@link com.tourya.api.services.impl.SearchTourAddressTypeEnricher}
+         * (Java-side, no toca el SP {@code sp_get_tour_schedule_json}).
+         */
+        private AddressTypeEnum addressType;
     }
 
     @Getter

--- a/src/main/java/com/tourya/api/models/responses/ShoppingCartItemResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/ShoppingCartItemResponse.java
@@ -52,5 +52,14 @@ public class ShoppingCartItemResponse {
      * en {@code cart.service.ts} para validaciones de disponibilidad.
      */
     private Integer maxPeople;
+
+    /**
+     * Sprint 2 mobile — deuda 2B: expone el {@code address_type} del meeting point
+     * del tour (FIXED_LOCATION / HOTEL_PICKUP) para que el mobile pueda distinguir
+     * casos Hotel Pickup en el checkout sin la deteccion heuristica de TC-017
+     * (empty-check de city+address). Poblado desde el primer {@code tour_address}
+     * asociado al tour del cart item; null para items de tipo SERVICE.
+     */
+    private String addressType;
 }
 

--- a/src/main/java/com/tourya/api/models/responses/TourFullDataResponse.java
+++ b/src/main/java/com/tourya/api/models/responses/TourFullDataResponse.java
@@ -53,4 +53,14 @@ public class TourFullDataResponse {
      * quedo guardado ni consultarlo despues.
      */
     private java.math.BigDecimal porcentajeTourya;
+
+    /**
+     * Sprint 2 mobile: expone en el detalle publico del tour el mismo flag de
+     * bloqueo DIMAR que la busqueda ({@link SearchTourScheduleFullResponse.TourScheduleResponse#blockedByMaritimeReport}).
+     * true si existe un reporte DIMAR con flag=RED activo HOY (subcategoria +
+     * cualquiera de las locations del tour). El mobile lo usa en TourDetailPage
+     * para deshabilitar el CTA "Reservar" sin tener que llamar al search.
+     * Backend duplica el guard en ShoppingCartService.addItemToCart por seguridad.
+     */
+    private Boolean blockedByMaritimeReport;
 }

--- a/src/main/java/com/tourya/api/services/ReservationService.java
+++ b/src/main/java/com/tourya/api/services/ReservationService.java
@@ -29,6 +29,7 @@ import com.tourya.api.models.request.CreateTemporalReservationHoldRequest;
 import com.tourya.api.models.request.RescheduleReservationRequest;
 import com.tourya.api.models.responses.ReservationDetailsResponse;
 import com.tourya.api.models.responses.ReservationResponse;
+import com.tourya.api.models.responses.TravelerBreakdownDto;
 import com.tourya.api.models.responses.CreditResponse;
 import com.tourya.api.models.responses.TourIncludesExcludesResponse;
 import com.tourya.api.models.responses.CreateTemporalReservationHoldResponse;
@@ -334,6 +335,12 @@ public class ReservationService {
         }
 
         reservationPriceBreakdownMapper.applyToReservationResponse(response, item);
+
+        // Sprint 2 mobile — deuda 3: expone el mismo shape de desglose que la vista provider
+        // (ReservationDetailsResponse.travelerBreakdown / sp_get_provider_reservations, TC-016).
+        // Se calcula desde shopping_cart_item_detail — misma fuente que priceBreakdown, distinto
+        // tipo, para que el mobile pueda compartir el componente entre provider y turista.
+        response.setTravelerBreakdown(buildTravelerBreakdown(item));
         
         // Actividades (main attractions)
         List<String> activities = tourMainAttractionRepository.findByTourId(tourId).stream()
@@ -361,6 +368,31 @@ public class ReservationService {
         // No se calculan dinámicamente porque se guardan en la tabla reservation
 
         logIfPaymentPayerDiffersFromCartUser(reservation, item);
+    }
+
+    /**
+     * Sprint 2 mobile — deuda 3. Construye el desglose por ageType usando el mismo
+     * shape que {@link TravelerBreakdownDto} (vista provider), a partir de
+     * {@code shopping_cart_item_detail}. Retorna lista vacia (no null) para que
+     * el mobile pueda iterar sin null-check adicional.
+     */
+    private List<TravelerBreakdownDto> buildTravelerBreakdown(ShoppingCartItem item) {
+        if (item == null || item.getDetails() == null || item.getDetails().isEmpty()) {
+            return new ArrayList<>();
+        }
+        List<TravelerBreakdownDto> out = new ArrayList<>();
+        for (ShoppingCartItemDetail detail : item.getDetails()) {
+            if (detail == null || detail.getQuantity() == null || detail.getQuantity() <= 0) {
+                continue;
+            }
+            out.add(TravelerBreakdownDto.builder()
+                    .ageType(detail.getAgeType() != null ? detail.getAgeType().name() : null)
+                    .quantity(detail.getQuantity())
+                    .unitPrice(detail.getUnitPrice() != null ? detail.getUnitPrice().doubleValue() : null)
+                    .providerUnitPrice(detail.getProviderUnitPrice() != null ? detail.getProviderUnitPrice().doubleValue() : null)
+                    .build());
+        }
+        return out;
     }
 
     private void applyTourLocations(ReservationResponse response, List<TourAddress> addresses) {

--- a/src/main/java/com/tourya/api/services/ShoppingCartService.java
+++ b/src/main/java/com/tourya/api/services/ShoppingCartService.java
@@ -695,6 +695,9 @@ public class ShoppingCartService {
                         slotEndTime = item.getSlot().getEndTime();
                     }
 
+                    // Sprint 2 mobile — deuda 2B: expone address_type del tour al mobile.
+                    String addressType = null;
+
                     if ("SERVICE".equalsIgnoreCase(item.getProductType())) {
                         // Cuando es SERVICE, obtener el nombre del servicio
                         TouryaService service = serviceRepository.findById(item.getProductId()).orElse(null);
@@ -725,6 +728,9 @@ public class ShoppingCartService {
                                     if (first.getCity().getState() != null) {
                                         department = first.getCity().getState().getName();
                                     }
+                                }
+                                if (first.getAddressType() != null) {
+                                    addressType = first.getAddressType().name();
                                 }
                             }
                         }
@@ -762,6 +768,7 @@ public class ShoppingCartService {
                             .details(detailResponses)
                             .priceType(tourPriceType)
                             .maxPeople(tourMaxPeople)
+                            .addressType(addressType)
                             .build();
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/com/tourya/api/services/TourService.java
+++ b/src/main/java/com/tourya/api/services/TourService.java
@@ -4,6 +4,7 @@ package com.tourya.api.services;
 import com.tourya.api._utils.Utils;
 import com.tourya.api.common.PageResponse;
 import com.tourya.api.constans.enums.IncludeExcludeTypeEnum;
+import com.tourya.api.constans.enums.MaritimeFlagEnum;
 import com.tourya.api.constans.enums.UserRoleType;
 import com.tourya.api.constans.enums.TourStatusEnum;
 import com.tourya.api.exceptions.InsufficientPrivilegesException;
@@ -25,6 +26,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +41,7 @@ import java.util.stream.Collectors;
 public class TourService {
     private final TourRepository tourRepository;
     private final TourAddressRepository tourAddressRepository;
+    private final MaritimActivityReportRepository maritimActivityReportRepository;
     private final TourIncludesExcludesRepository tourIncludesExcludesRepository;
     private final TourMainAttractionRepository tourMainAttractionRepository;
     private final TourFaqRepository tourFaqRepository;
@@ -985,6 +989,49 @@ public class TourService {
             }
         } catch (Exception ignored) {
         }
+
+        // Sprint 2 mobile — deuda 1: expone el mismo flag DIMAR RED del search
+        // (SearchTourScheduleFullResponse.TourScheduleResponse.blockedByMaritimeReport)
+        // a nivel de tour para que TourDetailPage pueda deshabilitar el CTA "Reservar"
+        // sin necesidad de llamar al search. Semantica: hay al menos un reporte RED
+        // vigente HOY para la subcategoria del tour + alguna de sus locations.
+        // El guard duro sigue vivo en ShoppingCartService (defense-in-depth).
+        resp.setBlockedByMaritimeReport(isTourBlockedByActiveMaritimeReport(tour));
         return resp;
+    }
+
+    /**
+     * Sprint 2 mobile — deuda 1.
+     * true si existe un reporte DIMAR con flag=RED activo HOY (America/Bogota) cuya
+     * subcategoria coincide con la del tour Y cuya ubicacion coincide con al menos
+     * una de las locations del tour (country+state+city). HOTEL_PICKUP y locations
+     * sin geo se ignoran (no las cubre ningun reporte DIMAR).
+     */
+    private Boolean isTourBlockedByActiveMaritimeReport(Tour tour) {
+        if (tour == null || tour.getSubCategory() == null) {
+            return false;
+        }
+        LocalDate today = LocalDate.now(ZoneId.of("America/Bogota"));
+        List<TourAddress> addresses = tourAddressRepository.findByTourId(tour.getId());
+        if (addresses == null || addresses.isEmpty()) {
+            return false;
+        }
+        for (TourAddress addr : addresses) {
+            if (addr.getCountry() == null || addr.getState() == null || addr.getCity() == null) {
+                continue;
+            }
+            List<MaritimActivityReport> hits = maritimActivityReportRepository
+                    .findActiveRedReportsForSubcategoryAndLocation(
+                            MaritimeFlagEnum.RED,
+                            tour.getSubCategory().getValue(),
+                            today,
+                            addr.getCountry().getId(),
+                            addr.getState().getId(),
+                            addr.getCity().getId());
+            if (hits != null && !hits.isEmpty()) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/com/tourya/api/services/impl/SearchTourAddressTypeEnricher.java
+++ b/src/main/java/com/tourya/api/services/impl/SearchTourAddressTypeEnricher.java
@@ -1,0 +1,93 @@
+package com.tourya.api.services.impl;
+
+import com.tourya.api.constans.enums.AddressTypeEnum;
+import com.tourya.api.models.TourAddress;
+import com.tourya.api.models.responses.SearchTourScheduleFullResponse;
+import com.tourya.api.repository.TourAddressRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Sprint 2 mobile — deuda 2A.
+ *
+ * Enriquece cada fila del search con el {@code address_type} del meeting point.
+ * El SP {@code sp_get_tour_schedule_json} devuelve country/state/city/address pero
+ * no expone {@code address_type} — se resuelve aca en Java para evitar tocar el SP
+ * (patron aditivo puro DTO + enricher).
+ *
+ * Estrategia:
+ * 1) Batch: {@link TourAddressRepository#findByTourIdIn(List)} para todos los tour_id
+ *    presentes en la pagina de resultados (1 sola query, no N+1).
+ * 2) Match: por tour_id + tuple (country_id, state_id, city_id) — incluyendo el caso
+ *    HOTEL_PICKUP con los 3 en null. Si hay match, se setea el enum.
+ * 3) Fallback: si no matchea (deberia ser raro por FK y por el propio JOIN del SP),
+ *    se deja null y el mobile cae al comportamiento previo.
+ */
+@Component
+@RequiredArgsConstructor
+public class SearchTourAddressTypeEnricher {
+
+    private final TourAddressRepository tourAddressRepository;
+
+    public void enrich(List<SearchTourScheduleFullResponse> rows) {
+        if (rows == null || rows.isEmpty()) {
+            return;
+        }
+        Set<Integer> tourIds = new HashSet<>();
+        for (SearchTourScheduleFullResponse row : rows) {
+            if (row != null && row.getTour() != null && row.getTour().getId() != null) {
+                tourIds.add(row.getTour().getId());
+            }
+        }
+        if (tourIds.isEmpty()) {
+            return;
+        }
+        List<TourAddress> addresses = tourAddressRepository.findByTourIdIn(new ArrayList<>(tourIds));
+        if (addresses == null || addresses.isEmpty()) {
+            return;
+        }
+        // Map<tourId, Map<locationTupleKey, AddressType>>
+        Map<Integer, Map<String, AddressTypeEnum>> byTour = new HashMap<>();
+        for (TourAddress addr : addresses) {
+            if (addr == null || addr.getTour() == null || addr.getTour().getId() == null) {
+                continue;
+            }
+            Integer tourId = addr.getTour().getId();
+            String key = buildKey(
+                    addr.getCountry() != null ? addr.getCountry().getId() : null,
+                    addr.getState() != null ? addr.getState().getId() : null,
+                    addr.getCity() != null ? addr.getCity().getId() : null);
+            byTour.computeIfAbsent(tourId, k -> new HashMap<>())
+                    .putIfAbsent(key, addr.getAddressType());
+        }
+        for (SearchTourScheduleFullResponse row : rows) {
+            if (row == null || row.getTour() == null || row.getTour().getAddress() == null) {
+                continue;
+            }
+            Integer tourId = row.getTour().getId();
+            SearchTourScheduleFullResponse.AddressResponse addr = row.getTour().getAddress();
+            Map<String, AddressTypeEnum> byKey = byTour.get(tourId);
+            if (byKey == null || byKey.isEmpty()) {
+                continue;
+            }
+            AddressTypeEnum resolved = byKey.get(buildKey(addr.getCountry(), addr.getState(), addr.getCity()));
+            if (resolved == null && byKey.size() == 1) {
+                // Fallback: si el tour tiene una sola direccion, usar esa.
+                resolved = byKey.values().iterator().next();
+            }
+            addr.setAddressType(resolved);
+        }
+    }
+
+    private String buildKey(Integer country, Integer state, Integer city) {
+        return Objects.toString(country, "-") + "|" + Objects.toString(state, "-") + "|" + Objects.toString(city, "-");
+    }
+}

--- a/src/main/java/com/tourya/api/services/impl/SearchTourScheduleFullServiceImpl.java
+++ b/src/main/java/com/tourya/api/services/impl/SearchTourScheduleFullServiceImpl.java
@@ -34,6 +34,7 @@ public class SearchTourScheduleFullServiceImpl implements SearchTourScheduleFull
     private final ReviewRepository reviewRepository;
     private final TourRepository tourRepository;
     private final SearchTourScheduleSlotPercentageEnricher slotPercentageEnricher;
+    private final SearchTourAddressTypeEnricher addressTypeEnricher;
     private final ObjectMapper objectMapper;
 
     @Override
@@ -48,6 +49,9 @@ public class SearchTourScheduleFullServiceImpl implements SearchTourScheduleFull
         Map<Integer, BigDecimal> avgRatingByTourId = loadAvgPublishedRatingByTourIds(content);
         fillTourRatingFallbackForSearch(content, avgRatingByTourId);
         slotPercentageEnricher.enrich(content, isTouryaBackoffice(connectedUser));
+        // Sprint 2 mobile — deuda 2A: expone tour.address.addressType (FIXED_LOCATION / HOTEL_PICKUP)
+        // sin tocar sp_get_tour_schedule_json. Batch de tour_address por tour_id.
+        addressTypeEnricher.enrich(content);
         return page.map(r -> enrichRating(enrichPriceFrom(enrichProfilePicture(r)), avgRatingByTourId));
     }
 


### PR DESCRIPTION
## Summary

Cierra 3 deudas de exposicion de campos en response DTOs descubiertas por los agentes mobile del Sprint 2 (portes TCs 018/017/016). Cambios aditivos puros — DTOs + mappers, sin migraciones BD, sin cambios de shape existente.

## Deudas cerradas

### Deuda 1 - `TourFullDataResponse.blockedByMaritimeReport`
- **Endpoints:** `GET /public/tour/details/{id}`, `GET /public/consultDataTourById/{id}`, `GET /tour/admin/consultDataTourById/{id}`
- **Problema:** el flag DIMAR RED solo lo exponia el search (`SearchTourScheduleFullResponse.schedules[].blockedByMaritimeReport`, TC-018). Mobile `TourDetailPage` no podia deshabilitar el CTA "Reservar" sin llamar el search, dependia del guard 400 del `POST /shopping-cart` como fallback.
- **Fix:** calcula el flag reusando `MaritimActivityReportRepository.findActiveRedReportsForSubcategoryAndLocation` (mismo helper que `ShoppingCartService.validateNoActiveMaritimeAlert`), evaluado con `LocalDate.now(America/Bogota)` sobre la subcategoria del tour + cada location con geo. Retorna `false` si no hay locations con geo (Hotel Pickup / sin geo → no cubierto por DIMAR).

### Deuda 2A - `SearchTourScheduleFullResponse.AddressResponse.addressType`
- **Endpoint:** `POST /public/tours/schedule/search`
- **Problema:** mobile aplicaba heuristica empty-check de city+address para inferir Hotel Pickup (TC-017).
- **Fix:** nuevo `SearchTourAddressTypeEnricher` (Java-side, **no toca el SP `sp_get_tour_schedule_json`**). Batch load de `tour_address` por `tour_id_in` y match por tuple `(country_id, state_id, city_id)` — incluye caso HOTEL_PICKUP con los 3 en null. Fallback: si el tour tiene una sola direccion, se usa esa. Field opcional (`AddressTypeEnum`, nullable si no matchea).

### Deuda 2B - `ShoppingCartItemResponse.addressType`
- **Endpoint:** `GET /shopping-cart` (y todos los que devuelven cart items)
- **Fix:** poblado desde el primer `tour_address` asociado al tour del item (mismo patron que `city`/`department` ya presentes en el mapper). Null para items `SERVICE`. String (`AddressTypeEnum.name()`) para minimizar impacto del cliente.

### Deuda 3 - `ReservationResponse.travelerBreakdown`
- **Endpoint:** `GET /reservation/{id}` (vista turista)
- **Problema:** vista provider (`ReservationDetailsResponse` via `sp_get_provider_reservations`, TC-016) ya trae `travelerBreakdown`. Turista solo tiene `priceBreakdown` (`ReservationPriceBreakdownResponse`, distinto shape) → mobile no puede reusar el mismo componente de UI.
- **Fix:** poblado desde `shopping_cart_item.details` (JPA) en `ReservationService.enrichReservationResponse` con el **mismo tipo `TravelerBreakdownDto`** del provider. Redundante con `priceBreakdown` pero necesario para reuso de componente mobile.

## Archivos tocados

| Deuda | Archivo |
|-------|---------|
| 1 | `models/responses/TourFullDataResponse.java` (+ field) |
| 1 | `services/TourService.java` (+ helper `isTourBlockedByActiveMaritimeReport`, inyecta `MaritimActivityReportRepository`) |
| 2A | `models/responses/SearchTourScheduleFullResponse.java` (+ field en `AddressResponse`) |
| 2A | `services/impl/SearchTourAddressTypeEnricher.java` (nuevo) |
| 2A | `services/impl/SearchTourScheduleFullServiceImpl.java` (wiring) |
| 2B | `models/responses/ShoppingCartItemResponse.java` (+ field) |
| 2B | `services/ShoppingCartService.java` (populate en `buildShoppingCartResponse`) |
| 3 | `models/responses/ReservationResponse.java` (+ field) |
| 3 | `services/ReservationService.java` (+ helper `buildTravelerBreakdown`, populate en `enrichReservationResponse`) |

## Restricciones respetadas
- Zero side-effect en flujos existentes. Solo agregado de campos opcionales.
- **Sin migraciones BD** — el SP `sp_get_tour_schedule_json` queda intacto (enricher Java para 2A).
- Guard duro DIMAR TC-018 sigue vivo en `ShoppingCartService.validateNoActiveMaritimeAlert` (defense-in-depth).
- Reusa tipos existentes (`TravelerBreakdownDto`, `AddressTypeEnum`, `MaritimeFlagEnum`).

## Build
`./mvnw compile -DskipTests` verde (509 fuentes, sin errores; warnings pre-existentes de Lombok `@SuperBuilder`).

## Test plan
- [ ] `GET /public/tour/details/{id}` sobre un tour con subcategoria `snorkel` y un `MaritimActivityReport` RED activo hoy que matchee su location → response con `blockedByMaritimeReport = true`.
- [ ] Mismo endpoint sobre un tour sin alerta activa → `blockedByMaritimeReport = false`.
- [ ] Mismo endpoint sobre un tour HOTEL_PICKUP (sin geo) → `blockedByMaritimeReport = false` (por diseno).
- [ ] `POST /public/tours/schedule/search` con al menos un tour HOTEL_PICKUP y otro FIXED_LOCATION en la pagina → cada `tour.address.addressType` correcto.
- [ ] `POST /public/tours/schedule/search` sin filtros → todos los items exponen `addressType` (verificar por muestreo).
- [ ] `GET /shopping-cart` con un item TOUR HOTEL_PICKUP → `addressType = "HOTEL_PICKUP"`.
- [ ] `GET /shopping-cart` con un item TOUR FIXED_LOCATION → `addressType = "FIXED_LOCATION"`.
- [ ] `GET /shopping-cart` con un item SERVICE → `addressType = null`.
- [ ] `GET /reservation/{id}` sobre una reserva con multi-ageType (ADULT + CHILD) → `travelerBreakdown` con 2 entradas alineadas con `priceBreakdown`.
- [ ] Regresion: `POST /shopping-cart` sobre un tour con DIMAR RED activo sigue devolviendo 400 (guard duro intacto).
- [ ] Regresion: consumidores existentes de `SearchTourScheduleFullResponse` (front web) siguen deserializando OK (campo nuevo opcional).