### PR TITLE
feat(TC-022 #253): emails al turista en solicitud y confirmacion de devolucion de credito

### DIFF
--- a/docs/09-api-design.md
+++ b/docs/09-api-design.md
@@ -102,6 +102,8 @@ Gestión de sub-usuarios del provider.
 | PUT | `/tour/user/submitTourById/{tourId}` | JWT | PROVIDER |
 | GET | `/tour/details/{tourId}` | público u opt-in | Todos |
 
+> 📌 **Cambio PR #255 (2026-08-13)** — `TourFullDataResponse` expone ahora el campo opcional `blockedByMaritimeReport: boolean` (para cerrar la deuda mobile de TC-018 detectada en Sprint 2). Aplica a todos los endpoints que devuelven este DTO: `GET /public/tour/details/{tourId}`, `GET /public/consultDataTourById/{tourId}`, `GET /tour/details/{tourId}`, `GET /tour/user/consultDataTourById/{tourId}`, `GET /tour/admin/consultDataTourById/{tourId}` (y los mutadores admin que retornan el DTO — `acceptTourById`, `returnedTourById`, `cancelTourById`, `porcentajeTourya`, `submitTourById`, `saveCreateFullData`). Semántica: `true` si hay al menos un `MaritimActivityReport` en estado RED activo hoy (`LocalDate.now(America/Bogota)`) que matchee la subcategoría del tour y alguna de sus `locations` con geo. Hotel Pickup y locations sin geo se ignoran (DIMAR no las cubre) → `false` por defecto en esos casos. Reusa `MaritimActivityReportRepository.findActiveRedReportsForSubcategoryAndLocation` — mismo helper del guard duro `ShoppingCartService.validateNoActiveMaritimeAlert`. Antes del PR el flag solo lo exponía el search (`SearchTourScheduleFullResponse.schedules[].blockedByMaritimeReport`); ahora el detail también, para que mobile deshabilite el CTA "Reservar" sin depender del fallback 400 del carrito.
+
 #### `TourCategoryController` — `/tourCategory`
 | Método | Path | Auth |
 |--------|------|------|
@@ -194,6 +196,8 @@ Gestión de sub-usuarios del provider.
 |--------|------|------|
 | POST | `/tour/schedule/search` | público u opt-in |
 
+> 📌 **Cambio PR #255 (2026-08-13)** — `SearchTourScheduleFullResponse.AddressResponse` expone ahora el campo opcional `addressType: string` (`AddressTypeEnum.name()` — `"FIXED_LOCATION"` / `"HOTEL_PICKUP"` / etc., nullable si el enricher no matchea). Antes solo el detail traía este dato, obligando al mobile a heurística `empty(city) && empty(address) → HOTEL_PICKUP` (TC-017). Aplica a **todos los endpoints que usan `SearchTourScheduleFullService`**: `POST /tour/schedule/search`, `POST /public/tours/schedule/search` y `POST /wishlist/search`. Implementado con `SearchTourAddressTypeEnricher` (batch load Java, **sin tocar el SP `sp_get_tour_schedule_json`**): recolecta `tour_address` por `tour_id_in` y matchea por tupla `(country_id, state_id, city_id)` — incluye el caso HOTEL_PICKUP con los 3 nulls. Fallback: si el tour tiene una sola dirección, se usa esa. Sin N+1.
+
 #### `PublicController` — `/public`
 | Método | Path | Descripción |
 |--------|------|-------------|
@@ -235,6 +239,8 @@ Gestión de sub-usuarios del provider.
 | GET | `/reservations/{id}/reschedule/validate` | JWT | USER |
 | PUT | `/reservations/{id}/reschedule` | JWT | USER |
 
+> 📌 **Cambio PR #255 (2026-08-13)** — `ReservationResponse` expone ahora el campo opcional `travelerBreakdown: List<TravelerBreakdownDto>` (reusa el tipo ya existente del provider). Cada entrada trae `ageType` (`ADULT` / `CHILD` / `INFANT`), `count`, `unitPrice` y `providerUnitPrice`. Aplica a todos los endpoints que devuelven `ReservationResponse` — vista turista `GET /reservations/{id}`, `GET /reservations`, `GET /reservations/qr/{qrUrl}`, `GET /reservations/payment/{paymentId}`, listas por fecha / estado, etc. Antes solo la vista provider (`ReservationDetailsResponse` vía `sp_get_provider_reservations`, TC-016) traía este desglose; el turista tenía únicamente `priceBreakdown: ReservationPriceBreakdownResponse` (datos equivalentes pero distinto shape, agrupado por `age_price_type` de la tarifa). **Coexisten** ambos en la vista turista — `priceBreakdown` sigue como fuente autoritativa para totales, `travelerBreakdown` existe para que el mobile reuse el mismo componente de UI entre provider y turista sin duplicar renderers. Poblado en `ReservationService.enrichReservationResponse` desde `shopping_cart_item_detail` del carrito original.
+
 #### `ShoppingCartController` — `/shopping-cart`
 | Método | Path | Auth | Roles |
 |--------|------|------|-------|
@@ -248,6 +254,8 @@ Gestión de sub-usuarios del provider.
 | PUT | `/shopping-cart/{cartId}/items/{itemId}/status` | JWT | USER |
 | POST | `/shopping-cart/{cartId}/checkout` | JWT | USER |
 | DELETE | `/shopping-cart/{cartId}/clear` | JWT | USER |
+
+> 📌 **Cambio PR #255 (2026-08-13)** — `ShoppingCartItemResponse` expone ahora el campo opcional `addressType: string` (`AddressTypeEnum.name()`, nullable). Aplica a todos los endpoints que devuelven items del cart — `POST /shopping-cart`, `GET /shopping-cart`, `GET /shopping-cart/user`, `GET /shopping-cart/{cartId}`, `GET /shopping-cart/{cartId}/details`, `POST /shopping-cart/items`. Se mapea desde el primer `tour_address` asociado al tour del item (mismo patrón que `city` / `department` ya presentes). **`null` para items `SERVICE`** — no tienen dirección asociada. Cierra la deuda mobile TC-017 (antes el cliente heurística sobre `city`/`address` vacíos para inferir Hotel Pickup).
 
 #### `TourReservationController` — `/tour-reservations` (legacy)
 | Método | Path | Notas |

--- a/src/main/java/com/tourya/api/services/CreditService.java
+++ b/src/main/java/com/tourya/api/services/CreditService.java
@@ -15,8 +15,10 @@ import com.tourya.api.models.responses.TouristLookupResponse;
 import com.tourya.api.repository.CreditRepository;
 import com.tourya.api.repository.TouristProfileRepository;
 import com.tourya.api.repository.UserRepository;
+import com.tourya.api.services.credit.events.CreditRefundEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
@@ -51,6 +53,7 @@ public class CreditService {
     private final TouristProfileRepository touristProfileRepository;
     private final UserRepository userRepository;
     private final IStorageService storageService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public List<CreditResponse> getAllCredits(Authentication authentication, CreditStatusEnum status) {
@@ -157,6 +160,13 @@ public class CreditService {
         credit = creditRepository.save(credit);
 
         log.info("Credit {} refund requested by user {}", creditId, owner.getId());
+        // TC-022: email al turista via evento AFTER_COMMIT (fire-and-forget).
+        eventPublisher.publishEvent(new CreditRefundEvent.RefundRequested(
+                credit.getId(),
+                credit.getReservationId(),
+                credit.getUserId(),
+                credit.getAmount(),
+                credit.getRefundRequestedAt()));
         return mapToResponse(credit);
     }
 
@@ -190,6 +200,14 @@ public class CreditService {
         credit = creditRepository.save(credit);
 
         log.info("Credit {} refunded by admin/backoffice user {} with proof {}", creditId, user.getId(), url);
+        // TC-022: email al turista via evento AFTER_COMMIT (fire-and-forget).
+        eventPublisher.publishEvent(new CreditRefundEvent.RefundCompleted(
+                credit.getId(),
+                credit.getReservationId(),
+                credit.getUserId(),
+                credit.getAmount(),
+                credit.getRefundedAt(),
+                credit.getRefundProofUrl()));
         return mapToResponse(credit);
     }
 

--- a/src/main/java/com/tourya/api/services/EmailService.java
+++ b/src/main/java/com/tourya/api/services/EmailService.java
@@ -261,6 +261,92 @@ public class EmailService {
         mailSender.send(mimeMessage);
     }
 
+    /**
+     * TC-022 (#253): confirmacion al turista de que su solicitud de devolucion
+     * de credito fue recibida (status CREATED -> REFUND_REQUESTED).
+     */
+    @Async
+    public void sendCreditRefundRequestedEmail(
+            String to,
+            String username,
+            Long creditId,
+            Long reservationId,
+            java.math.BigDecimal amount,
+            java.time.LocalDateTime refundRequestedAt,
+            String subject
+    ) throws MessagingException {
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(
+                mimeMessage,
+                MULTIPART_MODE_MIXED,
+                UTF_8.name());
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("username", username);
+        properties.put("creditId", creditId);
+        properties.put("reservationId", reservationId);
+        properties.put("amount", amount);
+        properties.put("refundRequestedAt", formatBogotaDateTime(refundRequestedAt));
+        Context context = new Context();
+        context.setVariables(properties);
+        helper.setFrom(fromEmail);
+        helper.setTo(to);
+        helper.setSubject(subject);
+        String template = templateEngine.process("credit_refund_requested", context);
+        helper.setText(template, true);
+        mailSender.send(mimeMessage);
+    }
+
+    /**
+     * TC-022 (#253): notificacion al turista de que el reembolso fue procesado
+     * (status REFUND_REQUESTED -> REFUNDED), con link al comprobante.
+     */
+    @Async
+    public void sendCreditRefundCompletedEmail(
+            String to,
+            String username,
+            Long creditId,
+            Long reservationId,
+            java.math.BigDecimal amount,
+            java.time.LocalDateTime refundedAt,
+            String proofUrl,
+            String subject
+    ) throws MessagingException {
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(
+                mimeMessage,
+                MULTIPART_MODE_MIXED,
+                UTF_8.name());
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("username", username);
+        properties.put("creditId", creditId);
+        properties.put("reservationId", reservationId);
+        properties.put("amount", amount);
+        properties.put("refundedAt", formatBogotaDateTime(refundedAt));
+        properties.put("proofUrl", proofUrl);
+        Context context = new Context();
+        context.setVariables(properties);
+        helper.setFrom(fromEmail);
+        helper.setTo(to);
+        helper.setSubject(subject);
+        String template = templateEngine.process("credit_refund_completed", context);
+        helper.setText(template, true);
+        mailSender.send(mimeMessage);
+    }
+
+    /**
+     * Renderiza un {@link java.time.LocalDateTime} en zona {@code America/Bogota}
+     * con formato {@code dd/MM/yyyy HH:mm}. Los timestamps del dominio se
+     * persisten en Bogota, se re-aplica la zona por seguridad.
+     */
+    private String formatBogotaDateTime(java.time.LocalDateTime dt) {
+        if (dt == null) {
+            return "";
+        }
+        java.time.ZoneId bogota = java.time.ZoneId.of("America/Bogota");
+        return dt.atZone(bogota)
+                .format(java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm"));
+    }
+
     @Async
     public void sendRequestProviderStatusEmail(
             String to,

--- a/src/main/java/com/tourya/api/services/credit/events/CreditRefundEvent.java
+++ b/src/main/java/com/tourya/api/services/credit/events/CreditRefundEvent.java
@@ -1,0 +1,50 @@
+package com.tourya.api.services.credit.events;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * TC-022 (#253): eventos de dominio del ciclo de vida de devolucion de credito.
+ *
+ * <p>Publicados desde {@link com.tourya.api.services.CreditService} y consumidos
+ * por {@link CreditRefundEventListener} con
+ * {@code @TransactionalEventListener(AFTER_COMMIT)}. Esto garantiza:</p>
+ * <ul>
+ *   <li>Si la tx principal hace rollback, el email nunca se envia.</li>
+ *   <li>Si el envio del email falla, la tx principal ya cerro — no aborta la
+ *       actualizacion de estado del credito (fire-and-forget).</li>
+ * </ul>
+ *
+ * <p>Snapshot: los eventos llevan los datos ya resueltos (amount, timestamp,
+ * proofUrl) para evitar re-queries en el listener y problemas de sesion JPA
+ * cerrada. El userId se usa para resolver el destinatario del email en el
+ * listener.</p>
+ */
+public sealed interface CreditRefundEvent {
+
+    /**
+     * Email 1: turista solicito la devolucion — status paso de CREATED a
+     * REFUND_REQUESTED. Se envia confirmacion de recepcion.
+     */
+    record RefundRequested(
+            Long creditId,
+            Long reservationId,
+            Integer userId,
+            BigDecimal amount,
+            LocalDateTime refundRequestedAt
+    ) implements CreditRefundEvent {}
+
+    /**
+     * Email 2: ADMIN/BACKOFFICE subio el comprobante — status paso de
+     * REFUND_REQUESTED a REFUNDED. Se envia confirmacion con link al
+     * comprobante.
+     */
+    record RefundCompleted(
+            Long creditId,
+            Long reservationId,
+            Integer userId,
+            BigDecimal amount,
+            LocalDateTime refundedAt,
+            String proofUrl
+    ) implements CreditRefundEvent {}
+}

--- a/src/main/java/com/tourya/api/services/credit/events/CreditRefundEventListener.java
+++ b/src/main/java/com/tourya/api/services/credit/events/CreditRefundEventListener.java
@@ -1,0 +1,92 @@
+package com.tourya.api.services.credit.events;
+
+import com.tourya.api.models.User;
+import com.tourya.api.repository.UserRepository;
+import com.tourya.api.services.EmailService;
+import jakarta.mail.MessagingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.Optional;
+
+/**
+ * TC-022 (#253): reacciona a {@link CreditRefundEvent} DESPUES del commit de la
+ * tx que actualiza el credito. Envia el email correspondiente al turista.
+ *
+ * <p>Sin {@code @Async} en el listener — los metodos de {@link EmailService}
+ * ya son {@code @Async}, asi que la carga de SMTP se despacha al executor sin
+ * bloquear la respuesta HTTP. Se evita el bug observado en
+ * {@code MaritimeAlertEventListener} (async + AFTER_COMMIT no disparaba en
+ * dev).</p>
+ *
+ * <p>Ninguna excepcion propaga fuera del listener: si el email falla, se
+ * loguea WARN y termina. El estado del credito ya quedo consistente en BD.</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CreditRefundEventListener {
+
+    private final EmailService emailService;
+    private final UserRepository userRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(CreditRefundEvent.RefundRequested event) {
+        Optional<User> user = userRepository.findById(event.userId());
+        if (user.isEmpty() || user.get().getEmail() == null || user.get().getEmail().isBlank()) {
+            log.warn("TC-022 RefundRequested credit {} without user or email, skipping email",
+                    event.creditId());
+            return;
+        }
+        try {
+            emailService.sendCreditRefundRequestedEmail(
+                    user.get().getEmail(),
+                    buildDisplayName(user.get()),
+                    event.creditId(),
+                    event.reservationId(),
+                    event.amount(),
+                    event.refundRequestedAt(),
+                    "Tu solicitud de devolucion fue recibida - Credito #" + event.creditId()
+            );
+        } catch (MessagingException | RuntimeException e) {
+            log.warn("TC-022 RefundRequested email failed for credit {}: {}",
+                    event.creditId(), e.getMessage());
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(CreditRefundEvent.RefundCompleted event) {
+        Optional<User> user = userRepository.findById(event.userId());
+        if (user.isEmpty() || user.get().getEmail() == null || user.get().getEmail().isBlank()) {
+            log.warn("TC-022 RefundCompleted credit {} without user or email, skipping email",
+                    event.creditId());
+            return;
+        }
+        try {
+            emailService.sendCreditRefundCompletedEmail(
+                    user.get().getEmail(),
+                    buildDisplayName(user.get()),
+                    event.creditId(),
+                    event.reservationId(),
+                    event.amount(),
+                    event.refundedAt(),
+                    event.proofUrl(),
+                    "Tu devolucion fue procesada - Credito #" + event.creditId()
+            );
+        } catch (MessagingException | RuntimeException e) {
+            log.warn("TC-022 RefundCompleted email failed for credit {}: {}",
+                    event.creditId(), e.getMessage());
+        }
+    }
+
+    private String buildDisplayName(User user) {
+        String first = user.getFirstname();
+        if (first == null || first.isBlank()) {
+            return user.getEmail();
+        }
+        return first;
+    }
+}

--- a/src/main/resources/templates/credit_refund_completed.html
+++ b/src/main/resources/templates/credit_refund_completed.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tu devolución fue procesada</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #f4f4f4;
+        }
+        .container {
+            max-width: 600px;
+            margin: 10px auto;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+        }
+        h1 {
+            color: #1f2937;
+            margin-top: 0;
+        }
+        .amount-badge {
+            font-size: 32px;
+            font-weight: bold;
+            color: #16a34a;
+            text-align: center;
+            padding: 16px;
+            background-color: #f0fdf4;
+            border-radius: 8px;
+            margin: 20px 0;
+        }
+        .details {
+            background-color: #f9fafb;
+            padding: 16px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+        }
+        .details p {
+            margin: 6px 0;
+        }
+        .cta {
+            text-align: center;
+            margin-top: 24px;
+        }
+        .cta a {
+            display: inline-block;
+            padding: 12px 28px;
+            background-color: #16a34a;
+            color: #fff;
+            text-decoration: none;
+            border-radius: 5px;
+            font-weight: bold;
+        }
+        .info-box {
+            background-color: #fffbeb;
+            border-left: 4px solid #f59e0b;
+            padding: 12px 16px;
+            border-radius: 4px;
+            margin: 20px 0;
+            color: #78350f;
+        }
+        .footer {
+            margin-top: 24px;
+            font-size: 12px;
+            color: #6b7280;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Tu devolución fue procesada</h1>
+    <p th:text="'Hola ' + ${username} + ','"></p>
+    <p>
+        Confirmamos que el reembolso de tu crédito
+        <strong th:text="'#' + ${creditId}"></strong>
+        fue procesado y el dinero enviado a tu cuenta bancaria registrada en Tourya.
+    </p>
+
+    <div class="amount-badge">
+        <span th:text="'$' + ${amount}"></span>
+    </div>
+
+    <div class="details">
+        <p><strong>Crédito:</strong> <span th:text="'#' + ${creditId}"></span></p>
+        <p><strong>Reserva de origen:</strong> <span th:text="'#' + ${reservationId}"></span></p>
+        <p><strong>Fecha del reembolso:</strong> <span th:text="${refundedAt} + ' (hora Bogotá)'"></span></p>
+    </div>
+
+    <div class="cta" th:if="${proofUrl != null and !#strings.isEmpty(proofUrl)}">
+        <a th:href="${proofUrl}" target="_blank" rel="noopener noreferrer">Ver comprobante</a>
+    </div>
+
+    <div class="info-box">
+        Si no ves el monto reflejado en tu cuenta bancaria en las próximas 48 horas,
+        contáctanos por WhatsApp o email y con gusto lo revisamos.
+    </div>
+
+    <div class="footer">
+        <p>Tourya — Marketplace de experiencias turísticas.</p>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/credit_refund_requested.html
+++ b/src/main/resources/templates/credit_refund_requested.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Solicitud de devolución recibida</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #f4f4f4;
+        }
+        .container {
+            max-width: 600px;
+            margin: 10px auto;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+        }
+        h1 {
+            color: #1f2937;
+            margin-top: 0;
+        }
+        .amount-badge {
+            font-size: 28px;
+            font-weight: bold;
+            color: #007bff;
+            text-align: center;
+            padding: 16px;
+            background-color: #eff6ff;
+            border-radius: 8px;
+            margin: 20px 0;
+        }
+        .details {
+            background-color: #f9fafb;
+            padding: 16px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+        }
+        .details p {
+            margin: 6px 0;
+        }
+        .info-box {
+            background-color: #fffbeb;
+            border-left: 4px solid #f59e0b;
+            padding: 12px 16px;
+            border-radius: 4px;
+            margin: 20px 0;
+            color: #78350f;
+        }
+        .footer {
+            margin-top: 24px;
+            font-size: 12px;
+            color: #6b7280;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Recibimos tu solicitud de devolución</h1>
+    <p th:text="'Hola ' + ${username} + ','"></p>
+    <p>
+        Confirmamos que hemos recibido tu solicitud de devolución en efectivo del crédito
+        <strong th:text="'#' + ${creditId}"></strong>. A continuación un resumen:
+    </p>
+
+    <div class="amount-badge">
+        <span th:text="'$' + ${amount}"></span>
+    </div>
+
+    <div class="details">
+        <p><strong>Crédito:</strong> <span th:text="'#' + ${creditId}"></span></p>
+        <p><strong>Reserva de origen:</strong> <span th:text="'#' + ${reservationId}"></span></p>
+        <p><strong>Fecha de solicitud:</strong> <span th:text="${refundRequestedAt} + ' (hora Bogotá)'"></span></p>
+    </div>
+
+    <div class="info-box">
+        Nuestro equipo revisará tu solicitud y te notificaremos cuando el reembolso se haya realizado.
+        Recibirás el monto en la cuenta bancaria registrada en Tourya.
+    </div>
+
+    <p>
+        Si tienes preguntas mientras tanto, responde a este correo o escríbenos por WhatsApp.
+    </p>
+
+    <div class="footer">
+        <p>Tourya — Marketplace de experiencias turísticas.</p>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Cierra la deuda del PR #254 (TC-022, issue #253): notificaciones por email al turista en los 2 momentos del flujo de devolucion de credito. Backend puro.

## Que se implemento

Emails via **eventos AFTER_COMMIT** (`ApplicationEventPublisher` -> `@TransactionalEventListener`), patron alineado con `PushDomainEventListener` (MO-40b). Fire-and-forget: si SMTP falla, el estado del credito ya quedo consistente y no se aborta la tx principal.

### 1. Email "Solicitud de devolucion recibida"
- **Trigger:** `CreditService.requestRefund` (status `CREATED -> REFUND_REQUESTED`).
- **Template:** `src/main/resources/templates/credit_refund_requested.html`.
- **Asunto:** `Tu solicitud de devolucion fue recibida - Credito #{creditId}`.
- **Contenido:** saludo, monto, reserva de origen, `refundRequestedAt` en zona Bogota, mensaje "nuestro equipo revisara tu solicitud".

### 2. Email "Devolucion procesada" con comprobante
- **Trigger:** `CreditService.uploadRefundProof` (status `REFUND_REQUESTED -> REFUNDED`).
- **Template:** `src/main/resources/templates/credit_refund_completed.html`.
- **Asunto:** `Tu devolucion fue procesada - Credito #{creditId}`.
- **Contenido:** saludo, monto, `refundedAt` en Bogota, boton "Ver comprobante" enlazado a `refundProofUrl`, nota de 48h.

## Cambios

| Archivo | Cambio |
|---|---|
| `services/credit/events/CreditRefundEvent.java` | Nuevo. Sealed interface + 2 records (`RefundRequested`, `RefundCompleted`) con snapshot de datos. |
| `services/credit/events/CreditRefundEventListener.java` | Nuevo. `@TransactionalEventListener(AFTER_COMMIT)` sin `@Async` (EmailService ya despacha `@Async` internamente y el pattern `async + AFTER_COMMIT` mostro bugs en dev — ver `MaritimeAlertEventListener`). |
| `services/EmailService.java` | +2 metodos `sendCreditRefundRequestedEmail` / `sendCreditRefundCompletedEmail`, helper `formatBogotaDateTime`. |
| `services/CreditService.java` | Inyecta `ApplicationEventPublisher` y publica evento al final de `requestRefund` / `uploadRefundProof`. |
| `resources/templates/credit_refund_requested.html` | Nuevo. Estilo coherente con `credit_expiring_reminder.html`. |
| `resources/templates/credit_refund_completed.html` | Nuevo. Estilo verde (accion completada) + CTA al comprobante. |

## Decisiones fuera de scope (deuda separada, NO tocada)

- **i18n de emails:** solo espanol, alineado con `credit_expiring_reminder` / `credit_expired`. El multi-idioma de emails es deuda global.
- **"Motivo original" del credito:** la entidad `Credit` no persiste un `reason` de origen. Se muestra `#reservationId` para dar contexto. Agregar `reason` seria migracion + refactor del flujo de generacion (cancelacion / re-agendamiento / provider-declined) fuera de scope.
- No se agregaron push notifications equivalentes al flujo de refund. MO-40b existente cubre expiracion, no refund.

## Test plan

- [ ] `./mvnw compile -DskipTests` verde (verificado localmente).
- [ ] Deploy en Cloud Run dev + probar flujo end-to-end:
  - Turista: `POST /credits/{id}/request-refund` sobre credito `CREATED` -> verificar email 1 en bandeja.
  - ADMIN/BO: `POST /admin/credits/{id}/upload-refund-proof` -> verificar email 2 con link funcional al comprobante S3.
- [ ] Verificar que si SMTP esta caido, la respuesta HTTP igual retorna 200 con el `CreditResponse` actualizado.
- [ ] Verificar timestamps renderizados en hora Bogota (formato `dd/MM/yyyy HH:mm`).

## Refs

- Issue: #253
- PR base: #254 (TC-022 backend)